### PR TITLE
Change the log severity leve from ERROR to NOTICE if getStatus is not supported by vendor

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -708,7 +708,7 @@ sai_status_t Syncd::processGetStatsEvent(
 
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_NOTICE("Getting stats error");
+        SWSS_LOG_NOTICE("Getting stats error: %s", sai_serialize_status(status).c_str());
     }
     else
     {


### PR DESCRIPTION
Change the log severity leve from ERROR to NOTICE if getStatus is not supported by vendor

Signed-off-by: Stephen Sun <stephens@nvidia.com>