### PR TITLE
[sonic-sairedis] Support bulk counter

### DIFF
--- a/lib/ClientSai.cpp
+++ b/lib/ClientSai.cpp
@@ -983,6 +983,45 @@ sai_status_t ClientSai::waitForClearStatsResponse()
     return status;
 }
 
+sai_status_t ClientSai::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    SWSS_LOG_ERROR("not implemented");
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t ClientSai::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    SWSS_LOG_ERROR("not implemented");
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 // BULK CREATE
 
 sai_status_t ClientSai::bulkCreate(

--- a/lib/ClientSai.h
+++ b/lib/ClientSai.h
@@ -116,6 +116,27 @@ namespace sairedis
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/lib/ClientServerSai.cpp
+++ b/lib/ClientServerSai.cpp
@@ -297,6 +297,41 @@ sai_status_t ClientServerSai::clearStats(
             counter_ids);
 }
 
+sai_status_t ClientServerSai::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t ClientServerSai::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 // BULK QUAD OID
 
 sai_status_t ClientServerSai::bulkCreate(

--- a/lib/ClientServerSai.cpp
+++ b/lib/ClientServerSai.cpp
@@ -312,7 +312,15 @@ sai_status_t ClientServerSai::bulkGetStats(
     SWSS_LOG_ENTER();
     REDIS_CHECK_API_INITIALIZED();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return m_sai->bulkGetStats(switchId,
+                               object_type,
+                               object_count,
+                               object_key,
+                               number_of_counters,
+                               counter_ids,
+                               mode,
+                               object_statuses,
+                               counters);
 }
 
 sai_status_t ClientServerSai::bulkClearStats(
@@ -329,7 +337,14 @@ sai_status_t ClientServerSai::bulkClearStats(
     SWSS_LOG_ENTER();
     REDIS_CHECK_API_INITIALIZED();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return m_sai->bulkClearStats(switchId,
+                                 object_type,
+                                 object_count,
+                                 object_key,
+                                 number_of_counters,
+                                 counter_ids,
+                                 mode,
+                                 object_statuses);
 }
 
 // BULK QUAD OID

--- a/lib/ClientServerSai.h
+++ b/lib/ClientServerSai.h
@@ -108,6 +108,27 @@ namespace sairedis
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -1211,6 +1211,41 @@ sai_status_t RedisRemoteSaiInterface::clearStats(
     return status;
 }
 
+sai_status_t RedisRemoteSaiInterface::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_ERROR("not implemented");
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t RedisRemoteSaiInterface::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_ERROR("not implemented");
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t RedisRemoteSaiInterface::waitForClearStatsResponse()
 {
     SWSS_LOG_ENTER();

--- a/lib/RedisRemoteSaiInterface.h
+++ b/lib/RedisRemoteSaiInterface.h
@@ -127,6 +127,27 @@ namespace sairedis
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/lib/Sai.cpp
+++ b/lib/Sai.cpp
@@ -401,6 +401,37 @@ sai_status_t Sai::clearStats(
             counter_ids);
 }
 
+sai_status_t Sai::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t Sai::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 // BULK QUAD OID
 
 sai_status_t Sai::bulkCreate(

--- a/lib/Sai.h
+++ b/lib/Sai.h
@@ -117,6 +117,27 @@ namespace sairedis
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+             virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/lib/ServerSai.cpp
+++ b/lib/ServerSai.cpp
@@ -317,6 +317,37 @@ sai_status_t ServerSai::clearStats(
             counter_ids);
 }
 
+sai_status_t ServerSai::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t ServerSai::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 // BULK QUAD OID
 
 sai_status_t ServerSai::bulkCreate(

--- a/lib/ServerSai.cpp
+++ b/lib/ServerSai.cpp
@@ -328,9 +328,19 @@ sai_status_t ServerSai::bulkGetStats(
         _Inout_ sai_status_t *object_statuses,
         _Out_ uint64_t *counters)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return m_sai->bulkGetStats(switchId,
+                               object_type,
+                               object_count,
+                               object_key,
+                               number_of_counters,
+                               counter_ids,
+                               mode,
+                               object_statuses,
+                               counters);
 }
 
 sai_status_t ServerSai::bulkClearStats(
@@ -343,9 +353,18 @@ sai_status_t ServerSai::bulkClearStats(
         _In_ sai_stats_mode_t mode,
         _Inout_ sai_status_t *object_statuses)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return m_sai->bulkClearStats(switchId,
+                                 object_type,
+                                 object_count,
+                                 object_key,
+                                 number_of_counters,
+                                 counter_ids,
+                                 mode,
+                                 object_statuses);
 }
 
 // BULK QUAD OID

--- a/lib/ServerSai.h
+++ b/lib/ServerSai.h
@@ -113,6 +113,27 @@ namespace sairedis
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/lib/sai_redis_interfacequery.cpp
+++ b/lib/sai_redis_interfacequery.cpp
@@ -248,3 +248,34 @@ sai_status_t sai_query_api_version(
 
     return SAI_STATUS_NOT_IMPLEMENTED;
 }
+
+sai_status_t sai_bulk_object_get_stats(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t sai_bulk_object_clear_stats(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -213,6 +213,37 @@ sai_status_t DummySaiInterface::clearStats(
     return m_status;
 }
 
+sai_status_t DummySaiInterface::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+
+    return m_status;
+}
+
+sai_status_t DummySaiInterface::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    return m_status;
+}
+
 // bulk QUAD
 
 sai_status_t DummySaiInterface::bulkRemove(

--- a/meta/DummySaiInterface.h
+++ b/meta/DummySaiInterface.h
@@ -117,6 +117,27 @@ namespace saimeta
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1850,6 +1850,37 @@ sai_status_t Meta::clearStats(
     return status;
 }
 
+sai_status_t Meta::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t Meta::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 // for bulk operations actually we could make copy of current db and actually
 // execute to see if all will succeed
 

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -124,6 +124,27 @@ namespace saimeta
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/meta/SaiInterface.h
+++ b/meta/SaiInterface.h
@@ -215,6 +215,27 @@ namespace sairedis
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) = 0;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) = 0;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) = 0;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -646,6 +646,58 @@ sai_status_t VendorSai::clearStats(
     return ptr(object_id, number_of_counters, counter_ids);
 }
 
+sai_status_t VendorSai::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VENDOR_CHECK_API_INITIALIZED();
+
+    return sai_bulk_object_get_stats(
+            switchId,
+            object_type,
+            object_count,
+            object_key,
+            number_of_counters,
+            counter_ids,
+            mode,
+            object_statuses,
+            counters);
+}
+
+sai_status_t VendorSai::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VENDOR_CHECK_API_INITIALIZED();
+
+    return sai_bulk_object_clear_stats(
+            switchId,
+            object_type,
+            object_count,
+            object_key,
+            number_of_counters,
+            counter_ids,
+            mode,
+            object_statuses);
+}
+
 // BULK QUAD OID
 
 sai_status_t VendorSai::bulkCreate(

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -114,6 +114,27 @@ namespace syncd
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/unittest/lib/Makefile.am
+++ b/unittest/lib/Makefile.am
@@ -9,7 +9,7 @@ tests_SOURCES = \
 				../../meta/NumberOidIndexGenerator.cpp \
 				TestSwitch.cpp \
 				TestClientConfig.cpp \
-				TestClientServerSai.cppa \
+				TestClientServerSai.cpp \
 				TestContext.cpp \
 				TestContextConfig.cpp \
 				TestContextConfigContainer.cpp \

--- a/unittest/lib/TestClientServerSai.cpp
+++ b/unittest/lib/TestClientServerSai.cpp
@@ -81,3 +81,48 @@ TEST(ClientServerSai, logSet)
 
     EXPECT_EQ(SAI_STATUS_SUCCESS, css->logSet(SAI_API_PORT, SAI_LOG_LEVEL_NOTICE));
 }
+
+TEST(ClientServerSai, bulkGetClearStats)
+{
+    auto css = std::make_shared<ClientServerSai>();
+
+    EXPECT_EQ(SAI_STATUS_FAILURE, css->bulkGetStats(SAI_NULL_OBJECT_ID,
+                                                    SAI_OBJECT_TYPE_PORT,
+                                                    0,
+                                                    nullptr,
+                                                    0,
+                                                    nullptr,
+                                                    SAI_STATS_MODE_BULK_READ,
+                                                    nullptr,
+                                                    nullptr));
+
+    EXPECT_EQ(SAI_STATUS_FAILURE, css->bulkClearStats(SAI_NULL_OBJECT_ID,
+                                                      SAI_OBJECT_TYPE_PORT,
+                                                      0,
+                                                      nullptr,
+                                                      0,
+                                                      nullptr,
+                                                      SAI_STATS_MODE_BULK_CLEAR,
+                                                      nullptr));
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, css->initialize(0, &test_services));
+
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, css->bulkGetStats(SAI_NULL_OBJECT_ID,
+                                                            SAI_OBJECT_TYPE_PORT,
+                                                            0,
+                                                            nullptr,
+                                                            0,
+                                                            nullptr,
+                                                            SAI_STATS_MODE_BULK_READ,
+                                                            nullptr,
+                                                            nullptr));
+
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, css->bulkClearStats(SAI_NULL_OBJECT_ID,
+                                                              SAI_OBJECT_TYPE_PORT,
+                                                              0,
+                                                              nullptr,
+                                                              0,
+                                                              nullptr,
+                                                              SAI_STATS_MODE_BULK_CLEAR,
+                                                              nullptr));
+}

--- a/unittest/lib/TestClientServerSai.cpp
+++ b/unittest/lib/TestClientServerSai.cpp
@@ -1,5 +1,7 @@
 #include "ClientServerSai.h"
 
+#include "sairedis.h"
+
 #include "swss/logger.h"
 
 #include <gtest/gtest.h>
@@ -30,6 +32,25 @@ static int profile_get_next_value(
 
 static sai_service_method_table_t test_services = {
     profile_get_value,
+    profile_get_next_value
+};
+
+static const char* client_profile_get_value(
+        _In_ sai_switch_profile_id_t profile_id,
+        _In_ const char* variable)
+{
+    SWSS_LOG_ENTER();
+
+    if (variable != NULL && strcmp(variable, SAI_REDIS_KEY_ENABLE_CLIENT) == 0 )
+        return "true";
+    else
+        return NULL;
+
+    return nullptr;
+}
+
+static sai_service_method_table_t test_client_services = {
+    client_profile_get_value,
     profile_get_next_value
 };
 
@@ -106,6 +127,28 @@ TEST(ClientServerSai, bulkGetClearStats)
                                                       nullptr));
 
     EXPECT_EQ(SAI_STATUS_SUCCESS, css->initialize(0, &test_services));
+
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, css->bulkGetStats(SAI_NULL_OBJECT_ID,
+                                                            SAI_OBJECT_TYPE_PORT,
+                                                            0,
+                                                            nullptr,
+                                                            0,
+                                                            nullptr,
+                                                            SAI_STATS_MODE_BULK_READ,
+                                                            nullptr,
+                                                            nullptr));
+
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, css->bulkClearStats(SAI_NULL_OBJECT_ID,
+                                                              SAI_OBJECT_TYPE_PORT,
+                                                              0,
+                                                              nullptr,
+                                                              0,
+                                                              nullptr,
+                                                              SAI_STATS_MODE_BULK_CLEAR,
+                                                              nullptr));
+
+    css = std::make_shared<ClientServerSai>();
+    EXPECT_EQ(SAI_STATUS_SUCCESS, css->initialize(0, &test_client_services));
 
     EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, css->bulkGetStats(SAI_NULL_OBJECT_ID,
                                                             SAI_OBJECT_TYPE_PORT,

--- a/unittest/lib/TestContext.cpp
+++ b/unittest/lib/TestContext.cpp
@@ -29,3 +29,30 @@ TEST(Context, populateMetadata)
 
     ctx->populateMetadata(0x212121212212121L);
 }
+
+TEST(Context, bulkGetClearStats)
+{
+    auto recorder = std::make_shared<Recorder>();
+
+    auto cc = std::make_shared<ContextConfig>(0, "syncd", "ASIC_DB", "COUNTERS_DB","FLEX_DB", "STATE_DB");
+
+    auto ctx = std::make_shared<Context>(cc, recorder,handle_notification);
+
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, ctx->m_redisSai->bulkGetStats(SAI_NULL_OBJECT_ID,
+                                                                        SAI_OBJECT_TYPE_PORT,
+                                                                        0,
+                                                                        nullptr,
+                                                                        0,
+                                                                        nullptr,
+                                                                        SAI_STATS_MODE_BULK_READ,
+                                                                        nullptr,
+                                                                        nullptr));
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, ctx->m_redisSai->bulkClearStats(SAI_NULL_OBJECT_ID,
+                                                                          SAI_OBJECT_TYPE_PORT,
+                                                                          0,
+                                                                          nullptr,
+                                                                          0,
+                                                                          nullptr,
+                                                                          SAI_STATS_MODE_BULK_CLEAR,
+                                                                          nullptr));
+}

--- a/unittest/lib/test_sai_redis_interfacequery.cpp
+++ b/unittest/lib/test_sai_redis_interfacequery.cpp
@@ -80,3 +80,28 @@ TEST(libsairedis, sai_query_stats_capability)
 {
     EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai_query_stats_capability(0,SAI_OBJECT_TYPE_NULL,0));
 }
+
+TEST(libsairedis, sai_bulk_object_get_stats)
+{
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai_bulk_object_get_stats(SAI_NULL_OBJECT_ID,
+                                                                    SAI_OBJECT_TYPE_PORT,
+                                                                    0,
+                                                                    nullptr,
+                                                                    0,
+                                                                    nullptr,
+                                                                    SAI_STATS_MODE_BULK_READ,
+                                                                    nullptr,
+                                                                    nullptr));
+}
+
+TEST(libsairedis, sai_bulk_object_clear_stats)
+{
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai_bulk_object_clear_stats(SAI_NULL_OBJECT_ID,
+                                                                      SAI_OBJECT_TYPE_PORT,
+                                                                      0,
+                                                                      nullptr,
+                                                                      0,
+                                                                      nullptr,
+                                                                      SAI_STATS_MODE_BULK_CLEAR,
+                                                                      nullptr));
+}

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -1060,21 +1060,21 @@ TEST(Meta, populate)
 TEST(Meta, bulkGetClearStats)
 {
     Meta m(std::make_shared<MetaTestSaiInterface>());
-    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, m->bulkGetStats(SAI_NULL_OBJECT_ID,
-                                                          SAI_OBJECT_TYPE_PORT,
-                                                          0,
-                                                          nullptr,
-                                                          0,
-                                                          nullptr,
-                                                          SAI_STATS_MODE_BULK_READ,
-                                                          nullptr,
-                                                          nullptr));
-    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, m->bulkClearStats(SAI_NULL_OBJECT_ID,
-                                                            SAI_OBJECT_TYPE_PORT,
-                                                            0,
-                                                            nullptr,
-                                                            0,
-                                                            nullptr,
-                                                            SAI_STATS_MODE_BULK_CLEAR,
-                                                            nullptr));
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, m.bulkGetStats(SAI_NULL_OBJECT_ID,
+                                                         SAI_OBJECT_TYPE_PORT,
+                                                         0,
+                                                         nullptr,
+                                                         0,
+                                                         nullptr,
+                                                         SAI_STATS_MODE_BULK_READ,
+                                                         nullptr,
+                                                         nullptr));
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, m.bulkClearStats(SAI_NULL_OBJECT_ID,
+                                                           SAI_OBJECT_TYPE_PORT,
+                                                           0,
+                                                           nullptr,
+                                                           0,
+                                                           nullptr,
+                                                           SAI_STATS_MODE_BULK_CLEAR,
+                                                           nullptr));
 }

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -1056,3 +1056,25 @@ TEST(Meta, populate)
 
     m.populate(dump);
 }
+
+TEST(Meta, bulkGetClearStats)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, m->bulkGetStats(SAI_NULL_OBJECT_ID,
+                                                          SAI_OBJECT_TYPE_PORT,
+                                                          0,
+                                                          nullptr,
+                                                          0,
+                                                          nullptr,
+                                                          SAI_STATS_MODE_BULK_READ,
+                                                          nullptr,
+                                                          nullptr));
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, m->bulkClearStats(SAI_NULL_OBJECT_ID,
+                                                            SAI_OBJECT_TYPE_PORT,
+                                                            0,
+                                                            nullptr,
+                                                            0,
+                                                            nullptr,
+                                                            SAI_STATS_MODE_BULK_CLEAR,
+                                                            nullptr));
+}

--- a/unittest/syncd/MockableSaiInterface.cpp
+++ b/unittest/syncd/MockableSaiInterface.cpp
@@ -200,6 +200,45 @@ sai_status_t MockableSaiInterface::clearStats(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t MockableSaiInterface::bulkGetStats(
+    _In_ sai_object_id_t switchId,
+    _In_ sai_object_type_t object_type,
+    _In_ uint32_t object_count,
+    _In_ const sai_object_key_t *object_key,
+    _In_ uint32_t number_of_counters,
+    _In_ const sai_stat_id_t *counter_ids,
+    _In_ sai_stats_mode_t mode,
+    _Inout_ sai_status_t *object_statuses,
+    _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+    if (mock_bulkGetStats)
+    {
+        return mock_bulkGetStats(switchId, object_type, object_count, object_key, number_of_counters, counter_ids, mode, object_statuses, counters);
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t MockableSaiInterface::bulkClearStats(
+    _In_ sai_object_id_t switchId,
+    _In_ sai_object_type_t object_type,
+    _In_ uint32_t object_count,
+    _In_ const sai_object_key_t *object_key,
+    _In_ uint32_t number_of_counters,
+    _In_ const sai_stat_id_t *counter_ids,
+    _In_ sai_stats_mode_t mode,
+    _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+    if (mock_bulkClearStats)
+    {
+        return mock_bulkClearStats(switchId, object_type, object_count, object_key, number_of_counters, counter_ids, mode, object_statuses);
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t MockableSaiInterface::flushFdbEntries(
     _In_ sai_object_id_t switchId,
     _In_ uint32_t attrCount,

--- a/unittest/syncd/MockableSaiInterface.h
+++ b/unittest/syncd/MockableSaiInterface.h
@@ -120,6 +120,30 @@ class MockableSaiInterface: public saimeta::DummySaiInterface
 
         std::function<sai_status_t(sai_object_type_t, sai_object_id_t, uint32_t, const sai_stat_id_t *)> mock_clearStats;
 
+        virtual sai_status_t bulkGetStats(
+                _In_ sai_object_id_t switchId,
+                _In_ sai_object_type_t object_type,
+                _In_ uint32_t object_count,
+                _In_ const sai_object_key_t *object_key,
+                _In_ uint32_t number_of_counters,
+                _In_ const sai_stat_id_t *counter_ids,
+                _In_ sai_stats_mode_t mode,
+                _Inout_ sai_status_t *object_statuses,
+                _Out_ uint64_t *counters) override;
+
+        std::function<sai_status_t(sai_object_id_t, sai_object_type_t, uint32_t, const sai_object_key_t *, uint32_t, const sai_stat_id_t *, sai_stats_mode_t, sai_status_t *, uint64_t *)> mock_bulkGetStats;
+
+        virtual sai_status_t bulkClearStats(
+                _In_ sai_object_id_t switchId,
+                _In_ sai_object_type_t object_type,
+                _In_ uint32_t object_count,
+                _In_ const sai_object_key_t *object_key,
+                _In_ uint32_t number_of_counters,
+                _In_ const sai_stat_id_t *counter_ids,
+                _In_ sai_stats_mode_t mode,
+                _Inout_ sai_status_t *object_statuses) override;
+
+        std::function<sai_status_t(sai_object_id_t, sai_object_type_t, uint32_t, const sai_object_key_t *, uint32_t, const sai_stat_id_t *, sai_stats_mode_t, sai_status_t *)> mock_bulkClearStats;
 
     public: // non QUAD API
 

--- a/unittest/vslib/TestSaiUnittests.cpp
+++ b/unittest/vslib/TestSaiUnittests.cpp
@@ -183,3 +183,28 @@ TEST(SaiUnittests, channelOpSetStats)
     usleep(100*1000);
 }
 
+TEST(SaiUnittests, bulkGetClearStats)
+{
+    Sai sai;
+
+    sai.initialize(0, &test_services);
+
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai.bulkGetStats(SAI_NULL_OBJECT_ID,
+                                                           SAI_OBJECT_TYPE_PORT,
+                                                           0,
+                                                           nullptr,
+                                                           0,
+                                                           nullptr,
+                                                           SAI_STATS_MODE_BULK_READ,
+                                                           nullptr,
+                                                           nullptr));
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai.bulkClearStats(SAI_NULL_OBJECT_ID,
+                                                             SAI_OBJECT_TYPE_PORT,
+                                                             0,
+                                                             nullptr,
+                                                             0,
+                                                             nullptr,
+                                                             SAI_STATS_MODE_BULK_READ,
+                                                             nullptr));
+}
+

--- a/unittest/vslib/test_sai_vs_interfacequery.cpp
+++ b/unittest/vslib/test_sai_vs_interfacequery.cpp
@@ -55,3 +55,28 @@ TEST(libsaivs, sai_switch_id_query)
 {
     EXPECT_EQ(SAI_NULL_OBJECT_ID, sai_switch_id_query(SAI_NULL_OBJECT_ID));
 }
+
+TEST(libsaivs, sai_bulk_object_get_stats)
+{
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai_bulk_object_get_stats(SAI_NULL_OBJECT_ID,
+                                                                    SAI_OBJECT_TYPE_PORT,
+                                                                    0,
+                                                                    nullptr,
+                                                                    0,
+                                                                    nullptr,
+                                                                    SAI_STATS_MODE_BULK_READ,
+                                                                    nullptr,
+                                                                    nullptr));
+}
+
+TEST(libsaivs, sai_bulk_object_clear_stats)
+{
+    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai_bulk_object_clear_stats(SAI_NULL_OBJECT_ID,
+                                                                      SAI_OBJECT_TYPE_PORT,
+                                                                      0,
+                                                                      nullptr,
+                                                                      0,
+                                                                      nullptr,
+                                                                      SAI_STATS_MODE_BULK_CLEAR,
+                                                                      nullptr));
+}

--- a/vslib/Sai.cpp
+++ b/vslib/Sai.cpp
@@ -519,6 +519,41 @@ sai_status_t Sai::clearStats(
             counter_ids);
 }
 
+sai_status_t Sai::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VS_CHECK_API_INITIALIZED();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t Sai::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VS_CHECK_API_INITIALIZED();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 // BULK QUAD OID
 
 sai_status_t Sai::bulkCreate(

--- a/vslib/Sai.h
+++ b/vslib/Sai.h
@@ -122,6 +122,27 @@ namespace saivs
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -961,6 +961,37 @@ sai_status_t VirtualSwitchSaiInterface::clearStats(
             counters);
 }
 
+sai_status_t VirtualSwitchSaiInterface::bulkGetStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t VirtualSwitchSaiInterface::bulkClearStats(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 sai_status_t VirtualSwitchSaiInterface::bulkRemove(
         _In_ sai_object_id_t switchId,
         _In_ sai_object_type_t object_type,

--- a/vslib/VirtualSwitchSaiInterface.h
+++ b/vslib/VirtualSwitchSaiInterface.h
@@ -121,6 +121,27 @@ namespace saivs
                     _In_ uint32_t number_of_counters,
                     _In_ const sai_stat_id_t *counter_ids) override;
 
+            virtual sai_status_t bulkGetStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses,
+                    _Out_ uint64_t *counters) override;
+
+            virtual sai_status_t bulkClearStats(
+                    _In_ sai_object_id_t switchId,
+                    _In_ sai_object_type_t object_type,
+                    _In_ uint32_t object_count,
+                    _In_ const sai_object_key_t *object_key,
+                    _In_ uint32_t number_of_counters,
+                    _In_ const sai_stat_id_t *counter_ids,
+                    _In_ sai_stats_mode_t mode,
+                    _Inout_ sai_status_t *object_statuses) override;
+
         public: // non QUAD API
 
             virtual sai_status_t flushFdbEntries(

--- a/vslib/sai_vs_interfacequery.cpp
+++ b/vslib/sai_vs_interfacequery.cpp
@@ -201,3 +201,34 @@ sai_status_t sai_query_api_version(
     *version = SAI_API_VERSION;
     return SAI_STATUS_SUCCESS;
 }
+
+sai_status_t sai_bulk_object_get_stats(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses,
+        _Out_ uint64_t *counters)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+sai_status_t sai_bulk_object_clear_stats(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Inout_ sai_status_t *object_statuses)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}


### PR DESCRIPTION
Note: the build may fail due to SAI header dependency. Vendor SAI implementation shall include this PR: https://github.com/opencomputeproject/SAI/pull/1352

HLD: https://github.com/sonic-net/SONiC/blob/master/doc/bulk_counter/bulk_counter.md

**Why I did this?**

PR https://github.com/opencomputeproject/SAI/pull/1352/files introduced new SAI APIs that supports bulk stats:

sai_bulk_object_get_stats
sai_bulk_object_clear_stats
SONiC flex counter infrastructure shall utilize bulk stats API to gain better performance. This document discusses how to integrate these two new APIs to SONiC.

**What I did?**

1. Support using bulk stats APIs based on object type. E.g. for a counter group that queries queue and pg stats, queue stats support bulk while pg stats does not, in that case queue stats shall use bulk API, pg stats shall use non bulk API
2. Automatically fall back to old way if bulk stats APIs are not supported

**How I test this**

Almost full unit test coverage
Manual test

