### PR TITLE
[fastboot] fastboot enhancement: Use warm-boot infrastructure for fast-boot

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -204,9 +204,9 @@ void Syncd::performStartupLogic()
 {
     SWSS_LOG_ENTER();
 
-    // ignore warm logic here if syncd starts in Mellanox fastfast boot mode
+    // ignore warm logic here if syncd starts in fastboot or Mellanox fastfast boot mode
 
-    if (m_isWarmStart && (m_commandLineOptions->m_startType != SAI_START_TYPE_FASTFAST_BOOT))
+    if (m_isWarmStart && m_commandLineOptions->m_startType != SAI_START_TYPE_FASTFAST_BOOT && m_commandLineOptions->m_startType != SAI_START_TYPE_FAST_BOOT)
     {
         SWSS_LOG_WARN("override command line startType=%s via SAI_START_TYPE_WARM_BOOT",
                 CommandLineOptions::startTypeToString(m_commandLineOptions->m_startType).c_str());

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -204,7 +204,7 @@ void Syncd::performStartupLogic()
 {
     SWSS_LOG_ENTER();
 
-    // ignore warm logic here if syncd starts in fastboot or Mellanox fastfast boot mode
+    // ignore warm logic here if syncd starts in fast-boot or Mellanox fastfast boot mode
 
     if (m_isWarmStart && m_commandLineOptions->m_startType != SAI_START_TYPE_FASTFAST_BOOT && m_commandLineOptions->m_startType != SAI_START_TYPE_FAST_BOOT)
     {

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -26,8 +26,10 @@ else
     CMD_ARGS=
 fi
 
-# Use temporary view between init and apply
-CMD_ARGS+=" -u"
+# Use temporary view between init and apply except when in fast-reboot
+if [[ "$(cat /proc/cmdline)" != *"SONIC_BOOT_TYPE=fast-reboot"* ]]; then
+    CMD_ARGS+=" -u"
+fi
 
 # Use bulk APIs in SAI
 # currently disabled since most vendors don't support that yet


### PR DESCRIPTION
This PR should be merged together with sonic-utilities PR (https://github.com/sonic-net/sonic-utilities/pull/2286) and sonic-buildimage PR (https://github.com/sonic-net/sonic-buildimage/pull/11594).

Fast-reboot is utilizing warm-reboot infrastructure to improve its performance, but it should ignore warm-boot logic when syncd starts in fast-boot.
As well it shouldn't use temporary view between init and apply.