### PR TITLE
Fix issue: bulk counter feature cannot compile on platforms having no sai_bulk_object_get_stats/sai_bulk_object_clear_stats

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,8 @@ AC_MSG_ERROR("SAI headers API version and library version mismatch")])])
 CXXFLAGS="$SAVED_FLAGS"
 ])])
 
+AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats)
+
 AC_OUTPUT(Makefile
           meta/Makefile
           lib/Makefile

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -661,6 +661,7 @@ sai_status_t VendorSai::bulkGetStats(
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
+#ifdef HAVE_SAI_BULK_OBJECT_GET_STATS
     return sai_bulk_object_get_stats(
             switchId,
             object_type,
@@ -671,6 +672,9 @@ sai_status_t VendorSai::bulkGetStats(
             mode,
             object_statuses,
             counters);
+#else
+    return SAI_STATUS_NOT_IMPLEMENTED;
+#endif
 }
 
 sai_status_t VendorSai::bulkClearStats(
@@ -687,6 +691,7 @@ sai_status_t VendorSai::bulkClearStats(
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
+#ifdef HAVE_SAI_BULK_OBJECT_CLEAR_STATS
     return sai_bulk_object_clear_stats(
             switchId,
             object_type,
@@ -696,6 +701,9 @@ sai_status_t VendorSai::bulkClearStats(
             counter_ids,
             mode,
             object_statuses);
+#else
+    return SAI_STATUS_NOT_IMPLEMENTED;
+#endif
 }
 
 // BULK QUAD OID

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -672,7 +672,7 @@ sai_status_t VendorSai::bulkGetStats(
             mode,
             object_statuses,
             counters);
-#else
+#else // For vendors do not support this API
     return SAI_STATUS_NOT_IMPLEMENTED;
 #endif
 }
@@ -701,7 +701,7 @@ sai_status_t VendorSai::bulkClearStats(
             counter_ids,
             mode,
             object_statuses);
-#else
+#else // For vendors do not support this API
     return SAI_STATUS_NOT_IMPLEMENTED;
 #endif
 }

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -11,7 +11,8 @@ tests_SOURCES = main.cpp \
 				TestCommandLineOptions.cpp \
 				TestFlexCounter.cpp \
 				TestVirtualOidTranslator.cpp \
-				TestNotificationQueue.cpp
+				TestNotificationQueue.cpp \
+				TestVendorSai.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/vslib/libSaiVS.a -lhiredis -lswsscommon -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 -lpthread -L$(top_srcdir)/lib/.libs -lsairedis -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+#include "VendorSai.h"
+#include "swss/logger.h"
+
+#ifdef HAVE_SAI_BULK_OBJECT_GET_STATS
+#undef HAVE_SAI_BULK_OBJECT_GET_STATS
+#endif
+
+using namespace syncd;
+
+static const char* profile_get_value(
+        _In_ sai_switch_profile_id_t profile_id,
+        _In_ const char* variable)
+{
+    SWSS_LOG_ENTER();
+
+    if (variable == NULL)
+        return NULL;
+
+    return nullptr;
+}
+
+static int profile_get_next_value(
+        _In_ sai_switch_profile_id_t profile_id,
+        _Out_ const char** variable,
+        _Out_ const char** value)
+{
+    SWSS_LOG_ENTER();
+
+    return 0;
+}
+
+static sai_service_method_table_t test_services = {
+    profile_get_value,
+    profile_get_next_value
+};
+
+TEST(VendorSai, bulkGetStats)
+{
+    VendorSai sai;
+    sai.initialize(0, &test_services);
+    ASSERT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai.bulkGetStats(SAI_NULL_OBJECT_ID,
+                                                           SAI_OBJECT_TYPE_PORT,
+                                                           0,
+                                                           nullptr,
+                                                           0,
+                                                           nullptr,
+                                                           SAI_STATS_MODE_BULK_READ_AND_CLEAR,
+                                                           nullptr,
+                                                           nullptr));
+    ASSERT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai.bulkClearStats(SAI_NULL_OBJECT_ID,
+                                                             SAI_OBJECT_TYPE_PORT,
+                                                             0,
+                                                             nullptr,
+                                                             0,
+                                                             nullptr,
+                                                             SAI_STATS_MODE_BULK_READ_AND_CLEAR,
+                                                             nullptr));
+}


### PR DESCRIPTION
Why I did this?

bulk counter feature uses two new SAI API sai_bulk_object_get_stats/sai_bulk_object_clear_stats. Some vendors have no such API implemented in their SAI code. Need a way to make compilation pass.

How I fix this?

1. Add AC_CHECK_FUNCS for sai_bulk_object_get_stats/sai_bulk_object_clear_stats which generates macro HAVE_SAI_BULK_OBJECT_CLEAR_STATS/HAVE_SAI_BULK_OBJECT_GET_STATS in config.h.
2. Use ifdef to avoid compilation failure.