### PR TITLE
[vslib]: Add SAI_PORT_ATTR_OPER_SPEED get

### DIFF
--- a/unittest/vslib/TestSwitchBCM81724.cpp
+++ b/unittest/vslib/TestSwitchBCM81724.cpp
@@ -117,6 +117,38 @@ TEST(SwitchBCM81724, refresh_read_only)
 
     EXPECT_EQ(sw.get(SAI_OBJECT_TYPE_PORT, strPortId, 1, &attr), SAI_STATUS_SUCCESS);
 
+    char fakeinfo_buffer[sizeof(HostInterfaceInfo)] = { 0 };
+    HostInterfaceInfo *fakeinfo = reinterpret_cast<HostInterfaceInfo *>(reinterpret_cast<void *>(fakeinfo_buffer));
+    fakeinfo->m_portId = portId;
+    sw.m_hostif_info_map[""] = std::shared_ptr<HostInterfaceInfo>(fakeinfo, [](HostInterfaceInfo *){});
+    sw.m_switchConfig->m_laneMap->m_lane_to_ifname[1] = "eth0";
+
+    attr.id = SAI_PORT_ATTR_OPER_STATUS;
+    attr.value.s32 = SAI_PORT_OPER_STATUS_DOWN;
+
+    EXPECT_EQ(sw.set(SAI_OBJECT_TYPE_PORT, strPortId, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_PORT_ATTR_OPER_SPEED;
+
+    EXPECT_EQ(sw.get(SAI_OBJECT_TYPE_PORT, strPortId, 1, &attr), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(attr.value.u32, 0);
+
+    attr.id = SAI_PORT_ATTR_OPER_STATUS;
+    attr.value.s32 = SAI_PORT_OPER_STATUS_UP;
+
+    EXPECT_EQ(sw.set(SAI_OBJECT_TYPE_PORT, strPortId, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_PORT_ATTR_OPER_SPEED;
+
+    EXPECT_EQ(sw.get(SAI_OBJECT_TYPE_PORT, strPortId, 1, &attr), SAI_STATUS_SUCCESS);
+    EXPECT_GE(attr.value.u32, 0);
+
+    sw.m_hostif_info_map.clear();
+
+    attr.id = SAI_PORT_ATTR_OPER_SPEED;
+
+    EXPECT_NE(sw.get(SAI_OBJECT_TYPE_PORT, strPortId, 1, &attr), SAI_STATUS_SUCCESS);
+
     //std::cout << sw.dump_switch_database_for_warm_restart();
 }
 

--- a/vslib/SwitchBCM81724.cpp
+++ b/vslib/SwitchBCM81724.cpp
@@ -274,6 +274,9 @@ sai_status_t SwitchBCM81724::refresh_read_only(
 
             case SAI_PORT_ATTR_OPER_STATUS:
                 return SAI_STATUS_SUCCESS;
+
+            case SAI_PORT_ATTR_OPER_SPEED:
+                return refresh_port_oper_speed(object_id);
         }
     }
 

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -2200,6 +2200,36 @@ sai_status_t SwitchStateBase::refresh_port_serdes_id(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchStateBase::refresh_port_oper_speed(
+                    _In_ sai_object_id_t port_id)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_PORT_ATTR_OPER_STATUS;
+
+    CHECK_STATUS(get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
+
+    if (attr.value.s32 == SAI_PORT_OPER_STATUS_DOWN)
+    {
+        attr.value.u32 = 0;
+    }
+    else
+    {
+        if (!vs_get_oper_speed(port_id, attr.value.u32))
+        {
+            return SAI_STATUS_FAILURE;
+        }
+    }
+
+    attr.id = SAI_PORT_ATTR_OPER_SPEED;
+
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    return SAI_STATUS_SUCCESS;
+}
+
 // XXX extra work may be needed on GET api if N on list will be > then actual
 
 /*
@@ -2312,6 +2342,9 @@ sai_status_t SwitchStateBase::refresh_read_only(
 
             case SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE:
                 return SAI_STATUS_SUCCESS;
+
+            case SAI_PORT_ATTR_OPER_SPEED:
+                return refresh_port_oper_speed(object_id);
         }
     }
 

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -165,6 +165,9 @@ namespace saivs
             virtual sai_status_t refresh_port_serdes_id(
                     _In_ sai_object_id_t bridge_id);
 
+            virtual sai_status_t refresh_port_oper_speed(
+                    _In_ sai_object_id_t port_id);
+
         public:
 
             virtual sai_status_t warm_boot_initialize_objects();
@@ -485,6 +488,10 @@ namespace saivs
 
             bool hasIfIndex(
                     _In_ int ifIndex) const;
+
+            bool vs_get_oper_speed(
+                    _In_ sai_object_id_t port_id,
+                    _Out_ uint32_t& speed);
 
         public: // TODO move inside warm boot load state
 


### PR DESCRIPTION
Add `SAI_PORT_ATTR_OPER_SPEED ` get in vslib. 
If the `SAI_PORT_ATTR_OPER_STATUS` is DOWN, `SAI_PORT_ATTR_OPER_SPEED`  should be 0, otherwise its value comes from `/sys/class/net/eth{X}/speed`

Signed-off-by: Ze Gan <ganze718@gmail.com>