### PR TITLE
Add Xsight specific syncd start options

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -287,6 +287,55 @@ config_syncd_innovium()
     mkdir -p $II_ROOT
 }
 
+config_syncd_xsight()
+{
+    SYS_MODE="asic"
+    CFG_FILE="/etc/sonic/xlink.cfg"
+    LABEL_REVISION_FILE="/etc/sonic/hw_revision"
+    ONIE_MACHINE=`sed -n -e 's/^.*onie_machine=//p' /etc/machine.conf`
+
+    ln -sf /usr/share/sonic/hwsku/xdrv_config.json /etc/xsight/xdrv_config.json
+    ln -sf /usr/share/sonic/hwsku/xlink_cfg.json /etc/xsight/xlink_cfg.json
+    ln -sf /usr/share/sonic/hwsku/lanes_polarity.json /etc/xsight/lanes_polarity.json
+
+    if [ -f  ${LABEL_REVISION_FILE} ]; then
+        LABEL_REVISION=`cat ${LABEL_REVISION_FILE}`
+        if [[ x${LABEL_REVISION} == x"R0B" ]] || [[ x${LABEL_REVISION} == x"R0B2" ]]; then
+            ln -sf /etc/xsight/serdes_config_A0.json /etc/xsight/serdes_config.json
+        else
+            ln -sf /etc/xsight/serdes_config_A1.json /etc/xsight/serdes_config.json
+        fi
+    fi
+
+    #export XLOG_DEBUG="XSW SAI SAI-HOST XHAL-TBL XHAL-LKP XHAL-LPM XHAL-TCAM XHAL-DTE XHAL-RNG XHAL-SP XHAL-RPC"
+    export XLOG_SYSLOG=ALL
+    export XLOG_LEVEL=ERROR
+    #export XLOG_FILE="/tmp/xsai.log"
+
+    #ports for XCLI Thrift client
+    export SAI_RPC_PORT=31000
+    export XSW_RPC_PORT=31001
+    export XHAL_RPC_PORT=31002
+
+    if [[ ${ONIE_MACHINE,,} != *"kvm"* ]]; then
+        # Working on HW box. Determine what to run XBM/ASIC
+        if [[ -f ${CFG_FILE} ]]; then
+            SYS_MODE=`sed -n -e 's/^.*sys_mode[[:blank:]]*=[[:blank:]]*//p' ${CFG_FILE}`
+        fi
+    else
+        SYS_MODE="xbm"
+    fi
+
+    if [[ ${SYS_MODE,,} == "xbm" ]]; then
+        rm -f /xbm/log/*
+        /xbm/run_xbm.sh &
+    else
+        export XDRV_PLUGIN_SO=libxpci_drv_plugin.so
+    fi
+
+    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+}
+
 config_syncd()
 {
     check_warm_boot
@@ -314,6 +363,8 @@ config_syncd()
         config_syncd_innovium
     elif [ "$SONIC_ASIC_TYPE" == "soda" ]; then
         config_syncd_soda
+    elif [ "$SONIC_ASIC_TYPE" == "xsight" ]; then
+        config_syncd_xsight
     else
         echo "Unknown ASIC type $SONIC_ASIC_TYPE"
         exit 1


### PR DESCRIPTION
Signed-off-by: Roman Zhurakivsky <rzhurak@larch-networks.com>

**What I did**
Added xsight platform specific options for syncd common

**How I did it**

Modify syncd_init_common.sh script. added a function to support xsight based platforms. 

**How to verify it**
Verify on Accton platform (based on Xsight ASIC)
