### PR TITLE
Create fabric ports for switch_type fabric.

### DIFF
--- a/unittest/vslib/Makefile.am
+++ b/unittest/vslib/Makefile.am
@@ -42,7 +42,8 @@ tests_SOURCES = main.cpp \
 				TestSwitchBCM56850.cpp \
 				TestSwitchBCM81724.cpp \
 				TestSwitchStateBaseMACsec.cpp \
-				TestMACsecManager.cpp
+				TestMACsecManager.cpp \
+				TestSwitchStateBase.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) -fno-access-control
 tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/vslib/libSaiVS.a -lhiredis -lswsscommon -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 \

--- a/unittest/vslib/TestSwitchStateBase.cpp
+++ b/unittest/vslib/TestSwitchStateBase.cpp
@@ -1,0 +1,34 @@
+#include "SwitchStateBase.h"
+#include "MACsecAttr.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace saivs;
+
+//Test the following function:
+//sai_status_t initialize_voq_switch_objects(
+//             _In_ uint32_t attr_count,
+//             _In_ const sai_attribute_t *attr_list);
+
+TEST(SwitchStateBase, initialize_voq_switch_objects)
+{
+    auto sc = std::make_shared<SwitchConfig>(0, "");
+    auto scc = std::make_shared<SwitchConfigContainer>();
+
+    SwitchStateBase ss(
+            0x2100000000,
+            std::make_shared<RealObjectIdManager>(0, scc),
+            sc);
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_TYPE;
+    attr.value.u32 = SAI_SWITCH_TYPE_FABRIC;
+    sc->m_fabricLaneMap = LaneMap::getDefaultLaneMap(0);
+    // Check the result of the initialize_voq_switch_objects
+    EXPECT_EQ(SAI_STATUS_SUCCESS,
+              ss.initialize_voq_switch_objects(1, &attr));
+}
+

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3035,7 +3035,8 @@ sai_status_t SwitchStateBase::initialize_voq_switch_objects(
                 {
                     // Switch is not being set as VOQ type.
                     SWSS_LOG_NOTICE("initialize_voq_switch_objects the value is %d", attr_list[i].value.u32);
-                    if (attr_list[i].value.u32 == SAI_SWITCH_TYPE_FABRIC) {
+                    if (attr_list[i].value.u32 == SAI_SWITCH_TYPE_FABRIC)
+                    {
                        SWSS_LOG_NOTICE("about to config fabric ports");
                        if (m_switchConfig->m_fabricLaneMap)
                        {

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3034,6 +3034,15 @@ sai_status_t SwitchStateBase::initialize_voq_switch_objects(
                 if (attr_list[i].value.u32 != SAI_SWITCH_TYPE_VOQ)
                 {
                     // Switch is not being set as VOQ type.
+                    SWSS_LOG_NOTICE("initialize_voq_switch_objects the value is %d", attr_list[i].value.u32);
+                    if (attr_list[i].value.u32 == SAI_SWITCH_TYPE_FABRIC) {
+                       SWSS_LOG_NOTICE("about to config fabric ports");
+                       if (m_switchConfig->m_fabricLaneMap)
+                       {
+                          CHECK_STATUS(create_fabric_ports());
+                          CHECK_STATUS(set_fabric_port_list());
+                       }
+                    }
                     return SAI_STATUS_SUCCESS;
                 }
                 else


### PR DESCRIPTION
Create fabric ports for switch_type fabric. This is needed to create vs test for fabric on supervisor. 