### PR TITLE
Manage LANES mapping on VOQ system

### DIFF
--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -48,11 +48,20 @@ std::string RedisClient::getRedisLanesKey(
      * NOTE: To support multiple switches LANES needs to be made per switch.
      *
      * return std::string(LANES) + ":" + sai_serialize_object_id(m_switch_vid);
+     *
+     * Only switch with index 0 and global context 0 will have key "LANES" for
+     * backward compatibility. We could convert that during runtime at first
+     * time.
      */
 
     auto index = VidManager::getSwitchIndex(switchVid);
 
     auto context = VidManager::getGlobalContext(switchVid);
+
+    if (index == 0 && context == 0)
+    {
+        return std::string(LANES);
+    }
 
     return (LANES ":") + sai_serialize_object_id(switchVid);
 }

--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -48,20 +48,11 @@ std::string RedisClient::getRedisLanesKey(
      * NOTE: To support multiple switches LANES needs to be made per switch.
      *
      * return std::string(LANES) + ":" + sai_serialize_object_id(m_switch_vid);
-     *
-     * Only switch with index 0 and global context 0 will have key "LANES" for
-     * backward compatibility. We could convert that during runtime at first
-     * time.
      */
 
     auto index = VidManager::getSwitchIndex(switchVid);
 
     auto context = VidManager::getGlobalContext(switchVid);
-
-    if (index == 0 && context == 0)
-    {
-        return std::string(LANES);
-    }
 
     return (LANES ":") + sai_serialize_object_id(switchVid);
 }

--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -62,7 +62,10 @@ SaiSwitch::SaiSwitch(
 
     helperInternalOids();
 
-    helperCheckLaneMap();
+    if (getSwitchType() == SAI_SWITCH_TYPE_NPU || getSwitchType() == SAI_SWITCH_TYPE_VOQ)
+    {
+        helperCheckLaneMap();
+    }
 
     helperLoadColdVids();
 

--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -62,10 +62,7 @@ SaiSwitch::SaiSwitch(
 
     helperInternalOids();
 
-    if (getSwitchType() == SAI_SWITCH_TYPE_NPU)
-    {
-        helperCheckLaneMap();
-    }
+    helperCheckLaneMap();
 
     helperLoadColdVids();
 


### PR DESCRIPTION
This issue is related to the dynamic port breakout mode support on multi-ASIC platforms. When the port breakout mode changes, SWSS removes ports from LANES mapping and adds new ports to LANES mapping. This logic works properly on the single-chip platform (NPU switch type) but it does not work properly on the multi-ASIC platform (VOQ switch type) because LANES mapping is not created on the multi-ASIC platform.

To fix this issue, my proposal is to create LANES mapping on the multi-ASIC platform.  Though the fix is straightforward, the comment in the existing codebase is a bit concerning to me. I am not sure if creating LANES mapping on the multi-ASIC platform could affect backward compatibility. @arlakshm