### PR TITLE
[syncd] bulk OID remove requires RID (#854)

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1429,7 +1429,7 @@ sai_status_t Syncd::processBulkOidRemove(
     status = m_vendorSai->bulkRemove(
                                 objectType,
                                 (uint32_t)object_count,
-                                objectVids.data(),
+                                objectRids.data(),
                                 mode,
                                 statuses.data());
 


### PR DESCRIPTION
Syncd::processBulkOidRemove() is incorrectly passing objectVids.data() to m_vendorSai->bulkRemove() when it should be passing objectRids.data(). Only RID should be passed to m_vendorSai calls.