### PR TITLE
[syncd] bulk OID remove requires RID

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1429,7 +1429,7 @@ sai_status_t Syncd::processBulkOidRemove(
     status = m_vendorSai->bulkRemove(
                                 objectType,
                                 (uint32_t)object_count,
-                                objectVids.data(),
+                                objectRids.data(),
                                 mode,
                                 statuses.data());
 


### PR DESCRIPTION
the feature of "SAI bulk OID" on removing requires RID, not VID