### PR TITLE
[lgtm] Fix libyang missing in lgtm validation issue

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -21,7 +21,6 @@ extraction:
       - libgmock-dev
       - uuid
       - uuid-dev
-      - libyang
       - libyang-dev
     after_prepare:
       - ls -l

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -22,6 +22,7 @@ extraction:
       - uuid
       - uuid-dev
       - libyang-dev
+      - libyang
     after_prepare:
       - ls -l
       - git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common; ./autogen.sh; fakeroot dpkg-buildpackage -us -uc -b; popd

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -21,6 +21,8 @@ extraction:
       - libgmock-dev
       - uuid
       - uuid-dev
+      - libyang
+      - libyang-dev
     after_prepare:
       - ls -l
       - git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common; ./autogen.sh; fakeroot dpkg-buildpackage -us -uc -b; popd


### PR DESCRIPTION
#### Why I did it
sonic-swss-common lib will add depency to libyang soon, so need install libyang lib to prevent lgtm break.

#### How I did it
Modify azure pipeline to install libyang in lgtm steps.

#### How to verify it
Pass lgtm validation.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Modify lgtm.yml to install libyang in lgtm.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

