### PR TITLE
sairedis: Fixing race condition for rif counters

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1521,6 +1521,7 @@ void FlexCounter::removeCounter(
     {
         if (hasCounterContext(COUNTER_TYPE_RIF))
         {
+            removeDataFromCountersDB(vid, ":RIF");
             getCounterContext(COUNTER_TYPE_RIF)->removeObject(vid);
         }
     }


### PR DESCRIPTION
* Fixing issue #11621
* The cleanup code for stale rif counters are now moved to syncd . Earlier as part of fix for issue #2193 the cleanup for stale rif counters was added.
* But it could create a race condition between orchagent removes RIF rate counters from DB and lua script fetching them.
* So as a fix all such cleanup has been moved to syncd.

Signed-off-by: Suman Kumar <suman.kumar@broadcom.com>

All the details are mentioned in : 
https://github.com/sonic-net/sonic-swss/pull/2488
