### PR TITLE
[ci][asan] add DVS tests run with ASAN

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -23,6 +23,10 @@ parameters:
 - name: artifact_name
   type: string
 
+- name: asan
+  type: boolean
+  default: false
+
 jobs:
 - job:
   displayName: ${{ parameters.arch }}
@@ -63,13 +67,13 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
-      patterns: '**/target/docker-sonic-vs.gz'
-    displayName: "Download sonic-buildimage docker-sonic-vs"
+      patterns: '**/target/{{ parameters.artifact_name }}.gz'
+    displayName: "Download sonic-buildimage {{ parameters.artifact_name }}"
   - script: |
       set -ex
       echo $(Build.DefinitionName).$(Build.BuildNumber)
 
-      docker load < $(Build.ArtifactStagingDirectory)/download/target/docker-sonic-vs.gz
+      docker load < $(Build.ArtifactStagingDirectory)/download/target/${{ parameters.artifact_name }}.gz
 
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
@@ -77,13 +81,18 @@ jobs:
 
       pushd .azure-pipelines
 
-      docker build --no-cache -t docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber) docker-sonic-vs
+      build_args=""
+      if [ '${{ parameters.asan }}' == True ]; then
+        build_args="--build-arg need_dbg=y"
+      fi
+
+      docker build $build_args --no-cache -t docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }} docker-sonic-vs
 
       popd
 
-      docker save docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber) | gzip -c > $(Build.ArtifactStagingDirectory)/docker-sonic-vs.gz
+      docker save docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }} | gzip -c > $(Build.ArtifactStagingDirectory)/docker-sonic-vs.gz
       rm -rf $(Build.ArtifactStagingDirectory)/download
-    displayName: "Build docker-sonic-vs"
+    displayName: "Build {{ parameters.artifact_name }}"
 
   - publish: $(Build.ArtifactStagingDirectory)/
     artifact: ${{ parameters.artifact_name }}

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -67,8 +67,8 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
-      patterns: '**/target/{{ parameters.artifact_name }}.gz'
-    displayName: "Download sonic-buildimage {{ parameters.artifact_name }}"
+      patterns: '**/target/${{ parameters.artifact_name }}.gz'
+    displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
   - script: |
       set -ex
       echo $(Build.DefinitionName).$(Build.BuildNumber)
@@ -92,7 +92,7 @@ jobs:
 
       docker save docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }} | gzip -c > $(Build.ArtifactStagingDirectory)/docker-sonic-vs.gz
       rm -rf $(Build.ArtifactStagingDirectory)/download
-    displayName: "Build {{ parameters.artifact_name }}"
+    displayName: "Build ${{ parameters.artifact_name }}"
 
   - publish: $(Build.ArtifactStagingDirectory)/
     artifact: ${{ parameters.artifact_name }}

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -39,6 +39,10 @@ parameters:
   type: boolean
   default: false
 
+- name: asan
+  type: boolean
+  default: false
+
 - name: debian_version
   type: string
 
@@ -150,7 +154,11 @@ jobs:
       set -ex
       rm ../*.deb || true
       ./autogen.sh
-      DEB_BUILD_OPTIONS=nocheck fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="" binary-syncd-vs
+      extraflags='--enable-code-coverage'
+      if [ '${{ parameters.asan }}' == True ]; then
+         extraflags='--enable-asan'
+      fi
+      DEB_BUILD_OPTIONS=nocheck fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS=$extraflags CFLAGS="" CXXFLAGS="" binary-syncd-vs
       mv ../*.deb .
     displayName: "Compile sonic sairedis with coverage enabled"
   - script: |

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker-sonic-vs
 
 ARG docker_container_name
+ARG need_dbg
 
 ADD ["debs", "/debs"]
 
@@ -15,5 +16,6 @@ RUN dpkg -i /debs/libsaimetadata_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsaivs_1.0.0_amd64.deb
 RUN dpkg -i /debs/syncd-vs_1.0.0_amd64.deb
+RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/syncd-vs-dbg_1.0.0_amd64.deb ; fi
 
 RUN dpkg -i /debs/swss_1.0.0_amd64.deb

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -6,6 +6,14 @@ parameters:
 - name: log_artifact_name
   type: string
 
+- name: docker_sonic_vs_name
+  type: string
+  default: docker-sonic-vs
+
+- name: asan
+  type: boolean
+  default: false
+
 jobs:
 - job:
   displayName: vstest
@@ -30,9 +38,9 @@ jobs:
     displayName: Set up sonic-swss branch
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: docker-sonic-vs
+      artifact: ${{ parameters.docker_sonic_vs_name }}
       path: $(Build.ArtifactStagingDirectory)/download
-    displayName: "Download pre-stage built docker-sonic-vs"
+    displayName: "Download pre-stage built ${{ parameters.docker_sonic_vs_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
@@ -64,6 +72,10 @@ jobs:
       docker ps
       ip netns list
       pushd sonic-swss/tests
+      params=''
+      if [ '${{ parameters.asan }}' == True ]; then
+        params='--graceful-stop'
+      fi
       all_tests=$(ls test_*.py)
       all_tests="${all_tests} p4rt"
       test_set=()
@@ -72,16 +84,17 @@ jobs:
         test_set+=("${test}")
         if [ ${#test_set[@]} -ge 20 ]; then
           test_name=$(echo "${test_set[0]}" | cut -d "." -f 1)
-          echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
+          echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" $params --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }}
           test_set=()
         fi
       done
       if [ ${#test_set[@]} -gt 0 ]; then
         test_name=$(echo "${test_set[0]}" | cut -d "." -f 1)
-        echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
+        echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" $params --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }}
       fi
       rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"
+    continueOnError: ${{ parameters.asan }}
 
   - task: PublishTestResults@2
     inputs:
@@ -91,6 +104,9 @@ jobs:
 
   - script: |
       cp -r sonic-swss/tests/log $(Build.ArtifactStagingDirectory)/
+      if [ '${{ parameters.asan }}' == True ]; then
+        cp -vr sonic-swss/tests/log/*/log/asan $(Build.ArtifactStagingDirectory)/
+      fi
     displayName: "Collect logs"
     condition: always()
 
@@ -98,3 +114,19 @@ jobs:
     artifact: ${{ parameters.log_artifact_name }}@$(System.JobAttempt)
     displayName: "Publish logs"
     condition: always()
+
+  - publish: $(Build.ArtifactStagingDirectory)/asan
+    artifact: asan-reports
+    displayName: "Publish ASAN reports"
+    condition: eq('${{ parameters.asan }}', true)
+
+  - script: |
+      if [ "$(ls -A $(Build.ArtifactStagingDirectory)/asan)" ]; then
+        echo "There are issues reported by ASAN"
+        exit 1
+      else
+        echo "No issues reported by ASAN"
+      fi
+    displayName: "Check ASAN reports"
+    condition: eq('${{ parameters.asan }}', true)
+    continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,21 @@ stages:
       archive_gcov: true
       debian_version: ${{ parameters.debian_version }}
 
+- stage: BuildAsan
+  dependsOn: []
+  jobs:
+  - template: .azure-pipelines/build-template.yml
+    parameters:
+      arch: amd64
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}
+      swss_common_artifact_name: sonic-swss-common
+      artifact_name: sonic-sairedis-asan
+      syslog_artifact_name: sonic-sairedis-asan.syslog
+      asan: true
+      run_unit_test: false
+      archive_gcov: false
+      debian_version: ${{ parameters.debian_version }}
+
 - stage: BuildArm
   dependsOn: Build
   condition: succeeded('Build')
@@ -110,6 +125,20 @@ stages:
       swss_artifact_name: sonic-swss
       artifact_name: docker-sonic-vs
 
+- stage: BuildDockerAsan
+  dependsOn:
+    - BuildAsan
+    - BuildSwss
+  condition: and(succeeded('BuildAsan'), succeeded('BuildSwss'))
+  jobs:
+  - template: .azure-pipelines/build-docker-sonic-vs-template.yml
+    parameters:
+      swss_common_artifact_name: sonic-swss-common
+      sairedis_artifact_name: sonic-sairedis-asan
+      swss_artifact_name: sonic-swss
+      artifact_name: docker-sonic-vs-asan
+      asan: true
+
 - stage: Test
   dependsOn: BuildDocker
   condition: succeeded('BuildDocker')
@@ -117,3 +146,13 @@ stages:
   - template: .azure-pipelines/test-docker-sonic-vs-template.yml
     parameters:
       log_artifact_name: log
+
+- stage: TestAsan
+  dependsOn: BuildDockerAsan
+  condition: succeeded('BuildDockerAsan')
+  jobs:
+  - template: .azure-pipelines/test-docker-sonic-vs-template.yml
+    parameters:
+      docker_sonic_vs_name: docker-sonic-vs-asan
+      log_artifact_name: log-asan
+      asan: true


### PR DESCRIPTION
This adds ASAN to CI DVS test run via 3 new stages:

* BuildAsan: build with --enable-asan
* BuildDockerAsan: builds docker-sonic-vs-asan with asan-enabled syncd and syncd-dbg
* TestAsan: runs the tests via docker-sonic-vs-asan and checks/publishes the reports

Current stages are not affected. Also, if an ASAN test run or a report check fails, it doesn't block a PR.