### PR TITLE
[202012][Recorder]: Acquire lock for ofstream changes

### DIFF
--- a/lib/src/Recorder.cpp
+++ b/lib/src/Recorder.cpp
@@ -190,10 +190,7 @@ void Recorder::requestLogRotate()
 
     /* double check since reopen could fail */
 
-    if (m_ofstream.is_open())
-    {
-        m_ofstream << getTimestamp() << "|" << "#|logrotate on: " << m_recordingFile << std::endl;
-    }
+    recordLine("#|logrotate on: " + m_recordingFile);
 }
 
 void Recorder::recordingFileReopen()

--- a/lib/src/Recorder.cpp
+++ b/lib/src/Recorder.cpp
@@ -220,18 +220,20 @@ void Recorder::recordingFileReopen()
 
 void Recorder::startRecording()
 {
-    MUTEX();
 
     SWSS_LOG_ENTER();
 
     m_recordingFile = m_recordingOutputDirectory + "/" + m_recordingFileName;
 
-    m_ofstream.open(m_recordingFile, std::ofstream::out | std::ofstream::app);
-
-    if (!m_ofstream.is_open())
     {
-        SWSS_LOG_ERROR("failed to open recording file %s: %s", m_recordingFile.c_str(), strerror(errno));
-        return;
+        MUTEX();
+        m_ofstream.open(m_recordingFile, std::ofstream::out | std::ofstream::app);
+
+        if (!m_ofstream.is_open())
+        {
+            SWSS_LOG_ERROR("failed to open recording file %s: %s", m_recordingFile.c_str(), strerror(errno));
+            return;
+        }
     }
 
     recordLine("#|recording on: " + m_recordingFile);

--- a/lib/src/Recorder.cpp
+++ b/lib/src/Recorder.cpp
@@ -220,7 +220,6 @@ void Recorder::recordingFileReopen()
 
 void Recorder::startRecording()
 {
-
     SWSS_LOG_ENTER();
 
     m_recordingFile = m_recordingOutputDirectory + "/" + m_recordingFileName;

--- a/lib/src/Recorder.cpp
+++ b/lib/src/Recorder.cpp
@@ -198,6 +198,8 @@ void Recorder::requestLogRotate()
 
 void Recorder::recordingFileReopen()
 {
+    MUTEX();
+
     SWSS_LOG_ENTER();
 
     m_ofstream.close();
@@ -221,6 +223,8 @@ void Recorder::recordingFileReopen()
 
 void Recorder::startRecording()
 {
+    MUTEX();
+
     SWSS_LOG_ENTER();
 
     m_recordingFile = m_recordingOutputDirectory + "/" + m_recordingFileName;
@@ -240,6 +244,8 @@ void Recorder::startRecording()
 
 void Recorder::stopRecording()
 {
+    MUTEX();
+
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("stopped recording");


### PR DESCRIPTION
While the Recorder is writing to the sairedis log file, it's possible for a log rotate to occur at exactly the right time so that file stream used for writing (a `std::ofstream`) is re-opened in the middle of the write operation (since writing and log rotate are handled by separate threads). Since standard library objects are not thread safe, this can cause some pointers used during the write operation to be overwritten, leading to a segmentation fault when the write operation proceeds.

To prevent this from occurring, acquire a lock for the file stream for any methods that change the ofstream (including opening, closing, and writing to it with the `<<` operator).

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>