### PR TITLE
[Recorder]: Acquire lock for ofstream changes

### DIFF
--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -189,10 +189,7 @@ void Recorder::requestLogRotate()
 
     /* double check since reopen could fail */
 
-    if (m_ofstream.is_open())
-    {
-        m_ofstream << getTimestamp() << "|" << "#|logrotate on: " << m_recordingFile << std::endl;
-    }
+    recordLine("#|logrotate on: " + m_recordingFile);
 }
 
 void Recorder::recordingFileReopen()

--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -219,7 +219,6 @@ void Recorder::recordingFileReopen()
 
 void Recorder::startRecording()
 {
-
     SWSS_LOG_ENTER();
 
     m_recordingFile = m_recordingOutputDirectory + "/" + m_recordingFileName;

--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -219,18 +219,20 @@ void Recorder::recordingFileReopen()
 
 void Recorder::startRecording()
 {
-    MUTEX();
 
     SWSS_LOG_ENTER();
 
     m_recordingFile = m_recordingOutputDirectory + "/" + m_recordingFileName;
 
-    m_ofstream.open(m_recordingFile, std::ofstream::out | std::ofstream::app);
-
-    if (!m_ofstream.is_open())
     {
-        SWSS_LOG_ERROR("failed to open recording file %s: %s", m_recordingFile.c_str(), strerror(errno));
-        return;
+        MUTEX();
+        m_ofstream.open(m_recordingFile, std::ofstream::out | std::ofstream::app);
+
+        if (!m_ofstream.is_open())
+        {
+            SWSS_LOG_ERROR("failed to open recording file %s: %s", m_recordingFile.c_str(), strerror(errno));
+            return;
+        }
     }
 
     recordLine("#|recording on: " + m_recordingFile);

--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -197,6 +197,8 @@ void Recorder::requestLogRotate()
 
 void Recorder::recordingFileReopen()
 {
+    MUTEX();
+
     SWSS_LOG_ENTER();
 
     m_ofstream.close();
@@ -220,6 +222,8 @@ void Recorder::recordingFileReopen()
 
 void Recorder::startRecording()
 {
+    MUTEX();
+
     SWSS_LOG_ENTER();
 
     m_recordingFile = m_recordingOutputDirectory + "/" + m_recordingFileName;
@@ -239,6 +243,8 @@ void Recorder::startRecording()
 
 void Recorder::stopRecording()
 {
+    MUTEX();
+
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("stopped recording");


### PR DESCRIPTION
While the Recorder is writing to the sairedis log file, it's possible for a log rotate to occur at exactly the right time so that file stream used for writing (a std::ofstream) is re-opened in the middle of the write operation (since writing and log rotate are handled by separate threads). Since standard library objects are not thread safe, this can cause some pointers used during the write operation to be overwritten, leading to a segmentation fault when the write operation proceeds.

To prevent this from occurring, acquire a lock for the file stream for any methods that change the ofstream (including opening, closing, and writing to it with the << operator). Also use `recordLine` for all writes to the file stream to avoid deadlock.

Signed-off-by: Lawrence Lee [lawlee@microsoft.com](mailto:lawlee@microsoft.com)