### PR TITLE
[lgtm]: Use 202012 branch of swsscommon

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -23,7 +23,7 @@ extraction:
       - uuid-dev
     after_prepare:
       - ls -l
-      - git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common; ./autogen.sh; fakeroot dpkg-buildpackage -us -uc -b; popd
+      - git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common; git checkout 202012; ./autogen.sh; fakeroot dpkg-buildpackage -us -uc -b; popd
       - dpkg-deb -x libswsscommon_1.0.0_amd64.deb $LGTM_WORKSPACE
       - dpkg-deb -x libswsscommon-dev_1.0.0_amd64.deb $LGTM_WORKSPACE
     configure:


### PR DESCRIPTION
LGTM on 202012 PRs are failing due to a dependency issue with libyang and swsscommon. Use the 202012 branch of swsscommon to avoid this.

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>