### PR TITLE
validation support for SAI_ATTR_VALUE_TYPE_JSON

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -3680,6 +3680,7 @@ void Meta::meta_generic_validation_post_remove(
             case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
             case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST:
             case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+	    case SAI_ATTR_VALUE_TYPE_JSON:
                 // no special action required
                 break;
 
@@ -4928,6 +4929,10 @@ sai_status_t Meta::meta_generic_validation_create(
                 VALIDATION_LIST(md, value.segmentlist);
                 break;
 
+	    case SAI_ATTR_VALUE_TYPE_JSON:
+                VALIDATION_LIST(md, value.json.json);
+                break;
+
             case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
 
                 if (value.u32range.min > value.u32range.max)
@@ -5581,6 +5586,10 @@ sai_status_t Meta::meta_generic_validation_set(
             VALIDATION_LIST(md, value.segmentlist);
             break;
 
+        case SAI_ATTR_VALUE_TYPE_JSON:
+            VALIDATION_LIST(md, value.json.json);
+            break;
+
         case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
 
             if (value.u32range.min > value.u32range.max)
@@ -5992,6 +6001,10 @@ sai_status_t Meta::meta_generic_validation_get(
                 VALIDATION_LIST(md, value.segmentlist);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_JSON:
+                VALIDATION_LIST(md, value.json.json);
+                break;
+
             case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
             case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
                 // primitives
@@ -6236,6 +6249,10 @@ void Meta::meta_generic_validation_post_get(
 
             case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
                 VALIDATION_LIST_GET(md, value.segmentlist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_JSON:
+                VALIDATION_LIST_GET(md, value.json.json);
                 break;
 
             case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
@@ -7136,6 +7153,7 @@ void Meta::meta_generic_validation_post_create(
             case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
             case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST:
             case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+            case SAI_ATTR_VALUE_TYPE_JSON:
                 // no special action required
                 break;
 
@@ -7376,6 +7394,7 @@ void Meta::meta_generic_validation_post_set(
         case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST:
         case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY:
         case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+        case SAI_ATTR_VALUE_TYPE_JSON:
             // no special action required
             break;
 

--- a/unittest/lib/Makefile.am
+++ b/unittest/lib/Makefile.am
@@ -37,6 +37,7 @@ testslibsairedis_SOURCES =	main_libsairedis.cpp \
 				test_sai_redis_debug_counter.cpp \
 				test_sai_redis_dtel.cpp \
 				test_sai_redis_fdb.cpp \
+				test_sai_redis_generic_programmable.cpp \
 				test_sai_redis_ipmc.cpp \
 				test_sai_redis_l2mc.cpp \
 				test_sai_redis_l2mcgroup.cpp \

--- a/unittest/lib/test_sai_redis_generic_programmable.cpp
+++ b/unittest/lib/test_sai_redis_generic_programmable.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "sai.h"
+}
+
+#include "swss/logger.h"
+
+TEST(libsairedis, generic_programmable)
+{
+    sai_generic_programmable_api_t *api = nullptr;
+
+    sai_api_query(SAI_API_GENERIC_PROGRAMMABLE, (void**)&api);
+
+    EXPECT_NE(api, nullptr);
+
+    sai_object_id_t obj_id;
+
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->create_generic_programmable(&obj_id,0,0,0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->remove_generic_programmable(0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->set_generic_programmable_attribute(0,0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->get_generic_programmable_attribute(0,0,0));
+}

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -569,7 +569,7 @@ TEST(Meta, quad_generic_programmable_entry)
     EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, &attr));
 
     std::string table_name = "test_table";
-    std::string json_value = "[{"match":{"datatype":"SAI_ATTR_VALUE_TYPE_UINT16","value":"0x07b"}},{"action":[{"field":{"datatype":"SAI_ATTR_VALUE_TYPE_UINT32","value":"0x000007d0"}}]}]";
+    std::string json_value = "test_json";
 
     sai_attribute_t attrs[2];
     attrs[0].id = SAI_GENERIC_PROGRAMMABLE_ATTR_OBJECT_NAME;
@@ -586,9 +586,9 @@ TEST(Meta, quad_generic_programmable_entry)
     attr.id = SAI_GENERIC_PROGRAMMABLE_ATTR_ENTRY;
     attr.value.s8list.count = (uint32_t)json_value.size();
     attr.value.s8list.list = (int8_t *)const_cast<char *>(json_value.c_str());
-    EXPECT_EQ(SAI_STATUS_SUCCESS, m.set(objId, &attr));
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.set(&objId, &attr));
 
-    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(objId));
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(&objId));
 }
 
 

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -586,9 +586,9 @@ TEST(Meta, quad_generic_programmable_entry)
     attr.id = SAI_GENERIC_PROGRAMMABLE_ATTR_ENTRY;
     attr.value.s8list.count = (uint32_t)json_value.size();
     attr.value.s8list.list = (int8_t *)const_cast<char *>(json_value.c_str());
-    EXPECT_EQ(SAI_STATUS_SUCCESS, m.set(&objId, &attr));
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.set(SAI_OBJECT_TYPE_GENERIC_PROGRAMMABLE, objId, &attr));
 
-    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(&objId));
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(SAI_OBJECT_TYPE_GENERIC_PROGRAMMABLE, objId));
 }
 
 

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -555,6 +555,43 @@ TEST(Meta, meta_validate_stats)
     EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, m.call_meta_validate_stats(SAI_OBJECT_TYPE_VIRTUAL_ROUTER, vrId, 2, counter_ids, counters, SAI_STATS_MODE_READ));
 }
 
+TEST(Meta, quad_generic_programmable_entry)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchId = 0;
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, &attr));
+
+    std::string table_name = "test_table";
+    std::string json_value = "[{"match":{"datatype":"SAI_ATTR_VALUE_TYPE_UINT16","value":"0x07b"}},{"action":[{"field":{"datatype":"SAI_ATTR_VALUE_TYPE_UINT32","value":"0x000007d0"}}]}]";
+
+    sai_attribute_t attrs[2];
+    attrs[0].id = SAI_GENERIC_PROGRAMMABLE_ATTR_OBJECT_NAME;
+    attrs[0].value.s8list.count = (uint32_t)table_name.size();
+    attrs[0].value.s8list.list = (int8_t *)const_cast<char *>(table_name.c_str());
+
+    attrs[1].id = SAI_GENERIC_PROGRAMMABLE_ATTR_ENTRY;
+    attrs[1].value.s8list.count = (uint32_t)json_value.size();
+    attrs[1].value.s8list.list = (int8_t *)const_cast<char *>(json_value.c_str());
+
+    sai_object_id_t objId = 0;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_GENERIC_PROGRAMMABLE, &objId, switchId, 2, attrs));
+
+    attr.id = SAI_GENERIC_PROGRAMMABLE_ATTR_ENTRY;
+    attr.value.s8list.count = (uint32_t)json_value.size();
+    attr.value.s8list.list = (int8_t *)const_cast<char *>(json_value.c_str());
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.set(objId, &attr));
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(objId));
+}
+
+
 TEST(Meta, quad_my_sid_entry)
 {
     Meta m(std::make_shared<MetaTestSaiInterface>());

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -588,6 +588,9 @@ TEST(Meta, quad_generic_programmable_entry)
     attr.value.s8list.list = (int8_t *)const_cast<char *>(json_value.c_str());
     EXPECT_EQ(SAI_STATUS_SUCCESS, m.set(SAI_OBJECT_TYPE_GENERIC_PROGRAMMABLE, objId, &attr));
 
+    attr.id = SAI_GENERIC_PROGRAMMABLE_ATTR_ENTRY;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.get(SAI_OBJECT_TYPE_GENERIC_PROGRAMMABLE, objId, 1, &attr));
+
     EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(SAI_OBJECT_TYPE_GENERIC_PROGRAMMABLE, objId));
 }
 

--- a/unittest/vslib/Makefile.am
+++ b/unittest/vslib/Makefile.am
@@ -59,6 +59,7 @@ testslibsaivs_SOURCES =	main_libsaivs.cpp \
 				test_sai_vs_debug_counter.cpp \
 				test_sai_vs_dtel.cpp \
 				test_sai_vs_fdb.cpp \
+				test_sai_vs_generic_programmable.cpp \
 				test_sai_vs_ipmc.cpp \
 				test_sai_vs_l2mc.cpp \
 				test_sai_vs_l2mcgroup.cpp \

--- a/unittest/vslib/test_sai_vs_generic_programmable.cpp
+++ b/unittest/vslib/test_sai_vs_generic_programmable.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "sai.h"
+}
+
+#include "swss/logger.h"
+
+TEST(libsaivs, generic_programmable)
+{
+    sai_generic_programmable_api_t *api = nullptr;
+
+    sai_api_query(SAI_API_GENERIC_PROGRAMMABLE, (void**)&api);
+
+    EXPECT_NE(api, nullptr);
+
+    sai_object_id_t obj_id;
+
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->create_generic_programmable(&obj_id,0,0,0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->remove_generic_programmable(0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->set_generic_programmable_attribute(0,0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->get_generic_programmable_attribute(0,0,0));
+}


### PR DESCRIPTION
With a support added for attr value type json, there is a validation support for this attr value type missing. This PR is to enable validation checks for the same.

Signed-off-by: svshah-intel shitanshu.shah@intel.com
