### PR TITLE
enable cisco8000 SAI bulk API feature

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -92,6 +92,7 @@ config_syncd_cisco_8000()
 {
     export BASE_OUTPUT_DIR=/opt/cisco/silicon-one
     CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+    CMD_ARGS+=" -l"
 
     # Cisco SDK debug shell support
     version=$(python3 -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\.\2/')


### PR DESCRIPTION
enable cisco8000 SAI bulk API feature

**What is the motivation for this PR?**
running ipfwd/test_nhop_count.py with cisco8000 will have an log analyzer's error message from monit as below if testcase configs a very huge amount NHG with more NHG members.

E               Aug 10 11:05:43.720848 str2-8102-02 ERR monit[513]: 'routeCheck' status failed (255) – Failure results: {{#012    "Unaccounted_ROUTE_ENTRY_TABLE_entries": [#012        "192.168.87.132/31",#012        "192.168.87.134/31",#012        "192.168.87.136/31",#012        "192.168.87.138/31",#012        "192.168.87.150/31",#012        "192.168.87.154/31",#012        "192.168.87.156/31",#012        "192.168.87.158/31",#012        "192.168.87.160/31",#012        "192.168.87.164/31",#012        "192.168.87.166/31",#012        "192.168.87.184/31",#012      


ROOT-CAUSE: ASIC_DB and AAPL_DB are not in-sync on route info on time

loganalyzer got "ERR monit" because route-check.py(sonic-utility) 
compares with both DB are un-matched on routing within a certain period of time.

cisco@mth64-m5-2:~$ 
sonic-db-cli ASIC_DB keys * | grep -n 192.183.96.128
ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:
{"dest":"192.183.96.128/25","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000042"}

sonic-db-cli APPL_DB keys * | grep -n 192.183.96.128
ROUTE_TABLE:192.183.96.128/25
nothing...


**How did you do it?**
enable SAI bulk API config from syncd to pass a set of Rid and review code-flow performance on cisco SAI/SDK layer. until route-check.py(sonic-utility) will not dump the associated ERR message.

**How did you verify/test it?**
PASS ipfwd/test_nhop_count.py with configing a very huge amount NHG(ex: 32K) with more NHG members(ex: each NHG with 10).
