### PR TITLE
The meta_sai_validate_fdb_entry() validates the input FDB entry for the

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -3826,7 +3826,7 @@ sai_status_t Meta::meta_sai_validate_fdb_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                 sai_serialize_object_meta_key(meta_key_fdb).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     // fdb entry is valid


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The FDB orchagent modify(set_fdb_entry_attribute)/deletes(remove_fdb_entry) the FDB entry, the meta module validates whether the FDB entry is indeed available in the DB. If the FDB entry is  not available , then an incorrect SAI return code (SAI_STATUS_INVALID_PARAMETER) is being returned. This is misleading to decide the appropriate action at FDB orch level.

#### How I did it
The correct SAI error code "SAI_STATUS_ITEM_NOT_FOUND" is returned in this case.


#### How to verify it
in the MCLAG system, when the MCLAG interface of one of the peer goes down operationally, then there will be a race condition where the bulk flush of FDB will be performed (flush by port/trunk). at the same time , the MCLAG module will be triggering the deletion of MACs one by one. in this scenario, if the the FDB entry is already deleted via bulk flush, then the attempt to delete the MAC individually fails. by correcting this error code and if its checked in the FDB orch module, then the failure can be handled gracefully.
 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
-->
correcting the SAI error return code for FDB validation at meta

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)