### PR TITLE
[202205][Cherry-pick][asan] suppress the static variable leaks

### DIFF
--- a/syncd/Asan.cpp
+++ b/syncd/Asan.cpp
@@ -3,6 +3,13 @@
 #include <csignal>
 #include <sanitizer/lsan_interface.h>
 
+extern "C" {
+    const char* __lsan_default_suppressions() {
+        // SWSS_LOG_ENTER(); // disabled
+        return "leak:__static_initialization_and_destruction_0\n";
+    }
+}
+
 static void sigterm_handler(int signo)
 {
     SWSS_LOG_ENTER();


### PR DESCRIPTION
cherry-pick from https://github.com/sonic-net/sonic-sairedis/pull/1085

This is to suppress ASAN false positives for static variables. For example, the ServiceMethodTable::m_slots is sometimes reported as leaked.

* [asan] suppress the static variable leaks
* [asan] add missing SWSS_LOG_ENTER()
