### PR TITLE
Initialize attr variables in Legacy.switch_get and LegacyFdbEntry.fdb_entry_get

### DIFF
--- a/unittest/meta/TestLegacyFdbEntry.cpp
+++ b/unittest/meta/TestLegacyFdbEntry.cpp
@@ -326,10 +326,14 @@ TEST(LegacyFdbEntry, fdb_entry_get)
 
     // correct 2 attributes
     sai_attribute_t attr1;
+    memset(&attr1, 0, sizeof(attr1));
     attr1.id = SAI_FDB_ENTRY_ATTR_TYPE;
+    attr1.value.oid = SAI_OBJECT_TYPE_NULL;
 
     sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
     attr2.id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
+    attr2.value.oid = SAI_OBJECT_TYPE_NULL;
     sai_attribute_t list[2] = { attr1, attr2 };
 
     status = g_meta->get(&fdb_entry, 2, list);

--- a/unittest/meta/TestLegacyOther.cpp
+++ b/unittest/meta/TestLegacyOther.cpp
@@ -362,10 +362,14 @@ TEST(Legacy, switch_get)
     EXPECT_EQ(SAI_STATUS_SUCCESS, status);
 
     sai_attribute_t attr1;
+    memset(&attr1, 0, sizeof(attr1));
     attr1.id = SAI_SWITCH_ATTR_PORT_NUMBER;
+    attr1.value.oid = SAI_OBJECT_TYPE_NULL;
 
     sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
     attr2.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+    attr2.value.oid = SAI_OBJECT_TYPE_NULL;
     sai_attribute_t list[2] = { attr1, attr2 };
 
     status = g_meta->get(SAI_OBJECT_TYPE_SWITCH, switch_id, 2, list);


### PR DESCRIPTION
When running unit tests for sairedis, there may be random test failures for Legacy.switch_get and LegacyFdbEntry.fdb_entry_get. This is happening because when doing the get call for
`SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID`, the value isn't initialized in this unit test function, with the assumption that it would contain the actual value assuming the get call was successful. There's two problems that happen:

1. Since a dummy SAI interface is being used for these tests, the get call always succeeds (assuming that the attr list and count arguments are valid), but the value for each attr is not modified at all.
2. Since this call returns a success, in `meta_generic_validation_post_get_objlist`, it will see the value for the attr (which is uninitialized memory) and complain that this value is not valid for this attr.

Depending on the uninitialized memory there, the reference counter for this OID may get incremented, and then when deleting the switch object, it will complain that there's still objects present, because it thinks this object exists.

To get around this, initialize `attr1` and `attr2` to make sure it's all zeroes, and that some random OID won't get added to a reference list.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>