### PR TITLE
Switch to using stock gcovr 5.2

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -168,6 +168,16 @@ jobs:
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |
         set -ex
+        git clone https://github.com/gcovr/gcovr.git
+        cd gcovr/
+        git checkout 5.2
+        sudo pip3 install setuptools
+        sudo python3 setup.py install
+        cd ..
+        sudo rm -rf gcovr
+      displayName: "Install gcovr 5.2 (for --exclude-throw-branches support)"
+    - script: |
+        set -ex
         # Add SYS_TIME capability for settimeofday ok in syncd test
         sudo setcap "cap_sys_time=eip" syncd/.libs/tests
         make check

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -168,16 +168,6 @@ jobs:
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |
         set -ex
-        git clone https://github.com/Spacetown/gcovr.git
-        cd gcovr/
-        git checkout origin/recursive_search_file
-        sudo pip3 install setuptools
-        sudo python3 setup.py install
-        cd ..
-        sudo rm -rf gcovr
-      displayName: "Install gcovr 5.0 with recursive fix"
-    - script: |
-        set -ex
         # Add SYS_TIME capability for settimeofday ok in syncd test
         sudo setcap "cap_sys_time=eip" syncd/.libs/tests
         make check


### PR DESCRIPTION
The custom branch we were using previously has since been deleted. That branch appears to have some fix for searching for the source file (for a gcda file) recursively. I don'y know if it's needed or not today, but using the stock gcovr 5.2 (from the official repo) appears to work.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>