### PR TITLE
[202205] Create fabric ports for switch_type fabric

### DIFF
--- a/unittest/vslib/TestSwitchStateBase.cpp
+++ b/unittest/vslib/TestSwitchStateBase.cpp
@@ -1,10 +1,36 @@
 #include "SwitchStateBase.h"
+#include "MACsecAttr.h"
 
 #include <gtest/gtest.h>
 
 #include <vector>
 
 using namespace saivs;
+
+//Test the following function:
+//sai_status_t initialize_voq_switch_objects(
+//             _In_ uint32_t attr_count,
+//             _In_ const sai_attribute_t *attr_list);
+
+TEST(SwitchStateBase, initialize_voq_switch_objects)
+{
+    auto sc = std::make_shared<SwitchConfig>(0, "");
+    auto scc = std::make_shared<SwitchConfigContainer>();
+
+    SwitchStateBase ss(
+            0x2100000000,
+            std::make_shared<RealObjectIdManager>(0, scc),
+            sc);
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_TYPE;
+    attr.value.u32 = SAI_SWITCH_TYPE_FABRIC;
+    sc->m_fabricLaneMap = LaneMap::getDefaultLaneMap(0);
+    // Check the result of the initialize_voq_switch_objects
+    EXPECT_EQ(SAI_STATUS_SUCCESS,
+              ss.initialize_voq_switch_objects(1, &attr));
+}
 
 TEST(SwitchStateBase, initialize_voq_switch)
 {

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3018,6 +3018,16 @@ sai_status_t SwitchStateBase::initialize_voq_switch_objects(
                 if (attr_list[i].value.u32 != SAI_SWITCH_TYPE_VOQ)
                 {
                     // Switch is not being set as VOQ type.
+                    SWSS_LOG_NOTICE("initialize_voq_switch_objects the value is %d", attr_list[i].value.u32);
+                    if (attr_list[i].value.u32 == SAI_SWITCH_TYPE_FABRIC)
+                    {
+                       SWSS_LOG_NOTICE("about to config fabric ports");
+                       if (m_switchConfig->m_fabricLaneMap)
+                       {
+                          CHECK_STATUS(create_fabric_ports());
+                          CHECK_STATUS(set_fabric_port_list());
+                       }
+                    }
                     return SAI_STATUS_SUCCESS;
                 }
                 else


### PR DESCRIPTION
This PR is to cherry-pick #1114 into `202205` branch after resolving conflicts.

The error of `test_fabric.py` can be fixed with this change
```
sudo pytest test_fabric.py -v --pdb --imgname=docker-sonic-vs:build --keeptb
========================================================================================= test session starts =========================================================================================
platform linux -- Python 3.7.5, pytest-7.1.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/bingwang/work/sonic/sonic-buildimage-202205/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 2 items                                                                                                                                                                                     

test_fabric.py::TestVirtualChassis::test_voq_switch  ^HPASSED                                                                                                                                      [ 50%]
test_fabric.py::test_nonflaky_dummy PASSED                                   
```