### PR TITLE
[Dual-ToR] update sai.profile with SAI_ADDITIONAL_MAC_ENABLED attribute if corresponding arg passed to syncd

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -219,6 +219,10 @@ config_syncd_mlnx()
        echo "SAI_DSCP_REMAPPING_ENABLED=1" >> /tmp/sai.profile
     fi
 
+    if [[ "$DUAL_TOR" == "enable" ]]; then
+       echo "SAI_ADDITIONAL_MAC_ENABLED=1" >> /tmp/sai.profile
+    fi
+
     SDK_DUMP_PATH=`cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
     if [ ! -d "$SDK_DUMP_PATH" ]; then
         mkdir -p "$SDK_DUMP_PATH"


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

Update sai.profile with SAI_ADDITIONAL_MAC_ENABLED=1 if "dual_tor" attr is passed to syncd