### PR TITLE
Fixing race condition for rif counters #1136 (202205 branch)

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1016,6 +1016,38 @@ void FlexCounter::removeFlowCounter(
     }
 }
 
+string FlexCounter::getRifCounterTableKey(string key)
+{
+    SWSS_LOG_ENTER();
+    return "COUNTERS:" + key;
+}
+
+string FlexCounter::getRifRateTableKey(string key)
+{
+    SWSS_LOG_ENTER();
+    return "RATES:" + key;
+}
+
+string FlexCounter::getRifRateInitTableKey(string key)
+{
+    SWSS_LOG_ENTER();
+    return "RATES:" + key + ":RIF";
+}
+
+void FlexCounter::cleanUpRifFromCounterDb(_In_ sai_object_id_t rifId)
+{
+    SWSS_LOG_ENTER();
+    const auto id = sai_serialize_object_id(rifId);
+    swss::DBConnector db(m_dbCounters, 0);
+    string counter_key = getRifCounterTableKey(id);
+    string rate_key = getRifRateTableKey(id);
+    string rate_init_key = getRifRateInitTableKey(id);
+    db.del(counter_key);
+    db.del(rate_key);
+    db.del(rate_init_key);
+    SWSS_LOG_NOTICE("CleanUp oid %s from counter db", id.c_str());
+}
+
 void FlexCounter::removeRif(
         _In_ sai_object_id_t rifVid)
 {
@@ -1030,6 +1062,7 @@ void FlexCounter::removeRif(
     }
 
     m_rifCounterIdsMap.erase(it);
+    cleanUpRifFromCounterDb(rifVid);
 
     if (m_rifCounterIdsMap.empty())
     {

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -50,6 +50,11 @@ namespace syncd
 
             bool isDiscarded();
 
+            std::string getRifCounterTableKey(std::string s);
+            std::string getRifRateTableKey(std::string s);
+            std::string getRifRateInitTableKey(std::string s);
+            void cleanUpRifFromCounterDb(_In_ sai_object_id_t rifId);
+
         private:
 
             void setPollInterval(


### PR DESCRIPTION
Changes for 202205 branch

- Fixing issue #11621
- All the details of the fix in master branch is in the PR : -
https://github.com/sonic-net/sonic-sairedis/pull/1136
https://github.com/sonic-net/sonic-swss/pull/2488
- This change is already merged to master branch , but sonic-sairedis change (https://github.com/sonic-net/sonic-sairedis/pull/1136) could not be cherry picked to 202205 branch as the base file FlexCounter.cpp differs in both the branches. Also, the API removeDataFromCountersDB is not available in 202205 branch for the cleanup. Hence the current fix takes care of cleaning up the stale rif counters issue through newly added API cleanUpRifFromCounterDb .

Unit Tests:-
The steps followed are same as in https://github.com/sonic-net/sonic-buildimage/issues/11621

- Create RIF in SONiC, wait till RIF rates are populated in COUNTERS DB
- Remove RIF
- Repeat the steps multiple times and check if any error syslog is seen (No error syslog is seen)
-  Also checked cleanup for rif counters.

After RIF creation derived info of oid for RIF from "COUNTERS_RIF_NAME_MAP"
127) "Vlan100"
128) "oid:0x6000000000aa5"

Checked all the tabled in COUNTER_DB which has same OID in keys
127.0.0.1:6379[2]> keys 6000000000aa5
1) "RATES:oid:0x6000000000aa5:RIF"
2) "COUNTERS:oid:0x6000000000aa5"
3) "RATES:oid:0x6000000000aa5"
127.0.0.1:6379[2]>

Deleted the RIF by removing the ip on the intf.

Checked COUNTER_DB again with same OID if there are stale entries or not. No stale entries exist now.
127.0.0.1:6379[2]> keys 6000000000aa5
(empty array)
127.0.0.1:6379[2]>
Signed-off-by: Suman Kumar <suman.kumar@broadcom.com>