### PR TITLE
[Bulk counters] Enable bulk counter feature for SAI vendors supporting the feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,7 +207,12 @@ AC_MSG_ERROR("SAI headers API version and library version mismatch")])])
 CXXFLAGS="$SAVED_FLAGS"
 ])])
 
+AM_COND_IF([SYNCD], [
+SAVED_FLAGS="$CXXFLAGS"
+CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
 AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats)
+CXXFLAGS="$SAVED_FLAGS"
+])
 
 AC_OUTPUT(Makefile
           meta/Makefile

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "VendorSai.h"
 
 #include "meta/sai_serialize.h"


### PR DESCRIPTION
#### Why I did it
AC_CHECK_FUNCS did not create macros HAVE_SAI_BULK_OBJECT_GET_STATS HAVE_SAI_BULK_OBJECT_CLEAR_STATS as expected. When those macros are not created, feature is disabled.

#### How I did it
Define needed CXXFLAGS for AC_CHECK_FUNCS, now macros are being created.
 
#### How to verify it
Run sonic-mgmt test test_cpu_memory_usage_desired_process

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [ ] 202205
- [ ] 202211
