### PR TITLE
[202205] Use new value of STATE_DB FAST_REBOOT entry

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -52,8 +52,8 @@ case "$(cat /proc/cmdline)" in
     ;;
   *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
     # check that the key exists
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
-    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
        FAST_REBOOT='yes'
     else
        FAST_REBOOT='no'


### PR DESCRIPTION
Dedicated PR for 202205 branch similar to https://github.com/sonic-net/sonic-sairedis/pull/1213 as part of fast-reboot finalizer implementation.

Update syncd_init_common to check if fast-reboot is enabled according to the new value for FAST_REBOOT entry in STATE_DB.

This PR should come along with the following PRs:
https://github.com/sonic-net/sonic-utilities/pull/2724
https://github.com/sonic-net/sonic-platform-daemons/pull/343
https://github.com/sonic-net/sonic-buildimage/pull/14143

This set of PRs solves the issue https://github.com/sonic-net/sonic-buildimage/issues/13251