### PR TITLE
Update build pipeline to build for Bullseye

### DIFF
--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -60,15 +60,12 @@ jobs:
   - script: |
       set -ex
       sudo apt-get update
-      sudo apt-get install -y libhiredis0.14 libhiredis-dev
-      sudo apt-get install -y libzmq5 libzmq3-dev
-      sudo apt-get install -qq -y \
-          libhiredis-dev \
-          swig3.0
-      sudo apt-get install -y libdbus-1-3
-      sudo apt-get install -y libteam-dev \
-          libteam5 \
-          libteamdctl0
+      sudo apt-get install -y \
+        libhiredis-dev \
+        libzmq3-dev \
+        swig4.0 \
+        libdbus-1-dev \
+        libteam-dev
     displayName: "Install dependencies"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -193,9 +193,9 @@ jobs:
           set -ex
           # Install .NET CORE
           curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          sudo apt-add-repository https://packages.microsoft.com/debian/10/prod
+          sudo apt-add-repository https://packages.microsoft.com/debian/11/prod
           sudo apt-get update
-          sudo apt-get install -y dotnet-sdk-5.0
+          sudo apt-get install -y dotnet-sdk-7.0
         displayName: "Install .NET CORE"
       - task: PublishCodeCoverageResults@1
         inputs:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -74,21 +74,18 @@ jobs:
       sudo apt-get update
       sudo apt-get install -qq -y \
         qtbase5-dev \
-        libdbus-glib-1-2 \
         libdbus-glib-1-dev \
         libpcsclite-dev \
         docbook-to-man \
         docbook-utils \
         aspell-en \
-        libhiredis0.14 \
         libhiredis-dev \
         libnl-3-dev \
         libnl-genl-3-dev \
         libnl-route-3-dev \
         libnl-nf-3-dev \
         libnl-cli-3-dev \
-        swig3.0 \
-        libpython2.7-dev \
+        swig4.0 \
         libzmq5 \
         libzmq3-dev \
         autoconf-archive
@@ -161,7 +158,7 @@ jobs:
       if [ '${{ parameters.asan }}' == True ]; then
          extraflags='--enable-asan'
       fi
-      DEB_BUILD_OPTIONS=nocheck fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS=$extraflags CFLAGS="" CXXFLAGS="" binary-syncd-vs
+      DEB_BUILD_OPTIONS=nocheck fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS=$extraflags DEB_BUILD_PROFILES=nopython2 CFLAGS="" CXXFLAGS="" binary-syncd-vs
       mv ../*.deb .
     displayName: "Compile sonic sairedis with coverage enabled"
   - script: |

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -5,17 +5,13 @@ ARG need_dbg
 
 ADD ["debs", "/debs"]
 
-RUN dpkg --purge python-swsscommon python3-swsscommon swss libsairedis sonic-db-cli libswsscommon libsaimetadata libsaivs syncd-vs
+RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb \
+            /debs/python3-swsscommon_1.0.0_amd64.deb \
+            /debs/sonic-db-cli_1.0.0_amd64.deb \
+            /debs/libsaimetadata_1.0.0_amd64.deb \
+            /debs/libsairedis_1.0.0_amd64.deb \
+            /debs/libsaivs_1.0.0_amd64.deb \
+            /debs/syncd-vs_1.0.0_amd64.deb \
+            /debs/swss_1.0.0_amd64.deb
 
-RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
-RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb
-RUN dpkg -i /debs/python3-swsscommon_1.0.0_amd64.deb
-RUN dpkg -i /debs/sonic-db-cli_1.0.0_amd64.deb
-
-RUN dpkg -i /debs/libsaimetadata_1.0.0_amd64.deb
-RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb
-RUN dpkg -i /debs/libsaivs_1.0.0_amd64.deb
-RUN dpkg -i /debs/syncd-vs_1.0.0_amd64.deb
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/syncd-vs-dbg_1.0.0_amd64.deb ; fi
-
-RUN dpkg -i /debs/swss_1.0.0_amd64.deb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ resources:
 parameters:
   - name: debian_version
     type: string
-    default: buster
+    default: bullseye
 variables:
   - name: BUILD_BRANCH
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
With the merge of sonic-net/sonic-buildimage#13294, docker-sonic-vs is now based on Bullseye. Switch to building for Bullseye to match that change.