### PR TITLE
Add macros for bulk API handlers generation.

### DIFF
--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -869,7 +869,8 @@ void Recorder::recordRemove(                                            \
         _In_ const sai_ ## ot ## _t* ot)                                \
 {                                                                       \
     SWSS_LOG_ENTER();                                                   \
-    recordRemove(SAI_OBJECT_TYPE_ ## OT, sai_serialize_ ## ot(*ot));    \
+    recordRemove((sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,             \
+        sai_serialize_ ## ot(*ot));                                     \
 }
 
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_RECORD_REMOVE_ENTRY);
@@ -881,7 +882,8 @@ void Recorder::recordCreate(                                                    
         _In_ const sai_attribute_t *attr_list)                                                  \
 {                                                                                               \
     SWSS_LOG_ENTER();                                                                           \
-    recordCreate(SAI_OBJECT_TYPE_ ## OT, sai_serialize_ ## ot(*ot), attr_count, attr_list);     \
+    recordCreate((sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                     \
+        sai_serialize_ ## ot(*ot), attr_count, attr_list);                                      \
 }
 
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_RECORD_CREATE_ENTRY);
@@ -892,7 +894,8 @@ void Recorder::recordSet(                                                       
         _In_ const sai_attribute_t *attr)                                                       \
 {                                                                                               \
     SWSS_LOG_ENTER();                                                                           \
-    recordSet(SAI_OBJECT_TYPE_ ## OT, sai_serialize_ ## ot(*ot), attr);                         \
+    recordSet((sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                        \
+        sai_serialize_ ## ot(*ot), attr);                                                       \
 }
 
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_RECORD_SET_ENTRY);
@@ -904,7 +907,8 @@ void Recorder::recordGet(                                                       
         _In_ const sai_attribute_t *attr_list)                                                  \
 {                                                                                               \
     SWSS_LOG_ENTER();                                                                           \
-    recordGet(SAI_OBJECT_TYPE_ ## OT, sai_serialize_ ## ot(*ot), attr_count, attr_list);        \
+    recordGet((sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                        \
+        sai_serialize_ ## ot(*ot), attr_count, attr_list);                                      \
 }
 
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_RECORD_GET_ENTRY);

--- a/lib/sai_redis.h
+++ b/lib/sai_redis.h
@@ -256,60 +256,60 @@ PRIVATE extern std::shared_ptr<sairedis::SaiInterface>   redis_sai;
 
 // BULK QUAD
 
-#define REDIS_BULK_CREATE(OT,fname)                 \
-    static sai_status_t redis_bulk_create_ ## fname(\
-            _In_ sai_object_id_t switch_id,         \
-            _In_ uint32_t object_count,             \
-            _In_ const uint32_t *attr_count,        \
-            _In_ const sai_attribute_t **attr_list, \
-            _In_ sai_bulk_op_error_mode_t mode,     \
-            _Out_ sai_object_id_t *object_id,       \
-            _Out_ sai_status_t *object_statuses)    \
-{                                                   \
-    SWSS_LOG_ENTER();                               \
-    return redis_sai->bulkCreate(                   \
-            SAI_OBJECT_TYPE_ ## OT,                 \
-            switch_id,                              \
-            object_count,                           \
-            attr_count,                             \
-            attr_list,                              \
-            mode,                                   \
-            object_id,                              \
-            object_statuses);                       \
+#define REDIS_BULK_CREATE(OT,fname)                    \
+    static sai_status_t redis_bulk_create_ ## fname(   \
+            _In_ sai_object_id_t switch_id,            \
+            _In_ uint32_t object_count,                \
+            _In_ const uint32_t *attr_count,           \
+            _In_ const sai_attribute_t **attr_list,    \
+            _In_ sai_bulk_op_error_mode_t mode,        \
+            _Out_ sai_object_id_t *object_id,          \
+            _Out_ sai_status_t *object_statuses)       \
+{                                                      \
+    SWSS_LOG_ENTER();                                  \
+    return redis_sai->bulkCreate(                      \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT, \
+            switch_id,                                 \
+            object_count,                              \
+            attr_count,                                \
+            attr_list,                                 \
+            mode,                                      \
+            object_id,                                 \
+            object_statuses);                          \
 }
 
-#define REDIS_BULK_REMOVE(OT,fname)                 \
-    static sai_status_t redis_bulk_remove_ ## fname(\
-            _In_ uint32_t object_count,             \
-            _In_ const sai_object_id_t *object_id,  \
-            _In_ sai_bulk_op_error_mode_t mode,     \
-            _Out_ sai_status_t *object_statuses)    \
-{                                                   \
-    SWSS_LOG_ENTER();                               \
-    return redis_sai->bulkRemove(                   \
-            SAI_OBJECT_TYPE_ ## OT,                 \
-            object_count,                           \
-            object_id,                              \
-            mode,                                   \
-            object_statuses);                       \
+#define REDIS_BULK_REMOVE(OT,fname)                    \
+    static sai_status_t redis_bulk_remove_ ## fname(   \
+            _In_ uint32_t object_count,                \
+            _In_ const sai_object_id_t *object_id,     \
+            _In_ sai_bulk_op_error_mode_t mode,        \
+            _Out_ sai_status_t *object_statuses)       \
+{                                                      \
+    SWSS_LOG_ENTER();                                  \
+    return redis_sai->bulkRemove(                      \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT, \
+            object_count,                              \
+            object_id,                                 \
+            mode,                                      \
+            object_statuses);                          \
 }
 
-#define REDIS_BULK_SET(OT,fname)                    \
-    static sai_status_t redis_bulk_set_ ## fname(   \
-            _In_ uint32_t object_count,             \
-            _In_ const sai_object_id_t *object_id,  \
-            _In_ const sai_attribute_t *attr_list,  \
-            _In_ sai_bulk_op_error_mode_t mode,     \
-            _Out_ sai_status_t *object_statuses)    \
-{                                                   \
-    SWSS_LOG_ENTER();                               \
-    return redis_sai->bulkSet(                      \
-            SAI_OBJECT_TYPE_ ## OT,                 \
-            object_count,                           \
-            object_id,                              \
-            attr_list,                              \
-            mode,                                   \
-            object_statuses);                       \
+#define REDIS_BULK_SET(OT,fname)                       \
+    static sai_status_t redis_bulk_set_ ## fname(      \
+            _In_ uint32_t object_count,                \
+            _In_ const sai_object_id_t *object_id,     \
+            _In_ const sai_attribute_t *attr_list,     \
+            _In_ sai_bulk_op_error_mode_t mode,        \
+            _Out_ sai_status_t *object_statuses)       \
+{                                                      \
+    SWSS_LOG_ENTER();                                  \
+    return redis_sai->bulkSet(                         \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT, \
+            object_count,                              \
+            object_id,                                 \
+            attr_list,                                 \
+            mode,                                      \
+            object_statuses);                          \
 }
 
 #define REDIS_BULK_GET(OT,fname)                    \
@@ -337,7 +337,10 @@ PRIVATE extern std::shared_ptr<sairedis::SaiInterface>   redis_sai;
 // BULK QUAD ENTRY
 
 #define REDIS_BULK_CREATE_ENTRY(OT,ot)              \
-    static sai_status_t redis_bulk_create_ ## ot(   \
+    REDIS_BULK_CREATE_ENTRY_EX(OT, ot, ot)
+
+#define REDIS_BULK_CREATE_ENTRY_EX(OT,ot,fname)     \
+    static sai_status_t redis_bulk_create_ ## fname(\
             _In_ uint32_t object_count,             \
             _In_ const sai_ ## ot ## _t *entry,     \
             _In_ const uint32_t *attr_count,        \
@@ -356,7 +359,10 @@ PRIVATE extern std::shared_ptr<sairedis::SaiInterface>   redis_sai;
 }
 
 #define REDIS_BULK_REMOVE_ENTRY(OT,ot)              \
-    static sai_status_t redis_bulk_remove_ ## ot(   \
+    REDIS_BULK_REMOVE_ENTRY_EX(OT, ot, ot)
+
+#define REDIS_BULK_REMOVE_ENTRY_EX(OT,ot,fname)     \
+    static sai_status_t redis_bulk_remove_ ## fname(\
             _In_ uint32_t object_count,             \
             _In_ const sai_ ## ot ##_t *entry,      \
             _In_ sai_bulk_op_error_mode_t mode,     \

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -116,10 +116,55 @@ sai_status_t DummySaiInterface::get(                \
     return m_status;                                \
 }
 
+#define DECLARE_BULK_CREATE_ENTRY(OT,ot)                \
+sai_status_t DummySaiInterface::bulkCreate(             \
+        _In_ uint32_t object_count,                     \
+        _In_ const sai_ ## ot ## _t* ot,                \
+        _In_ const uint32_t *attr_count,                \
+        _In_ const sai_attribute_t **attr_list,         \
+        _In_ sai_bulk_op_error_mode_t mode,             \
+        _Out_ sai_status_t *object_statuses)            \
+{                                                       \
+    SWSS_LOG_ENTER();                                   \
+    for (uint32_t idx = 0; idx < object_count; idx++)   \
+        object_statuses[idx] = m_status;                \
+    return m_status;                                    \
+}
+
+#define DECLARE_BULK_REMOVE_ENTRY(OT,ot)                \
+sai_status_t DummySaiInterface::bulkRemove(             \
+        _In_ uint32_t object_count,                     \
+        _In_ const sai_ ## ot ## _t* ot,                \
+        _In_ sai_bulk_op_error_mode_t mode,             \
+        _Out_ sai_status_t *object_statuses)            \
+{                                                       \
+    SWSS_LOG_ENTER();                                   \
+    for (uint32_t idx = 0; idx < object_count; idx++)   \
+        object_statuses[idx] = m_status;                \
+    return m_status;                                    \
+}
+
+#define DECLARE_BULK_SET_ENTRY(OT,ot)                   \
+sai_status_t DummySaiInterface::bulkSet(                \
+        _In_ uint32_t object_count,                     \
+        _In_ const sai_ ## ot ## _t* ot,                \
+        _In_ const sai_attribute_t *attr_list,          \
+        _In_ sai_bulk_op_error_mode_t mode,             \
+        _Out_ sai_status_t *object_statuses)            \
+{                                                       \
+    SWSS_LOG_ENTER();                                   \
+    for (uint32_t idx = 0; idx < object_count; idx++)   \
+        object_statuses[idx] = m_status;                \
+    return m_status;                                    \
+}
+
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_REMOVE_ENTRY);
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_CREATE_ENTRY);
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_SET_ENTRY);
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_GET_ENTRY);
+SAIREDIS_DECLARE_EVERY_BULK_ENTRY(DECLARE_BULK_CREATE_ENTRY);
+SAIREDIS_DECLARE_EVERY_BULK_ENTRY(DECLARE_BULK_REMOVE_ENTRY);
+SAIREDIS_DECLARE_EVERY_BULK_ENTRY(DECLARE_BULK_SET_ENTRY);
 
 sai_status_t DummySaiInterface::flushFdbEntries(
         _In_ sai_object_id_t switchId,
@@ -261,184 +306,10 @@ sai_status_t DummySaiInterface::bulkRemove(
     return m_status;
 }
 
-sai_status_t DummySaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_route_entry_t *route_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_nat_entry_t *nat_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_inseg_entry_t *inseg_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_fdb_entry_t *fdb_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_my_sid_entry_t *my_sid_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_neighbor_entry_t *neighbor_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
 sai_status_t DummySaiInterface::bulkSet(
         _In_ sai_object_type_t object_type,
         _In_ uint32_t object_count,
         _In_ const sai_object_id_t *object_id,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_route_entry_t *route_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_nat_entry_t *nat_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_inseg_entry_t *inseg_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_fdb_entry_t *fdb_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_my_sid_entry_t *my_sid_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_neighbor_entry_t *neighbor_entry,
         _In_ const sai_attribute_t *attr_list,
         _In_ sai_bulk_op_error_mode_t mode,
         _Out_ sai_status_t *object_statuses)
@@ -459,102 +330,6 @@ sai_status_t DummySaiInterface::bulkCreate(
         _In_ const sai_attribute_t **attr_list,
         _In_ sai_bulk_op_error_mode_t mode,
         _Out_ sai_object_id_t *object_id,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_route_entry_t *route_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_fdb_entry_t *fdb_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_inseg_entry_t *inseg_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_nat_entry_t *nat_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_my_sid_entry_t *my_sid_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-        object_statuses[idx] = m_status;
-
-    return m_status;
-}
-
-sai_status_t DummySaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_neighbor_entry_t *neighbor_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
         _Out_ sai_status_t *object_statuses)
 {
     SWSS_LOG_ENTER();

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -453,31 +453,38 @@ namespace saimeta
 
             sai_status_t meta_sai_validate_neighbor_entry(
                     _In_ const sai_neighbor_entry_t* neighbor_entry,
-                    _In_ bool create);
+                    _In_ bool create,
+                    _In_ bool get = false);
 
             sai_status_t meta_sai_validate_route_entry(
                     _In_ const sai_route_entry_t* route_entry,
-                    _In_ bool create);
+                    _In_ bool create,
+                    _In_ bool get = false);
 
             sai_status_t meta_sai_validate_l2mc_entry(
                     _In_ const sai_l2mc_entry_t* l2mc_entry,
-                    _In_ bool create);
+                    _In_ bool create,
+                    _In_ bool get = false);
 
             sai_status_t meta_sai_validate_ipmc_entry(
                     _In_ const sai_ipmc_entry_t* ipmc_entry,
-                    _In_ bool create);
+                    _In_ bool create,
+                    _In_ bool get = false);
 
             sai_status_t meta_sai_validate_nat_entry(
                     _In_ const sai_nat_entry_t* nat_entry,
-                    _In_ bool create);
+                    _In_ bool create,
+                    _In_ bool get = false);
 
             sai_status_t meta_sai_validate_inseg_entry(
                     _In_ const sai_inseg_entry_t* inseg_entry,
-                    _In_ bool create);
+                    _In_ bool create,
+                    _In_ bool get = false);
 
             sai_status_t meta_sai_validate_my_sid_entry(
                     _In_ const sai_my_sid_entry_t* my_sid_entry,
-                    _In_ bool create);
+                    _In_ bool create,
+                    _In_ bool get = false);
 
         public:
 

--- a/unittest/lib/TestClientServerSai.cpp
+++ b/unittest/lib/TestClientServerSai.cpp
@@ -180,10 +180,4 @@ TEST(ClientServerSai, bulk_neighbor_op)
     EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, css->bulkCreate(0, e, nullptr, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
     EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, css->bulkSet(2, e, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
     EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, css->bulkRemove(2, e, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
-    css = std::make_shared<ClientServerSai>();
-    EXPECT_EQ(SAI_STATUS_SUCCESS, css->initialize(0, &test_client_services));
-    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, css->bulkCreate(0, e, nullptr, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
-    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, css->bulkSet(2, e, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
-    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, css->bulkRemove(2, e, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
-
 }

--- a/unittest/lib/TestClientServerSai.cpp
+++ b/unittest/lib/TestClientServerSai.cpp
@@ -172,12 +172,42 @@ TEST(ClientServerSai, bulkGetClearStats)
                                                               nullptr));
 }
 
-TEST(ClientServerSai, bulk_neighbor_op)
-{
-    auto css = std::make_shared<ClientServerSai>();
-    sai_neighbor_entry_t e[2];
-    EXPECT_EQ(SAI_STATUS_SUCCESS, css->initialize(0, &test_services));
-    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, css->bulkCreate(0, e, nullptr, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
-    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, css->bulkSet(2, e, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
-    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, css->bulkRemove(2, e, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));
+#define TEST_ENTRY(OT,ot)                                                \
+TEST(ClientServerSai, OT)                                                \
+{                                                                        \
+    auto css = std::make_shared<ClientServerSai>();                      \
+    sai_ ## ot ## _t e;                                                  \
+    EXPECT_EQ(SAI_STATUS_SUCCESS, css->initialize(0, &test_services));   \
+    EXPECT_NE(SAI_STATUS_SUCCESS, css->create(&e, 0, nullptr));          \
+    EXPECT_NE(SAI_STATUS_SUCCESS, css->set(&e, nullptr));                \
+    EXPECT_NE(SAI_STATUS_SUCCESS, css->get(&e, 0, nullptr));             \
+    EXPECT_NE(SAI_STATUS_SUCCESS, css->remove(&e));                      \
+                                                                         \
+    auto ss = std::make_shared<ClientServerSai>();                       \
+    EXPECT_EQ(SAI_STATUS_SUCCESS, ss->initialize(0, &test_services));    \
+    EXPECT_NE(SAI_STATUS_SUCCESS, ss->create(&e, 0, nullptr));           \
+    EXPECT_NE(SAI_STATUS_SUCCESS, ss->set(&e, nullptr));                 \
+    EXPECT_NE(SAI_STATUS_SUCCESS, ss->get(&e, 0, nullptr));              \
+    EXPECT_NE(SAI_STATUS_SUCCESS, ss->remove(&e));                       \
 }
+
+SAIREDIS_DECLARE_EVERY_ENTRY(TEST_ENTRY)
+
+#define TEST_BULK_ENTRY(OT,ot)                                                                                               \
+TEST(ClientServerSai, bulk_ ## OT)                                                                                           \
+{                                                                                                                            \
+    auto css = std::make_shared<ClientServerSai>();                                                                          \
+    sai_ ## ot ## _t e[2];                                                                                                   \
+    EXPECT_EQ(SAI_STATUS_SUCCESS, css->initialize(0, &test_services));                                                       \
+    EXPECT_NE(SAI_STATUS_SUCCESS, css->bulkCreate(0, e, nullptr, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));    \
+    EXPECT_NE(SAI_STATUS_SUCCESS, css->bulkSet(2, e, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));                \
+    EXPECT_NE(SAI_STATUS_SUCCESS, css->bulkRemove(2, e, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));                      \
+                                                                                                                             \
+    auto ss = std::make_shared<ClientServerSai>();                                                                           \
+    EXPECT_EQ(SAI_STATUS_SUCCESS, ss->initialize(0, &test_client_services));                                                 \
+    EXPECT_NE(SAI_STATUS_SUCCESS, ss->bulkCreate(0, e, nullptr, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));     \
+    EXPECT_NE(SAI_STATUS_SUCCESS, ss->bulkSet(0, e, nullptr, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));                 \
+    EXPECT_NE(SAI_STATUS_SUCCESS, ss->bulkRemove(0, e, SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, nullptr));                       \
+}
+
+SAIREDIS_DECLARE_EVERY_BULK_ENTRY(TEST_BULK_ENTRY)

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -412,7 +412,7 @@ sai_status_t VirtualSwitchSaiInterface::remove(                 \
     SWSS_LOG_ENTER();                                           \
     return remove(                                              \
             entry->switch_id,                                   \
-            SAI_OBJECT_TYPE_ ## OT,                             \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,          \
             sai_serialize_ ## ot(*entry));                      \
 }
 
@@ -430,7 +430,7 @@ sai_status_t VirtualSwitchSaiInterface::create(                 \
     timer.start();                                              \
     auto status =  create(                                      \
             entry->switch_id,                                   \
-            SAI_OBJECT_TYPE_ ## OT,                             \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,          \
             sai_serialize_ ## ot(*entry),                       \
             attr_count,                                         \
             attr_list);                                         \
@@ -449,12 +449,88 @@ sai_status_t VirtualSwitchSaiInterface::set(                    \
     SWSS_LOG_ENTER();                                           \
     return set(                                                 \
             entry->switch_id,                                   \
-            SAI_OBJECT_TYPE_ ## OT,                             \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,          \
             sai_serialize_ ## ot(*entry),                       \
             attr);                                              \
 }
 
 SAIREDIS_DECLARE_EVERY_ENTRY(DECLARE_SET_ENTRY);
+
+#define DECLARE_BULK_CREATE_ENTRY(OT,ot)                              \
+sai_status_t VirtualSwitchSaiInterface::bulkCreate(                   \
+        _In_ uint32_t object_count,                                   \
+        _In_ const sai_ ## ot ## _t* ot,                              \
+        _In_ const uint32_t *attr_count,                              \
+        _In_ const sai_attribute_t **attr_list,                       \
+        _In_ sai_bulk_op_error_mode_t mode,                           \
+        _Out_ sai_status_t *object_statuses)                          \
+{                                                                     \
+    SWSS_LOG_ENTER();                                                 \
+    std::vector<std::string> serialized_object_ids;                   \
+    for (uint32_t idx = 0; idx < object_count; idx++)                 \
+    {                                                                 \
+        std::string str_object_id = sai_serialize_ ##ot (ot[idx]);    \
+        serialized_object_ids.push_back(str_object_id);               \
+    }                                                                 \
+    return bulkCreate(                                                \
+            ot->switch_id,                                            \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                \
+            serialized_object_ids,                                    \
+            attr_count,                                               \
+            attr_list,                                                \
+            mode,                                                     \
+            object_statuses);                                         \
+}
+
+SAIREDIS_DECLARE_EVERY_BULK_ENTRY(DECLARE_BULK_CREATE_ENTRY);
+
+#define DECLARE_BULK_REMOVE_ENTRY(OT,ot)                                   \
+sai_status_t VirtualSwitchSaiInterface::bulkRemove(                        \
+        _In_ uint32_t object_count,                                        \
+        _In_ const sai_ ## ot ## _t* ot,                                   \
+        _In_ sai_bulk_op_error_mode_t mode,                                \
+        _Out_ sai_status_t *object_statuses)                               \
+{                                                                          \
+    SWSS_LOG_ENTER();                                                      \
+    std::vector<std::string> serializedObjectIds;                          \
+    for (uint32_t idx = 0; idx < object_count; idx++)                      \
+    {                                                                      \
+        serializedObjectIds.emplace_back(sai_serialize_ ##ot (ot[idx]));   \
+    }                                                                      \
+    return bulkRemove(                                                     \
+            ot->switch_id,                                                 \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                     \
+            serializedObjectIds,                                           \
+            mode,                                                          \
+            object_statuses);                                              \
+}
+
+SAIREDIS_DECLARE_EVERY_BULK_ENTRY(DECLARE_BULK_REMOVE_ENTRY);
+
+#define DECLARE_BULK_SET_ENTRY(OT,ot)                                      \
+sai_status_t VirtualSwitchSaiInterface::bulkSet(                           \
+        _In_ uint32_t object_count,                                        \
+        _In_ const sai_ ## ot ## _t* ot,                                   \
+        _In_ const sai_attribute_t *attr_list,                             \
+        _In_ sai_bulk_op_error_mode_t mode,                                \
+        _Out_ sai_status_t *object_statuses)                               \
+{                                                                          \
+    SWSS_LOG_ENTER();                                                      \
+    std::vector<std::string> serializedObjectIds;                          \
+    for (uint32_t idx = 0; idx < object_count; idx++)                      \
+    {                                                                      \
+        serializedObjectIds.emplace_back(sai_serialize_ ##ot (ot[idx]));   \
+    }                                                                      \
+    return bulkSet(                                                        \
+            ot->switch_id,                                                 \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                     \
+            serializedObjectIds,                                           \
+            attr_list,                                                     \
+            mode,                                                          \
+            object_statuses);                                              \
+}
+
+SAIREDIS_DECLARE_EVERY_BULK_ENTRY(DECLARE_BULK_SET_ENTRY);
 
 std::shared_ptr<SwitchStateBase> VirtualSwitchSaiInterface::init_switch(
         _In_ sai_object_id_t switch_id,
@@ -715,7 +791,7 @@ sai_status_t VirtualSwitchSaiInterface::get(                    \
     SWSS_LOG_ENTER();                                           \
     return get(                                                 \
             entry->switch_id,                                   \
-            SAI_OBJECT_TYPE_ ## OT,                             \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,          \
             sai_serialize_ ## ot(*entry),                       \
             attr_count,                                         \
             attr_list);                                         \
@@ -1027,114 +1103,6 @@ sai_status_t VirtualSwitchSaiInterface::bulkRemove(
     return bulkRemove(switchId, object_type, serializedObjectIds, mode, object_statuses);
 }
 
-sai_status_t VirtualSwitchSaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_route_entry_t *route_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_route_entry(route_entry[idx]));
-    }
-
-    return bulkRemove(route_entry->switch_id, SAI_OBJECT_TYPE_ROUTE_ENTRY, serializedObjectIds, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_my_sid_entry_t *my_sid_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_my_sid_entry(my_sid_entry[idx]));
-    }
-
-    return bulkRemove(my_sid_entry->switch_id, SAI_OBJECT_TYPE_MY_SID_ENTRY, serializedObjectIds, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_neighbor_entry_t *neighbor_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_neighbor_entry(neighbor_entry[idx]));
-    }
-
-    return bulkRemove(neighbor_entry->switch_id, SAI_OBJECT_TYPE_NEIGHBOR_ENTRY, serializedObjectIds, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_nat_entry_t *nat_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_nat_entry(nat_entry[idx]));
-    }
-
-    return bulkRemove(nat_entry->switch_id, SAI_OBJECT_TYPE_NAT_ENTRY, serializedObjectIds, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_inseg_entry_t *inseg_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_inseg_entry(inseg_entry[idx]));
-    }
-
-    return bulkRemove(inseg_entry->switch_id, SAI_OBJECT_TYPE_INSEG_ENTRY, serializedObjectIds, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkRemove(
-        _In_ uint32_t object_count,
-        _In_ const sai_fdb_entry_t *fdb_entry,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_fdb_entry(fdb_entry[idx]));
-    }
-
-    return bulkRemove(fdb_entry->switch_id, SAI_OBJECT_TYPE_FDB_ENTRY, serializedObjectIds, mode, object_statuses);
-}
-
 sai_status_t VirtualSwitchSaiInterface::bulkSet(
         _In_ sai_object_type_t object_type,
         _In_ uint32_t object_count,
@@ -1155,120 +1123,6 @@ sai_status_t VirtualSwitchSaiInterface::bulkSet(
     auto switchId = switchIdQuery(*object_id);
 
     return bulkSet(switchId, object_type, serializedObjectIds, attr_list, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_route_entry_t *route_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_route_entry(route_entry[idx]));
-    }
-
-    return bulkSet(route_entry->switch_id, SAI_OBJECT_TYPE_ROUTE_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_my_sid_entry_t *my_sid_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_my_sid_entry(my_sid_entry[idx]));
-    }
-
-    return bulkSet(my_sid_entry->switch_id, SAI_OBJECT_TYPE_MY_SID_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_neighbor_entry_t *neighbor_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_neighbor_entry(neighbor_entry[idx]));
-    }
-
-    return bulkSet(neighbor_entry->switch_id, SAI_OBJECT_TYPE_NEIGHBOR_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_nat_entry_t *nat_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_nat_entry(nat_entry[idx]));
-    }
-
-    return bulkSet(nat_entry->switch_id, SAI_OBJECT_TYPE_NAT_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_inseg_entry_t *inseg_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_inseg_entry(inseg_entry[idx]));
-    }
-
-    return bulkSet(inseg_entry->switch_id, SAI_OBJECT_TYPE_INSEG_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkSet(
-        _In_ uint32_t object_count,
-        _In_ const sai_fdb_entry_t *fdb_entry,
-        _In_ const sai_attribute_t *attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serializedObjectIds;
-
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        serializedObjectIds.emplace_back(sai_serialize_fdb_entry(fdb_entry[idx]));
-    }
-
-    return bulkSet(fdb_entry->switch_id, SAI_OBJECT_TYPE_FDB_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);
 }
 
 sai_status_t VirtualSwitchSaiInterface::bulkSet(
@@ -1309,6 +1163,7 @@ sai_status_t VirtualSwitchSaiInterface::bulkCreate(
     // on create vid is put in db by syncd
     for (uint32_t idx = 0; idx < object_count; idx++)
     {
+        object_id[idx] = m_realObjectIdManager->allocateNewObjectId(object_type, switch_id);
         std::string str_object_id = sai_serialize_object_id(object_id[idx]);
         serialized_object_ids.push_back(str_object_id);
     }
@@ -1337,180 +1192,6 @@ sai_status_t VirtualSwitchSaiInterface::bulkCreate(
     auto ss = m_switchStateMap.at(switchId);
 
     return ss->bulkCreate(switchId, object_type, serialized_object_ids, attr_count, attr_list, mode, object_statuses);;
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_route_entry_t* route_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serialized_object_ids;
-
-    // on create vid is put in db by syncd
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        std::string str_object_id = sai_serialize_route_entry(route_entry[idx]);
-        serialized_object_ids.push_back(str_object_id);
-    }
-
-    return bulkCreate(
-            route_entry->switch_id,
-            SAI_OBJECT_TYPE_ROUTE_ENTRY,
-            serialized_object_ids,
-            attr_count,
-            attr_list,
-            mode,
-            object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_fdb_entry_t* fdb_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serialized_object_ids;
-
-    // on create vid is put in db by syncd
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        std::string str_object_id = sai_serialize_fdb_entry(fdb_entry[idx]);
-        serialized_object_ids.push_back(str_object_id);
-    }
-
-    return bulkCreate(
-            fdb_entry->switch_id,
-            SAI_OBJECT_TYPE_FDB_ENTRY,
-            serialized_object_ids,
-            attr_count,
-            attr_list,
-            mode,
-            object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_inseg_entry_t* inseg_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serialized_object_ids;
-
-    // on create vid is put in db by syncd
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        std::string str_object_id = sai_serialize_inseg_entry(inseg_entry[idx]);
-        serialized_object_ids.push_back(str_object_id);
-    }
-
-    return bulkCreate(
-            inseg_entry->switch_id,
-            SAI_OBJECT_TYPE_INSEG_ENTRY,
-            serialized_object_ids,
-            attr_count,
-            attr_list,
-            mode,
-            object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_my_sid_entry_t* my_sid_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serialized_object_ids;
-
-    // on create vid is put in db by syncd
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        std::string str_object_id = sai_serialize_my_sid_entry(my_sid_entry[idx]);
-        serialized_object_ids.push_back(str_object_id);
-    }
-
-    return bulkCreate(
-            my_sid_entry->switch_id,
-            SAI_OBJECT_TYPE_MY_SID_ENTRY,
-            serialized_object_ids,
-            attr_count,
-            attr_list,
-            mode,
-            object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_neighbor_entry_t* neighbor_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serialized_object_ids;
-
-    // on create vid is put in db by syncd
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        std::string str_object_id = sai_serialize_neighbor_entry(neighbor_entry[idx]);
-        serialized_object_ids.push_back(str_object_id);
-    }
-
-    return bulkCreate(
-            neighbor_entry->switch_id,
-            SAI_OBJECT_TYPE_NEIGHBOR_ENTRY,
-            serialized_object_ids,
-            attr_count,
-            attr_list,
-            mode,
-            object_statuses);
-}
-
-sai_status_t VirtualSwitchSaiInterface::bulkCreate(
-        _In_ uint32_t object_count,
-        _In_ const sai_nat_entry_t* nat_entry,
-        _In_ const uint32_t *attr_count,
-        _In_ const sai_attribute_t **attr_list,
-        _In_ sai_bulk_op_error_mode_t mode,
-        _Out_ sai_status_t *object_statuses)
-{
-    SWSS_LOG_ENTER();
-
-    std::vector<std::string> serialized_object_ids;
-
-    // on create vid is put in db by syncd
-    for (uint32_t idx = 0; idx < object_count; idx++)
-    {
-        std::string str_object_id = sai_serialize_nat_entry(nat_entry[idx]);
-        serialized_object_ids.push_back(str_object_id);
-    }
-
-    return bulkCreate(
-            nat_entry->switch_id,
-            SAI_OBJECT_TYPE_NAT_ENTRY,
-            serialized_object_ids,
-            attr_count,
-            attr_list,
-            mode,
-            object_statuses);
 }
 
 sai_object_type_t VirtualSwitchSaiInterface::objectTypeQuery(

--- a/vslib/sai_vs.h
+++ b/vslib/sai_vs.h
@@ -256,60 +256,60 @@ PRIVATE extern std::shared_ptr<sairedis::SaiInterface>      vs_sai;
 
 // BULK QUAD
 
-#define VS_BULK_CREATE(OT,fname)                    \
-    static sai_status_t vs_bulk_create_ ## fname(   \
-            _In_ sai_object_id_t switch_id,         \
-            _In_ uint32_t object_count,             \
-            _In_ const uint32_t *attr_count,        \
-            _In_ const sai_attribute_t **attr_list, \
-            _In_ sai_bulk_op_error_mode_t mode,     \
-            _Out_ sai_object_id_t *object_id,       \
-            _Out_ sai_status_t *object_statuses)    \
-{                                                   \
-    SWSS_LOG_ENTER();                               \
-    return vs_sai->bulkCreate(                      \
-            SAI_OBJECT_TYPE_ ## OT,                 \
-            switch_id,                              \
-            object_count,                           \
-            attr_count,                             \
-            attr_list,                              \
-            mode,                                   \
-            object_id,                              \
-            object_statuses);                       \
+#define VS_BULK_CREATE(OT,fname)                       \
+    static sai_status_t vs_bulk_create_ ## fname(      \
+            _In_ sai_object_id_t switch_id,            \
+            _In_ uint32_t object_count,                \
+            _In_ const uint32_t *attr_count,           \
+            _In_ const sai_attribute_t **attr_list,    \
+            _In_ sai_bulk_op_error_mode_t mode,        \
+            _Out_ sai_object_id_t *object_id,          \
+            _Out_ sai_status_t *object_statuses)       \
+{                                                      \
+    SWSS_LOG_ENTER();                                  \
+    return vs_sai->bulkCreate(                         \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT, \
+            switch_id,                                 \
+            object_count,                              \
+            attr_count,                                \
+            attr_list,                                 \
+            mode,                                      \
+            object_id,                                 \
+            object_statuses);                          \
 }
 
-#define VS_BULK_REMOVE(OT,fname)                    \
-    static sai_status_t vs_bulk_remove_ ## fname(   \
-            _In_ uint32_t object_count,             \
-            _In_ const sai_object_id_t *object_id,  \
-            _In_ sai_bulk_op_error_mode_t mode,     \
-            _Out_ sai_status_t *object_statuses)    \
-{                                                   \
-    SWSS_LOG_ENTER();                               \
-    return vs_sai->bulkRemove(                      \
-            SAI_OBJECT_TYPE_ ## OT,                 \
-            object_count,                           \
-            object_id,                              \
-            mode,                                   \
-            object_statuses);                       \
+#define VS_BULK_REMOVE(OT,fname)                       \
+    static sai_status_t vs_bulk_remove_ ## fname(      \
+            _In_ uint32_t object_count,                \
+            _In_ const sai_object_id_t *object_id,     \
+            _In_ sai_bulk_op_error_mode_t mode,        \
+            _Out_ sai_status_t *object_statuses)       \
+{                                                      \
+    SWSS_LOG_ENTER();                                  \
+    return vs_sai->bulkRemove(                         \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT, \
+            object_count,                              \
+            object_id,                                 \
+            mode,                                      \
+            object_statuses);                          \
 }
 
-#define VS_BULK_SET(OT,fname)                       \
-    static sai_status_t vs_bulk_set_ ## fname(      \
-            _In_ uint32_t object_count,             \
-            _In_ const sai_object_id_t *object_id,  \
-            _In_ const sai_attribute_t *attr_list,  \
-            _In_ sai_bulk_op_error_mode_t mode,     \
-            _Out_ sai_status_t *object_statuses)    \
-{                                                   \
-    SWSS_LOG_ENTER();                               \
-    return vs_sai->bulkSet(                         \
-            SAI_OBJECT_TYPE_ ## OT,                 \
-            object_count,                           \
-            object_id,                              \
-            attr_list,                              \
-            mode,                                   \
-            object_statuses);                       \
+#define VS_BULK_SET(OT,fname)                          \
+    static sai_status_t vs_bulk_set_ ## fname(         \
+            _In_ uint32_t object_count,                \
+            _In_ const sai_object_id_t *object_id,     \
+            _In_ const sai_attribute_t *attr_list,     \
+            _In_ sai_bulk_op_error_mode_t mode,        \
+            _Out_ sai_status_t *object_statuses)       \
+{                                                      \
+    SWSS_LOG_ENTER();                                  \
+    return vs_sai->bulkSet(                            \
+            (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT, \
+            object_count,                              \
+            object_id,                                 \
+            attr_list,                                 \
+            mode,                                      \
+            object_statuses);                          \
 }
 
 #define VS_BULK_GET(OT,fname)                       \
@@ -336,8 +336,11 @@ PRIVATE extern std::shared_ptr<sairedis::SaiInterface>      vs_sai;
 
 // BULK QUAD ENTRY
 
-#define VS_BULK_CREATE_ENTRY(OT,ot)                 \
-    static sai_status_t vs_bulk_create_ ## ot(      \
+#define VS_BULK_CREATE_ENTRY(OT,ot)   \
+    VS_BULK_CREATE_ENTRY_EX(OT,ot,ot)
+
+#define VS_BULK_CREATE_ENTRY_EX(OT,ot,fname)        \
+    static sai_status_t vs_bulk_create_ ## fname(   \
             _In_ uint32_t object_count,             \
             _In_ const sai_ ## ot ## _t *entry,     \
             _In_ const uint32_t *attr_count,        \
@@ -355,8 +358,11 @@ PRIVATE extern std::shared_ptr<sairedis::SaiInterface>      vs_sai;
             object_statuses);                       \
 }
 
-#define VS_BULK_REMOVE_ENTRY(OT,ot)                 \
-    static sai_status_t vs_bulk_remove_ ## ot(      \
+#define VS_BULK_REMOVE_ENTRY(OT,ot) \
+    VS_BULK_REMOVE_ENTRY_EX(OT, ot, ot)
+
+#define VS_BULK_REMOVE_ENTRY_EX(OT,ot,fname)        \
+    static sai_status_t vs_bulk_remove_ ## fname(   \
             _In_ uint32_t object_count,             \
             _In_ const sai_ ## ot ##_t *entry,      \
             _In_ sai_bulk_op_error_mode_t mode,     \


### PR DESCRIPTION
Replace manually written handlers for bulk API with macro-generated handlers.
The macro-generated handlers significantly reduce the number of lines of manually written code, prevent code duplication, and simplify adding new API support. The approach is the same a for regular quad API.
This is needed to prepare infrastructure for DASH API implementation.
