### PR TITLE
sonic-sairedis : Wred stats feature changes on Sai-redis and Syncd

### DIFF
--- a/lib/ClientSai.cpp
+++ b/lib/ClientSai.cpp
@@ -981,16 +981,6 @@ sai_status_t ClientSai::getStats(
     return waitForGetStatsResponse(number_of_counters, counters);
 }
 
-sai_status_t ClientSai::queryStatsCapability(
-        _In_ sai_object_id_t switchId,
-        _In_ sai_object_type_t objectType,
-        _Inout_ sai_stat_capability_list_t *stats_capability)
-{
-    SWSS_LOG_ENTER();
-
-    return SAI_STATUS_NOT_IMPLEMENTED;
-}
-
 sai_status_t ClientSai::waitForGetStatsResponse(
         _In_ uint32_t number_of_counters,
         _Out_ uint64_t *counters)
@@ -1014,6 +1004,109 @@ sai_status_t ClientSai::waitForGetStatsResponse(
         {
             counters[idx] = stoull(fvValue(values[idx]));
         }
+    }
+
+    return status;
+}
+
+sai_status_t ClientSai::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    auto switchIdStr = sai_serialize_object_id(switchId);
+    auto objectTypeStr = sai_serialize_object_type(objectType);
+
+    if (stats_capability == NULL)
+    {
+        SWSS_LOG_ERROR("Failed to find stats-capability: switch %s object type %s", switchIdStr.c_str(), objectTypeStr.c_str());
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    if (stats_capability && stats_capability->list && (stats_capability->count))
+    {
+        // clear input list, since we use serialize to transfer values
+        for (uint32_t idx = 0; idx < stats_capability->count; idx++)
+	{
+            stats_capability->list[idx].stat_enum = 0;
+            stats_capability->list[idx].stat_modes = 0;
+	}
+    }
+
+    const std::string listSize = std::to_string(stats_capability->count);
+
+    const std::vector<swss::FieldValueTuple> entry =
+    {
+        swss::FieldValueTuple("OBJECT_TYPE", objectTypeStr),
+	swss::FieldValueTuple("LIST_SIZE", listSize)
+    };
+
+    SWSS_LOG_DEBUG(
+            "Query arguments: switch %s, object type: %s, count: %s",
+            switchIdStr.c_str(),
+            objectTypeStr.c_str(),
+            listSize.c_str()
+    );
+
+    // This query will not put any data into the ASIC view, just into the
+    // message queue
+
+    m_communicationChannel->set(switchIdStr, entry, REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_QUERY);
+
+    return waitForQueryStatsCapabilityResponse(stats_capability);
+}
+
+sai_status_t ClientSai::waitForQueryStatsCapabilityResponse(
+        _Inout_ sai_stat_capability_list_t* stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    swss::KeyOpFieldsValuesTuple kco;
+
+    auto status = m_communicationChannel->wait(REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_RESPONSE, kco);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        const std::vector<swss::FieldValueTuple> &values = kfvFieldsValues(kco);
+
+        if (values.size() != 3)
+        {
+            SWSS_LOG_ERROR("Invalid response from syncd: expected 3 value, received %zu", values.size());
+
+            return SAI_STATUS_FAILURE;
+        }
+
+        const std::string &stat_enum_str = fvValue(values[0]);
+        const std::string &stat_modes_str = fvValue(values[1]);
+        const uint32_t num_capabilities = std::stoi(fvValue(values[2]));
+
+        SWSS_LOG_DEBUG("Received payload: stat_enums = '%s', stat_modes = '%s', count = %d",
+                       stat_enum_str.c_str(), stat_modes_str.c_str(), num_capabilities);
+
+        stats_capability->count = num_capabilities;
+
+        sai_deserialize_stats_capability_list(stats_capability, stat_enum_str, stat_modes_str);
+    }
+    else if (status ==  SAI_STATUS_BUFFER_OVERFLOW)
+    {
+        const std::vector<swss::FieldValueTuple> &values = kfvFieldsValues(kco);
+
+        if (values.size() != 1)
+        {
+            SWSS_LOG_ERROR("Invalid response from syncd: expected 1 value, received %zu", values.size());
+
+            return SAI_STATUS_FAILURE;
+        }
+
+        const uint32_t num_capabilities = std::stoi(fvValue(values[0]));
+
+        SWSS_LOG_DEBUG("Received payload: count = %u", num_capabilities);
+
+        stats_capability->count = num_capabilities;
     }
 
     return status;

--- a/lib/ClientSai.h
+++ b/lib/ClientSai.h
@@ -297,6 +297,9 @@ namespace sairedis
             sai_status_t waitForObjectTypeGetAvailabilityResponse(
                     _In_ uint64_t *count);
 
+            sai_status_t waitForQueryStatsCapabilityResponse(
+                    _Inout_ sai_stat_capability_list_t* stats_capability);
+
         private:
 
             void handleNotification(

--- a/lib/ClientServerSai.cpp
+++ b/lib/ClientServerSai.cpp
@@ -256,7 +256,10 @@ sai_status_t ClientServerSai::queryStatsCapability(
     SWSS_LOG_ENTER();
     REDIS_CHECK_API_INITIALIZED();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return m_sai->queryStatsCapability(
+            switchId,
+            objectType,
+            stats_capability);
 }
 
 sai_status_t ClientServerSai::getStatsExt(

--- a/lib/Recorder.h
+++ b/lib/Recorder.h
@@ -298,6 +298,16 @@ namespace sairedis
                     _In_ sai_attr_id_t attrId,
                     _In_ const sai_s32_list_t* enumValuesCapability);
 
+            void recordQueryStatsCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_capability_list_t* stats_capability);
+
+            void recordQueryStatsCapabilityResponse(
+                    _In_ sai_status_t status,
+                    _In_ sai_object_type_t objectType,
+                    _In_ const sai_stat_capability_list_t *stats_capability);
+
             // TODO move to private
             void recordQueryAttributeCapability(
                     _In_ const std::string& key,
@@ -322,6 +332,14 @@ namespace sairedis
             void recordObjectTypeGetAvailabilityResponse(
                     _In_ sai_status_t status,
                     _In_ const std::vector<swss::FieldValueTuple>& arguments);
+
+            void recordQueryStatsCapability(
+                    _In_ const std::string& key,
+                    _In_ const std::vector<swss::FieldValueTuple>& arguments);
+
+            void recordQueryStatsCapabilityResponse(
+                    _In_ sai_status_t status,
+                    _In_ const std::string& arguments);
 
         public: // SAI notifications
 

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -1356,16 +1356,6 @@ sai_status_t RedisRemoteSaiInterface::getStats(
     return waitForGetStatsResponse(number_of_counters, counters);
 }
 
-sai_status_t RedisRemoteSaiInterface::queryStatsCapability(
-        _In_ sai_object_id_t switchId,
-        _In_ sai_object_type_t objectType,
-        _Inout_ sai_stat_capability_list_t *stats_capability)
-{
-    SWSS_LOG_ENTER();
-
-    return SAI_STATUS_NOT_IMPLEMENTED;
-}
-
 sai_status_t RedisRemoteSaiInterface::waitForGetStatsResponse(
         _In_ uint32_t number_of_counters,
         _Out_ uint64_t *counters)
@@ -1389,6 +1379,113 @@ sai_status_t RedisRemoteSaiInterface::waitForGetStatsResponse(
         {
             counters[idx] = stoull(fvValue(values[idx]));
         }
+    }
+
+    return status;
+}
+
+sai_status_t RedisRemoteSaiInterface::queryStatsCapability(
+        _In_ sai_object_id_t switchId,
+        _In_ sai_object_type_t objectType,
+        _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    auto switchIdStr = sai_serialize_object_id(switchId);
+    auto objectTypeStr = sai_serialize_object_type(objectType);
+
+    if (stats_capability == NULL)
+    {
+        SWSS_LOG_ERROR("Failed to find stats-capability: switch %s, object type %s", switchIdStr.c_str(), objectTypeStr.c_str());
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    if (stats_capability && stats_capability->list && (stats_capability->count))
+    {
+        // clear input list, since we use serialize to transfer the values
+        for (uint32_t idx = 0; idx < stats_capability->count; idx++)
+	{
+            stats_capability->list[idx].stat_enum = 0;
+            stats_capability->list[idx].stat_modes = 0;
+	}
+    }
+
+    const std::string listSize = std::to_string(stats_capability->count);
+
+    const std::vector<swss::FieldValueTuple> entry =
+    {
+        swss::FieldValueTuple("OBJECT_TYPE", objectTypeStr),
+	swss::FieldValueTuple("LIST_SIZE", listSize)
+    };
+
+    SWSS_LOG_DEBUG(
+            "Query arguments: switch %s, object type: %s, count: %s",
+            switchIdStr.c_str(),
+            objectTypeStr.c_str(),
+            listSize.c_str()
+    );
+
+    // This query will not put any data into the ASIC view, just into the
+    // message queue
+
+    m_recorder->recordQueryStatsCapability(switchId, objectType, stats_capability);
+
+    m_communicationChannel->set(switchIdStr, entry, REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_QUERY);
+
+    auto status = waitForQueryStatsCapabilityResponse(stats_capability);
+
+    m_recorder->recordQueryStatsCapabilityResponse(status, objectType, stats_capability);
+
+    return status;
+}
+
+sai_status_t RedisRemoteSaiInterface::waitForQueryStatsCapabilityResponse(
+        _Inout_ sai_stat_capability_list_t* stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    swss::KeyOpFieldsValuesTuple kco;
+
+    auto status = m_communicationChannel->wait(REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_RESPONSE, kco);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        const std::vector<swss::FieldValueTuple> &values = kfvFieldsValues(kco);
+
+        if (values.size() != 3)
+        {
+            SWSS_LOG_ERROR("Invalid response from syncd: expected 3 value, received %zu", values.size());
+
+            return SAI_STATUS_FAILURE;
+        }
+
+        const std::string &stat_enum_str = fvValue(values[0]);
+        const std::string &stat_modes_str = fvValue(values[1]);
+        const uint32_t num_capabilities = std::stoi(fvValue(values[2]));
+
+        SWSS_LOG_DEBUG("Received payload: stat_enums = '%s', stat_modes = '%s', count = %d",
+                       stat_enum_str.c_str(), stat_modes_str.c_str(), num_capabilities);
+
+        stats_capability->count = num_capabilities;
+
+        sai_deserialize_stats_capability_list(stats_capability, stat_enum_str, stat_modes_str);
+    }
+    else if (status ==  SAI_STATUS_BUFFER_OVERFLOW)
+    {
+        const std::vector<swss::FieldValueTuple> &values = kfvFieldsValues(kco);
+
+        if (values.size() != 1)
+        {
+            SWSS_LOG_ERROR("Invalid response from syncd: expected 1 value, received %zu", values.size());
+
+            return SAI_STATUS_FAILURE;
+        }
+
+        const uint32_t num_capabilities = std::stoi(fvValue(values[0]));
+
+        SWSS_LOG_DEBUG("Received payload: count = %u", num_capabilities);
+
+        stats_capability->count = num_capabilities;
     }
 
     return status;

--- a/lib/RedisRemoteSaiInterface.h
+++ b/lib/RedisRemoteSaiInterface.h
@@ -340,6 +340,9 @@ namespace sairedis
             sai_status_t waitForObjectTypeGetAvailabilityResponse(
                     _In_ uint64_t *count);
 
+            sai_status_t waitForQueryStatsCapabilityResponse(
+                    _Inout_ sai_stat_capability_list_t* stats_capability);
+
         private: // notify syncd response
 
             sai_status_t waitForNotifySyncdResponse();

--- a/lib/Sai.cpp
+++ b/lib/Sai.cpp
@@ -362,9 +362,15 @@ sai_status_t Sai::queryStatsCapability(
         _In_ sai_object_type_t objectType,
         _Inout_ sai_stat_capability_list_t *stats_capability)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+    REDIS_CHECK_CONTEXT(switchId);
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return context->m_meta->queryStatsCapability(
+            switchId,
+            objectType,
+            stats_capability);
 }
 
 sai_status_t Sai::getStatsExt(

--- a/lib/ServerSai.cpp
+++ b/lib/ServerSai.cpp
@@ -274,9 +274,14 @@ sai_status_t ServerSai::queryStatsCapability(
         _In_ sai_object_type_t objectType,
         _Inout_ sai_stat_capability_list_t *stats_capability)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return m_sai->queryStatsCapability(
+            switchId,
+            objectType,
+            stats_capability);
 }
 
 sai_status_t ServerSai::getStatsExt(
@@ -776,6 +781,9 @@ sai_status_t ServerSai::processSingleEvent(
 
     if (op == REDIS_ASIC_STATE_COMMAND_OBJECT_TYPE_GET_AVAILABILITY_QUERY)
         return processObjectTypeGetAvailabilityQuery(kco);
+
+    if (op == REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_QUERY)
+        return processStatsCapabilityQuery(kco);
 
     SWSS_LOG_THROW("event op '%s' is not implemented, FIXME", op.c_str());
 }
@@ -2071,6 +2079,87 @@ sai_status_t ServerSai::processObjectTypeGetAvailabilityQuery(
     }
 
     m_selectableChannel->set(sai_serialize_status(status), entry, REDIS_ASIC_STATE_COMMAND_OBJECT_TYPE_GET_AVAILABILITY_RESPONSE);
+
+    return status;
+}
+
+sai_status_t ServerSai::processStatsCapabilityQuery(
+        _In_ const swss::KeyOpFieldsValuesTuple &kco)
+{
+    SWSS_LOG_ENTER();
+
+    auto& strSwitchOid = kfvKey(kco);
+
+    sai_object_id_t switchOid;
+    sai_deserialize_object_id(strSwitchOid, switchOid);
+
+    auto& values = kfvFieldsValues(kco);
+
+    if (values.size() != 2)
+    {
+        SWSS_LOG_ERROR("Invalid input: expected 2 arguments, received %zu", values.size());
+
+        m_selectableChannel->set(sai_serialize_status(SAI_STATUS_INVALID_PARAMETER), {}, REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_RESPONSE);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    sai_object_type_t objectType;
+    sai_deserialize_object_type(fvValue(values[0]), objectType);
+
+    uint32_t list_size = std::stoi(fvValue(values[1]));
+
+    std::vector<sai_stat_capability_t> stat_capability_list(list_size);
+
+    sai_stat_capability_list_t statCapList;
+
+    statCapList.count = list_size;
+    statCapList.list = stat_capability_list.data();
+
+    sai_status_t status = m_sai->queryStatsCapability(switchOid, objectType, &statCapList);
+
+    std::vector<swss::FieldValueTuple> entry;
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        std::vector<std::string> vec_stat_enum;
+        std::vector<std::string> vec_stat_modes;
+
+        for (uint32_t it = 0; it < statCapList.count; it++)
+        {
+                vec_stat_enum.push_back(std::to_string(statCapList.list[it].stat_enum));
+                vec_stat_modes.push_back(std::to_string(statCapList.list[it].stat_modes));
+        }
+
+        std::ostringstream join_stat_enum;
+        std::copy(vec_stat_enum.begin(), vec_stat_enum.end(), std::ostream_iterator<std::string>(join_stat_enum, ","));
+        auto strCapEnum = join_stat_enum.str();
+
+        std::ostringstream join_stat_modes;
+        std::copy(vec_stat_modes.begin(), vec_stat_modes.end(), std::ostream_iterator<std::string>(join_stat_modes, ","));
+        auto strCapModes = join_stat_modes.str();
+
+        entry =
+        {
+            swss::FieldValueTuple("STAT_ENUM", strCapEnum),
+            swss::FieldValueTuple("STAT_MODES", strCapModes),
+            swss::FieldValueTuple("STAT_COUNT", std::to_string(statCapList.count))
+        };
+
+        SWSS_LOG_DEBUG("Sending response: stat_enums = '%s', stat_modes = '%s', count = %d",
+                        strCapEnum.c_str(), strCapModes.c_str(), statCapList.count);
+    }
+    else if (status == SAI_STATUS_BUFFER_OVERFLOW)
+    {
+        entry =
+        {
+            swss::FieldValueTuple("STAT_COUNT", std::to_string(statCapList.count))
+        };
+
+        SWSS_LOG_DEBUG("Sending response: count = %u", statCapList.count);
+    }
+
+    m_selectableChannel->set(sai_serialize_status(status), entry, REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_RESPONSE);
 
     return status;
 }

--- a/lib/ServerSai.h
+++ b/lib/ServerSai.h
@@ -304,12 +304,19 @@ namespace sairedis
 
             sai_service_method_table_t m_service_method_table;
 
-            std::shared_ptr<SaiInterface> m_sai;
 
             std::shared_ptr<std::thread> m_serverThread;
 
-            std::shared_ptr<SelectableChannel> m_selectableChannel;
 
             swss::SelectableEvent m_serverThreadThreadShouldEndEvent;
+
+        protected:
+
+            sai_status_t processStatsCapabilityQuery(
+                    _In_ const swss::KeyOpFieldsValuesTuple &kco);
+
+            std::shared_ptr<SelectableChannel> m_selectableChannel;
+
+            std::shared_ptr<SaiInterface> m_sai;
     };
 }

--- a/lib/sairediscommon.h
+++ b/lib/sairediscommon.h
@@ -57,6 +57,10 @@
 #define REDIS_FLEX_COUNTER_COMMAND_SET_GROUP        "set_counter_group"
 #define REDIS_FLEX_COUNTER_COMMAND_DEL_GROUP        "del_counter_group"
 #define REDIS_FLEX_COUNTER_COMMAND_RESPONSE         "counter_response"
+
+#define REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_QUERY      "stats_capability_query"
+#define REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_RESPONSE   "stats_capability_response"
+
 /**
  * @brief Redis virtual object id counter key name.
  *

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -464,10 +464,6 @@ namespace saimeta
                     _Out_ uint64_t *counters,
                     _In_ sai_stats_mode_t mode);
 
-            sai_status_t meta_validate_query_stats_capability(
-                    _In_ sai_object_type_t object_type,
-                    _In_ sai_object_id_t object_id);
-
         private: // validate OID
 
             sai_status_t meta_sai_validate_oid(

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -294,6 +294,11 @@ std::string sai_serialize_twamp_session_stat(
 std::string sai_serialize_poe_port_power_consumption(
         _In_ const sai_poe_port_power_consumption_t& pppc);
 
+std::string sai_serialize_stats_capability_list(
+        _In_ const sai_stat_capability_list_t& stat_capability_list,
+        _In_ const sai_enum_metadata_t* meta,
+        _In_ bool countOnly);
+
 // serialize notifications
 
 std::string sai_serialize_fdb_event_ntf(
@@ -652,3 +657,8 @@ void sai_deserialize_redis_link_event_damping_algorithm(
 void sai_deserialize_redis_link_event_damping_aied_config(
         _In_ const std::string& s,
          _Out_ sai_redis_link_event_damping_algo_aied_config_t& value);
+
+void sai_deserialize_stats_capability_list(
+        _Inout_ sai_stat_capability_list_t *stats_capability,
+        _In_    const std::string& stat_enum_str,
+        _In_    const std::string& stat_modes_str);

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -417,6 +417,9 @@ sai_status_t Syncd::processSingleEvent(
     if (op == REDIS_FLEX_COUNTER_COMMAND_DEL_GROUP)
         return processFlexCounterGroupEvent(key, DEL_COMMAND, kfvFieldsValues(kco));
 
+    if (op == REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_QUERY)
+        return processStatsCapabilityQuery(kco);
+
     SWSS_LOG_THROW("event op '%s' is not implemented, FIXME", op.c_str());
 }
 
@@ -598,6 +601,86 @@ sai_status_t Syncd::processObjectTypeGetAvailabilityQuery(
     }
 
     m_selectableChannel->set(sai_serialize_status(status), entry, REDIS_ASIC_STATE_COMMAND_OBJECT_TYPE_GET_AVAILABILITY_RESPONSE);
+
+    return status;
+}
+
+sai_status_t Syncd::processStatsCapabilityQuery(
+        _In_ const swss::KeyOpFieldsValuesTuple &kco)
+{
+    SWSS_LOG_ENTER();
+
+    auto& strSwitchVid = kfvKey(kco);
+
+    sai_object_id_t switchVid;
+    sai_deserialize_object_id(strSwitchVid, switchVid);
+
+    sai_object_id_t switchRid = m_translator->translateVidToRid(switchVid);
+
+    auto& values = kfvFieldsValues(kco);
+
+    if (values.size() != 2)
+    {
+        SWSS_LOG_ERROR("Invalid input: expected 2 arguments, received %zu", values.size());
+
+        m_selectableChannel->set(sai_serialize_status(SAI_STATUS_INVALID_PARAMETER), {}, REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_RESPONSE);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    sai_object_type_t objectType;
+    sai_deserialize_object_type(fvValue(values[0]), objectType);
+
+    uint32_t list_size = std::stoi(fvValue(values[1]));
+
+    std::vector<sai_stat_capability_t> stat_capability_list(list_size);
+
+    sai_stat_capability_list_t statCapList;
+
+    statCapList.count = list_size;
+    statCapList.list = stat_capability_list.data();
+
+    sai_status_t status = m_vendorSai->queryStatsCapability(switchRid, objectType, &statCapList);
+
+    std::vector<swss::FieldValueTuple> entry;
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        std::vector<std::string> vec_stat_enum;
+        std::vector<std::string> vec_stat_modes;
+
+	for (uint32_t it = 0; it < statCapList.count; it++)
+	{
+		vec_stat_enum.push_back(std::to_string(statCapList.list[it].stat_enum));
+		vec_stat_modes.push_back(std::to_string(statCapList.list[it].stat_modes));
+	}
+
+        std::ostringstream join_stat_enum;
+        std::copy(vec_stat_enum.begin(), vec_stat_enum.end(), std::ostream_iterator<std::string>(join_stat_enum, ","));
+        auto strCapEnum = join_stat_enum.str();
+
+        std::ostringstream join_stat_modes;
+        std::copy(vec_stat_modes.begin(), vec_stat_modes.end(), std::ostream_iterator<std::string>(join_stat_modes, ","));
+        auto strCapModes = join_stat_modes.str();
+
+        entry =
+        {
+            swss::FieldValueTuple("STAT_ENUM", strCapEnum),
+            swss::FieldValueTuple("STAT_MODES", strCapModes),
+            swss::FieldValueTuple("STAT_COUNT", std::to_string(statCapList.count))
+        };
+
+        SWSS_LOG_DEBUG("Sending response: stat_enums = '%s', stat_modes = '%s', count = %d",
+			strCapEnum.c_str(), strCapModes.c_str(), statCapList.count);
+    }
+    else if (status == SAI_STATUS_BUFFER_OVERFLOW)
+    {
+        entry = { swss::FieldValueTuple("STAT_COUNT", std::to_string(statCapList.count)) };
+
+        SWSS_LOG_DEBUG("Sending response: count = %u", statCapList.count);
+    }
+
+    m_selectableChannel->set(sai_serialize_status(status), entry, REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_RESPONSE);
 
     return status;
 }

--- a/syncd/Syncd.h
+++ b/syncd/Syncd.h
@@ -136,6 +136,9 @@ namespace syncd
             sai_status_t processObjectTypeGetAvailabilityQuery(
                     _In_ const swss::KeyOpFieldsValuesTuple &kco);
 
+            sai_status_t processStatsCapabilityQuery(
+                    _In_ const swss::KeyOpFieldsValuesTuple &kco);
+
             sai_status_t processFdbFlush(
                     _In_ const swss::KeyOpFieldsValuesTuple &kco);
 

--- a/tests/TestClient.cpp
+++ b/tests/TestClient.cpp
@@ -362,6 +362,33 @@ void TestClient::test_query_api()
                 NULL,
                 &count));
 
+    /* Test queue stats capability get */
+    sai_stat_capability_list_t queue_stats_capability;
+
+    queue_stats_capability.count = 1;
+    queue_stats_capability.list = nullptr;
+
+    SWSS_LOG_NOTICE(" * sai_query_stats_capability");
+
+    auto rc = sai_query_stats_capability(
+                m_switch_id,
+                SAI_OBJECT_TYPE_QUEUE,
+                &queue_stats_capability);
+    ASSERT_TRUE(rc == SAI_STATUS_BUFFER_OVERFLOW);
+
+    sai_stat_capability_t stat_initializer;
+    stat_initializer.stat_enum = 0;
+    stat_initializer.stat_modes = 0;
+    std::vector<sai_stat_capability_t> qstat_cap_list(queue_stats_capability.count, stat_initializer);
+    queue_stats_capability.list = qstat_cap_list.data();
+
+    SWSS_LOG_NOTICE(" * sai_query_stats_capability");
+
+    ASSERT_SUCCESS(sai_query_stats_capability(
+                m_switch_id,
+                SAI_OBJECT_TYPE_QUEUE,
+                &queue_stats_capability));
+
     teardown();
 }
 

--- a/unittest/lib/Makefile.am
+++ b/unittest/lib/Makefile.am
@@ -2,7 +2,7 @@ AM_CXXFLAGS = $(SAIINC) -I$(top_srcdir)/meta -I$(top_srcdir)/lib
 
 bin_PROGRAMS = tests
 
-LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
+LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main -lgmock
 
 tests_SOURCES = \
 				main.cpp \
@@ -26,7 +26,8 @@ tests_SOURCES = \
 				TestClientSai.cpp \
 				TestRedisRemoteSaiInterface.cpp \
 				TestServerSai.cpp \
-				TestSai.cpp
+				TestSai.cpp \
+				MockSaiInterface.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/lib/libSaiRedis.a -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)

--- a/unittest/lib/MockSaiInterface.cpp
+++ b/unittest/lib/MockSaiInterface.cpp
@@ -1,0 +1,26 @@
+#include "MockSaiInterface.h"
+#include "swss/logger.h"
+
+MockSaiInterface::MockSaiInterface()
+{
+    SWSS_LOG_ENTER();
+}
+
+MockSaiInterface::~MockSaiInterface()
+{
+    SWSS_LOG_ENTER();
+}
+
+sai_status_t MockSaiInterface::apiInitialize(
+    _In_ uint64_t flags,
+    _In_ const sai_service_method_table_t *service_method_table)
+{
+    SWSS_LOG_ENTER();
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t MockSaiInterface::apiUninitialize()
+{
+    SWSS_LOG_ENTER();
+    return SAI_STATUS_SUCCESS;
+}

--- a/unittest/lib/MockSaiInterface.h
+++ b/unittest/lib/MockSaiInterface.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <functional>
+#include "DummySaiInterface.h"
+#include <gmock/gmock.h>
+
+class MockSaiInterface: public saimeta::DummySaiInterface
+{
+    public:
+
+        MockSaiInterface();
+
+        virtual ~MockSaiInterface();
+
+    public:
+
+        virtual sai_status_t apiInitialize(
+                _In_ uint64_t flags,
+                _In_ const sai_service_method_table_t *service_method_table) override;
+        virtual sai_status_t apiUninitialize(void) override;
+public:
+    MOCK_METHOD(sai_status_t, queryStatsCapability,
+        (sai_object_id_t switchOid, sai_object_type_t objectType, sai_stat_capability_list_t* statCapList),
+        (override));
+};
+

--- a/unittest/lib/TestClientServerSai.cpp
+++ b/unittest/lib/TestClientServerSai.cpp
@@ -94,6 +94,25 @@ TEST(ClientServerSai, switchIdQuery)
     EXPECT_EQ(SAI_NULL_OBJECT_ID, css->switchIdQuery(0x1111111111111111L));
 }
 
+TEST(ClientServerSai, queryStatsCapability)
+{
+    auto css = std::make_shared<ClientServerSai>();
+
+    sai_stat_capability_list_t queue_stats_capability;
+    sai_stat_capability_t stat_initializer;
+    stat_initializer.stat_enum = 0;
+    stat_initializer.stat_modes = 0;
+    std::vector<sai_stat_capability_t> qstat_cap_list(2, stat_initializer);
+    queue_stats_capability.count = 2;
+    queue_stats_capability.list = qstat_cap_list.data();
+    queue_stats_capability.list[0].stat_enum = SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS;
+    queue_stats_capability.list[0].stat_modes = SAI_STATS_MODE_READ;
+    queue_stats_capability.list[1].stat_enum = SAI_QUEUE_STAT_PACKETS;
+    queue_stats_capability.list[1].stat_modes = SAI_STATS_MODE_READ;
+
+    EXPECT_EQ(SAI_STATUS_FAILURE, css->queryStatsCapability(SAI_NULL_OBJECT_ID, SAI_OBJECT_TYPE_QUEUE, &queue_stats_capability));
+}
+
 TEST(ClientServerSai, logSet)
 {
     auto css = std::make_shared<ClientServerSai>();

--- a/unittest/lib/TestRedisRemoteSaiInterface.cpp
+++ b/unittest/lib/TestRedisRemoteSaiInterface.cpp
@@ -28,3 +28,16 @@ TEST(RedisRemoteSaiInterface, bulkGet)
                 statuses));
 }
 
+TEST(RedisRemoteSaiInterface, queryStatsCapabilityNegative)
+{
+    auto ctx = ContextConfigContainer::loadFromFile("foo");
+    auto rec = std::make_shared<Recorder>();
+
+    RedisRemoteSaiInterface sai(ctx->get(0), nullptr, rec);
+
+    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER,
+              sai.queryStatsCapability(0,
+                SAI_OBJECT_TYPE_NULL,
+                0));
+}
+

--- a/unittest/lib/TestServerSai.cpp
+++ b/unittest/lib/TestServerSai.cpp
@@ -1,8 +1,24 @@
 #include "ServerSai.h"
 
-#include <gtest/gtest.h>
+#include "sai_serialize.h"
+#include "vslib/ContextConfigContainer.h"
+#include "vslib/VirtualSwitchSaiInterface.h"
+#include "vslib/Sai.h"
+#include "lib/Sai.h"
 
+#include "swss/dbconnector.h"
+
+#include "sairediscommon.h"
+
+#include "MockSaiInterface.h"
+#include "SelectableChannel.h"
+#include "swss/dbconnector.h"
+#include "swss/redisreply.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <memory>
+
 
 using namespace sairedis;
 
@@ -50,3 +66,94 @@ TEST(ServerSai, bulkGet)
                 statuses));
 }
 
+using namespace ::testing;
+
+#ifdef MOCK_METHOD
+class MockSelectableChannel : public sairedis::SelectableChannel {
+public:
+    MOCK_METHOD(bool, empty, (), (override));
+    MOCK_METHOD(void, pop, (swss::KeyOpFieldsValuesTuple& kco, bool initViewMode), (override));
+    MOCK_METHOD(void, set, (const std::string& key, const std::vector<swss::FieldValueTuple>& values, const std::string& op), (override));
+    MOCK_METHOD(int, getFd, (), (override));
+    MOCK_METHOD(uint64_t, readData, (), (override));
+};
+
+class TestableServerSai : public ServerSai
+{
+public:
+
+    using ServerSai::processStatsCapabilityQuery;
+
+    void setSaiInterface(std::shared_ptr<SaiInterface> saiInterface)
+    {
+        SWSS_LOG_ENTER();
+        m_sai = std::move(saiInterface);
+    }
+
+    void setSelectableChannel(std::shared_ptr<SelectableChannel> selectableChannel)
+    {
+        SWSS_LOG_ENTER();
+        m_selectableChannel = std::move(selectableChannel);
+    }
+};
+
+class ServerSaiTest : public ::testing::Test
+{
+protected:
+    TestableServerSai serverSai;
+    std::shared_ptr<MockSaiInterface> mockSai;
+    std::shared_ptr<MockSelectableChannel> mockSelectableChannel;
+
+    void SetUp() override
+    {
+        mockSai = std::make_shared<MockSaiInterface>();
+        mockSelectableChannel = std::make_shared<MockSelectableChannel>();
+
+        serverSai.setSaiInterface(mockSai);
+        serverSai.setSelectableChannel(mockSelectableChannel);
+
+    }
+
+    void TearDown() override
+    {
+        mockSai.reset();
+        mockSelectableChannel.reset();
+    }
+};
+
+TEST_F(ServerSaiTest, ProcessStatsCapabilityQuery_ValidInputSuccess)
+{
+    swss::KeyOpFieldsValuesTuple kco(
+        std::string("oid:0x21000000000000"),
+        std::string("SET"),
+        std::vector<std::pair<std::string, std::string>>{
+            {std::string("type"), std::string("SAI_OBJECT_TYPE_PORT")},
+            {std::string("list_size"), std::string("1")}
+        }
+    );
+
+    sai_stat_capability_t statList[2] = {
+        {SAI_PORT_STAT_IF_IN_UCAST_PKTS, SAI_STATS_MODE_READ}
+    };
+
+    sai_stat_capability_list_t statCapList;
+    statCapList.count = 1;
+    statCapList.list = statList;
+
+    EXPECT_CALL(*mockSai, queryStatsCapability(_, _, _))
+        .WillRepeatedly(DoAll(SetArgPointee<2>(statCapList), Return(SAI_STATUS_SUCCESS)));
+
+    EXPECT_CALL(*mockSelectableChannel, set(
+        StrEq("SAI_STATUS_SUCCESS"),
+        AllOf(
+            Contains(swss::FieldValueTuple("STAT_ENUM", "1,")),
+            Contains(swss::FieldValueTuple("STAT_MODES", "1,")),
+            Contains(swss::FieldValueTuple("STAT_COUNT", "1"))
+        ),
+        StrEq("stats_capability_response")
+    )).Times(1);
+
+    sai_status_t status = serverSai.processStatsCapabilityQuery(kco);
+    EXPECT_EQ(status, SAI_STATUS_SUCCESS);
+}
+#endif

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -940,6 +940,36 @@ TEST(Meta, queryAttributeEnumValuesCapability)
     EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, m.queryAttributeEnumValuesCapability(switchId, SAI_OBJECT_TYPE_SWITCH, 10000, &list));
 }
 
+TEST(Meta, queryStatsCapability)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchId = 0;
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, &attr));
+
+    sai_stat_capability_list_t queue_stats_capability;
+    sai_stat_capability_t stat_initializer;
+    stat_initializer.stat_enum = 0;
+    stat_initializer.stat_modes = 0;
+    std::vector<sai_stat_capability_t> qstat_cap_list(20, stat_initializer);
+    queue_stats_capability.count = 15;
+    queue_stats_capability.list = qstat_cap_list.data();
+
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.queryStatsCapability(switchId, SAI_OBJECT_TYPE_QUEUE, &queue_stats_capability));
+
+    queue_stats_capability.list = nullptr;
+
+    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, m.queryStatsCapability(switchId, SAI_OBJECT_TYPE_QUEUE, &queue_stats_capability));
+
+}
+
 TEST(Meta, meta_validate_stats)
 {
     MockMeta m(std::make_shared<MetaTestSaiInterface>());

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -1358,3 +1358,72 @@ TEST(SaiSerialize, sai_serialize_prefix_compression_entry)
 
     sai_deserialize_prefix_compression_entry(s, e);
 }
+
+TEST(SaiSerialize, serialize_stat_capability_list)
+{
+    SWSS_LOG_ENTER();
+
+    extern const sai_enum_metadata_t sai_metadata_enum_sai_stats_mode_t;
+    sai_stat_capability_list_t queue_stats_capability;
+    sai_stat_capability_t stat_initializer;
+    stat_initializer.stat_enum = 0;
+    stat_initializer.stat_modes = 0;
+    std::vector<sai_stat_capability_t> qstat_cap_list(2, stat_initializer);
+    queue_stats_capability.count = 2;
+    queue_stats_capability.list = qstat_cap_list.data();
+    queue_stats_capability.list[0].stat_enum = SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS;
+    queue_stats_capability.list[0].stat_modes = SAI_STATS_MODE_READ;
+    queue_stats_capability.list[1].stat_enum = SAI_QUEUE_STAT_PACKETS;
+    queue_stats_capability.list[1].stat_modes = SAI_STATS_MODE_READ;
+
+    std::string capab_count = sai_serialize_stats_capability_list(queue_stats_capability, &sai_metadata_enum_sai_stats_mode_t, true);
+    std::string capab_str = sai_serialize_stats_capability_list(queue_stats_capability, &sai_metadata_enum_sai_stats_mode_t, false);
+
+    std::string exp_count_str = "{\"count\":2,\"list\":null}";
+    EXPECT_EQ(capab_count, exp_count_str);
+
+    std::string exp_capab_str = "{\"count\":2,\"list\":[{\"stat_enum\":\"34\",\"stat_modes\":[\"SAI_STATS_MODE_READ\"]},{\"stat_enum\":\"0\",\"stat_modes\":[\"SAI_STATS_MODE_READ\"]}]}";
+    EXPECT_EQ(capab_str, exp_capab_str);
+
+    std::vector<std::string> vec_stat_enum;
+    std::vector<std::string> vec_stat_modes;
+
+    for (uint32_t it = 0; it < queue_stats_capability.count; it++)
+    {
+        vec_stat_enum.push_back(std::to_string(queue_stats_capability.list[it].stat_enum));
+        vec_stat_modes.push_back(std::to_string(queue_stats_capability.list[it].stat_modes));
+    }
+
+    std::ostringstream join_stat_enum;
+    std::copy(vec_stat_enum.begin(), vec_stat_enum.end(), std::ostream_iterator<std::string>(join_stat_enum, ","));
+    auto strCapEnum = join_stat_enum.str();
+
+    std::ostringstream join_stat_modes;
+    std::copy(vec_stat_modes.begin(), vec_stat_modes.end(), std::ostream_iterator<std::string>(join_stat_modes, ","));
+    auto strCapModes = join_stat_modes.str();
+
+    sai_stat_capability_list_t stats_capability;
+    std::vector<sai_stat_capability_t> stat_cap_list(queue_stats_capability.count, stat_initializer);
+    stats_capability.count = queue_stats_capability.count;
+    stats_capability.list = stat_cap_list.data();
+
+    // deserialize
+    EXPECT_THROW(sai_deserialize_stats_capability_list(NULL, strCapEnum, strCapModes), std::runtime_error);
+
+    sai_deserialize_stats_capability_list(&stats_capability, strCapEnum, strCapModes);
+
+    EXPECT_EQ(stats_capability.count, queue_stats_capability.count);
+    EXPECT_EQ(stats_capability.list[0].stat_modes, SAI_STATS_MODE_READ);
+    EXPECT_EQ(stats_capability.list[1].stat_modes, SAI_STATS_MODE_READ);
+    int is_expected_enum = false;
+
+    if ((stats_capability.list[0].stat_enum == SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS)||(stats_capability.list[1].stat_enum == SAI_QUEUE_STAT_PACKETS))
+    {
+        is_expected_enum = true;
+    }
+    if ((stats_capability.list[1].stat_enum == SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS)||(stats_capability.list[0].stat_enum == SAI_QUEUE_STAT_PACKETS))
+    {
+        is_expected_enum = true;
+    }
+    EXPECT_EQ(is_expected_enum, true);
+}

--- a/unittest/syncd/MockableSaiInterface.cpp
+++ b/unittest/syncd/MockableSaiInterface.cpp
@@ -180,7 +180,7 @@ sai_status_t MockableSaiInterface::queryStatsCapability(
         return mock_queryStatsCapability(switch_id, object_type, stats_capability);
     }
 
-    return SAI_STATUS_NOT_SUPPORTED;
+    return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t MockableSaiInterface::getStatsExt(

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -476,7 +476,9 @@ TEST(FlexCounter, addRemoveCounterPlugin)
                             RIF_PLUGIN_FIELD,
                             BUFFER_POOL_PLUGIN_FIELD,
                             TUNNEL_PLUGIN_FIELD,
-                            FLOW_COUNTER_PLUGIN_FIELD};
+                            FLOW_COUNTER_PLUGIN_FIELD,
+                            WRED_QUEUE_PLUGIN_FIELD,
+                            WRED_PORT_PLUGIN_FIELD};
     for (auto &field : fields)
     {
         testAddRemovePlugin(field);
@@ -564,7 +566,7 @@ TEST(FlexCounter, addRemoveCounterForPort)
     fc.addCounter(counterVid, counterRid, values);
     EXPECT_EQ(fc.isEmpty(), false);
 
-    usleep(1000*1000);
+    usleep(1000*2000);
     countersTable.hget(expectedKey, "SAI_PORT_STAT_IF_IN_OCTETS", value);
     EXPECT_EQ(value, "100");
     countersTable.hget(expectedKey, "SAI_PORT_STAT_IF_IN_ERRORS", value);

--- a/unittest/syncd/TestSyncd.cpp
+++ b/unittest/syncd/TestSyncd.cpp
@@ -1,4 +1,5 @@
 #include "Syncd.h"
+#include "sai_serialize.h"
 #include "RequestShutdown.h"
 #include "vslib/ContextConfigContainer.h"
 #include "vslib/VirtualSwitchSaiInterface.h"
@@ -256,6 +257,42 @@ TEST_F(SyncdTest, processNotifySyncd)
     EXPECT_CALL(consumer, pop(testing::_, testing::_)).WillOnce(testing::Invoke([](swss::KeyOpFieldsValuesTuple& kco, bool initViewMode) {
         kfvKey(kco) = SYNCD_APPLY_VIEW;
         kfvOp(kco) = REDIS_ASIC_STATE_COMMAND_NOTIFY;
+    }));
+    syncd_object.processEvent(consumer);
+}
+TEST_F(SyncdTest, processStatsCapabilityQuery)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto opt = std::make_shared<syncd::CommandLineOptions>();
+    opt->m_enableTempView = true;
+    opt->m_startType = SAI_START_TYPE_FASTFAST_BOOT;
+    syncd::Syncd syncd_object(sai, opt, false);
+
+    auto translator = syncd_object.m_translator;
+    translator->insertRidAndVid(0x11000000000000, 0x21000000000000);
+
+    MockSelectableChannel consumer;
+    EXPECT_CALL(consumer, empty()).WillOnce(testing::Return(true));
+    EXPECT_CALL(consumer, pop(testing::_, testing::_))
+        .Times(1)
+        .WillRepeatedly(testing::Invoke([](swss::KeyOpFieldsValuesTuple& kco, bool initViewMode) {
+        static int callCount = 0;
+        if (callCount == 0)
+        {
+            kfvKey(kco) = "oid:0x21000000000000";
+            kfvOp(kco) = REDIS_ASIC_STATE_COMMAND_STATS_CAPABILITY_QUERY;
+            kfvFieldsValues(kco) = {
+                std::make_pair("OBJECT_TYPE", "SAI_OBJECT_TYPE_QUEUE"),
+                std::make_pair("LIST_SIZE", "1")
+        };
+        }
+        else
+        {
+                kfvKey(kco) = "";
+                kfvOp(kco) = "";
+                kfvFieldsValues(kco).clear();
+        }
+        ++callCount;
     }));
     syncd_object.processEvent(consumer);
 }

--- a/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
+++ b/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
@@ -140,3 +140,41 @@ TEST_F(VirtualSwitchSaiInterfaceTest, bulkGet)
                 statuses));
 }
 
+TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsCapability)
+{
+    sai_stat_capability_t capability_list[51];
+    sai_stat_capability_list_t stats_capability;
+    stats_capability.list = capability_list;
+
+    /* Queue stats capability get */
+    stats_capability.count = 1;
+
+    EXPECT_EQ(SAI_STATUS_BUFFER_OVERFLOW,
+            m_vssai->queryStatsCapability(
+                m_swid,
+                SAI_OBJECT_TYPE_QUEUE,
+                &stats_capability));
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS,
+            m_vssai->queryStatsCapability(
+                m_swid,
+                SAI_OBJECT_TYPE_QUEUE,
+                &stats_capability));
+
+    /* Port stats capability get */
+    stats_capability.count = 1;
+
+    EXPECT_EQ(SAI_STATUS_BUFFER_OVERFLOW,
+            m_vssai->queryStatsCapability(
+                m_swid,
+                SAI_OBJECT_TYPE_PORT,
+                &stats_capability));
+
+    stats_capability.count = 51;
+    EXPECT_EQ(SAI_STATUS_SUCCESS,
+            m_vssai->queryStatsCapability(
+                m_swid,
+                SAI_OBJECT_TYPE_PORT,
+                &stats_capability));
+}
+

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3844,7 +3844,6 @@ sai_status_t SwitchStateBase::queryAttrEnumValuesCapability(
 
     return SAI_STATUS_NOT_SUPPORTED;
 }
-
 sai_status_t SwitchStateBase::queryAttributeCapability(
                               _In_ sai_object_id_t switch_id,
                               _In_ sai_object_type_t object_type,
@@ -3863,4 +3862,104 @@ sai_status_t SwitchStateBase::queryAttributeCapability(
     attr_capability->get_implemented    = true;
 
     return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchStateBase::queryStatsCapability(
+                              _In_ sai_object_id_t switchId,
+                              _In_ sai_object_type_t objectType,
+                              _Inout_ sai_stat_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+    uint32_t i = 0;
+    uint32_t stats_count = 0;
+
+    if (objectType == SAI_OBJECT_TYPE_QUEUE)
+    {
+        stats_count = SAI_QUEUE_STAT_DELAY_WATERMARK_NS;
+        if (stats_capability->count < stats_count )
+        {
+            stats_capability->count = stats_count;
+            return SAI_STATUS_BUFFER_OVERFLOW;
+        }
+
+        stats_capability->count = stats_count;
+
+        for(i = 0; i < stats_capability->count; i++)
+        {
+            stats_capability->list[i].stat_modes = SAI_STATS_MODE_READ_AND_CLEAR | SAI_STATS_MODE_READ ;
+            stats_capability->list[i].stat_enum = i;
+        }
+
+        return SAI_STATUS_SUCCESS;
+    }
+    else if (objectType == SAI_OBJECT_TYPE_PORT)
+    {
+        if (stats_capability->count < 51)
+        {
+            stats_capability->count = 51;
+            return SAI_STATUS_BUFFER_OVERFLOW;
+        }
+
+        stats_capability->count = 51;
+        stats_capability->list[0].stat_enum = SAI_PORT_STAT_IF_IN_OCTETS;
+        stats_capability->list[1].stat_enum = SAI_PORT_STAT_IF_IN_UCAST_PKTS;
+        stats_capability->list[2].stat_enum = SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS;
+        stats_capability->list[3].stat_enum = SAI_PORT_STAT_IF_IN_DISCARDS;
+        stats_capability->list[4].stat_enum = SAI_PORT_STAT_IF_IN_ERRORS;
+        stats_capability->list[5].stat_enum = SAI_PORT_STAT_IF_IN_UNKNOWN_PROTOS;
+        stats_capability->list[6].stat_enum = SAI_PORT_STAT_IF_IN_BROADCAST_PKTS;
+        stats_capability->list[7].stat_enum = SAI_PORT_STAT_IF_IN_MULTICAST_PKTS;
+        stats_capability->list[8].stat_enum = SAI_PORT_STAT_IF_IN_VLAN_DISCARDS;
+        stats_capability->list[9].stat_enum = SAI_PORT_STAT_IF_OUT_OCTETS;
+        stats_capability->list[10].stat_enum = SAI_PORT_STAT_IF_OUT_UCAST_PKTS;
+        stats_capability->list[11].stat_enum = SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS;
+        stats_capability->list[12].stat_enum = SAI_PORT_STAT_IF_OUT_DISCARDS;
+        stats_capability->list[13].stat_enum = SAI_PORT_STAT_IF_OUT_ERRORS;
+        stats_capability->list[14].stat_enum = SAI_PORT_STAT_IF_OUT_QLEN;
+        stats_capability->list[15].stat_enum = SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS;
+        stats_capability->list[16].stat_enum = SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS;
+        stats_capability->list[17].stat_enum = SAI_PORT_STAT_ETHER_STATS_DROP_EVENTS;
+        stats_capability->list[18].stat_enum = SAI_PORT_STAT_ETHER_STATS_MULTICAST_PKTS;
+        stats_capability->list[19].stat_enum = SAI_PORT_STAT_ETHER_STATS_BROADCAST_PKTS;
+        stats_capability->list[20].stat_enum = SAI_PORT_STAT_ETHER_STATS_UNDERSIZE_PKTS;
+        stats_capability->list[21].stat_enum = SAI_PORT_STAT_ETHER_STATS_FRAGMENTS;
+        stats_capability->list[22].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_64_OCTETS;
+        stats_capability->list[23].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_65_TO_127_OCTETS;
+        stats_capability->list[24].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_128_TO_255_OCTETS;
+        stats_capability->list[25].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_256_TO_511_OCTETS;
+        stats_capability->list[26].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_512_TO_1023_OCTETS;
+        stats_capability->list[27].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_1024_TO_1518_OCTETS;
+        stats_capability->list[28].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_1519_TO_2047_OCTETS;
+        stats_capability->list[29].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_2048_TO_4095_OCTETS;
+        stats_capability->list[30].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_4096_TO_9216_OCTETS;
+        stats_capability->list[31].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_9217_TO_16383_OCTETS;
+        stats_capability->list[32].stat_enum = SAI_PORT_STAT_ETHER_STATS_OVERSIZE_PKTS;
+        stats_capability->list[33].stat_enum = SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS;
+        stats_capability->list[34].stat_enum = SAI_PORT_STAT_ETHER_TX_OVERSIZE_PKTS;
+        stats_capability->list[35].stat_enum = SAI_PORT_STAT_ETHER_STATS_JABBERS;
+        stats_capability->list[36].stat_enum = SAI_PORT_STAT_ETHER_STATS_OCTETS;
+        stats_capability->list[37].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS;
+        stats_capability->list[38].stat_enum = SAI_PORT_STAT_ETHER_STATS_COLLISIONS;
+        stats_capability->list[39].stat_enum = SAI_PORT_STAT_ETHER_STATS_CRC_ALIGN_ERRORS;
+        stats_capability->list[40].stat_enum = SAI_PORT_STAT_ETHER_STATS_TX_NO_ERRORS;
+        stats_capability->list[41].stat_enum = SAI_PORT_STAT_ETHER_STATS_RX_NO_ERRORS;
+        stats_capability->list[42].stat_enum = SAI_PORT_STAT_GREEN_WRED_DROPPED_PACKETS;
+        stats_capability->list[43].stat_enum = SAI_PORT_STAT_GREEN_WRED_DROPPED_BYTES;
+        stats_capability->list[44].stat_enum = SAI_PORT_STAT_YELLOW_WRED_DROPPED_PACKETS;
+        stats_capability->list[45].stat_enum = SAI_PORT_STAT_YELLOW_WRED_DROPPED_BYTES;
+        stats_capability->list[46].stat_enum = SAI_PORT_STAT_RED_WRED_DROPPED_PACKETS;
+        stats_capability->list[47].stat_enum = SAI_PORT_STAT_RED_WRED_DROPPED_BYTES;
+        stats_capability->list[48].stat_enum = SAI_PORT_STAT_WRED_DROPPED_PACKETS;
+        stats_capability->list[49].stat_enum = SAI_PORT_STAT_WRED_DROPPED_BYTES;
+        stats_capability->list[50].stat_enum = SAI_PORT_STAT_ECN_MARKED_PACKETS;
+
+        for(i = 0; i < stats_capability->count; i++)
+        {
+            stats_capability->list[i].stat_modes = SAI_STATS_MODE_READ_AND_CLEAR | SAI_STATS_MODE_READ ;
+        }
+
+        return SAI_STATUS_SUCCESS;
+    }
+
+    return SAI_STATUS_NOT_SUPPORTED;
 }

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -300,6 +300,11 @@ namespace saivs
                               _In_ sai_attr_id_t attr_id,
                              _Inout_ sai_s32_list_t *enum_values_capability);
 
+           virtual sai_status_t queryStatsCapability(
+                              _In_ sai_object_id_t switchId,
+                              _In_ sai_object_type_t objectType,
+                              _Inout_ sai_stat_capability_list_t *stats_capability);
+
            virtual sai_status_t queryAttributeCapability(
                               _In_ sai_object_id_t switch_id,
                               _In_ sai_object_type_t object_type,

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -990,6 +990,94 @@ sai_status_t VirtualSwitchSaiInterface::queryStatsCapability(
 
     auto ss = m_switchStateMap.at(switchId);
 
+
+    if (objectType == SAI_OBJECT_TYPE_QUEUE)
+    {
+        if (stats_capability->count < SAI_OBJECT_TYPE_QUEUE)
+        {
+            stats_capability->count = SAI_QUEUE_STAT_DELAY_WATERMARK_NS;
+            return SAI_STATUS_BUFFER_OVERFLOW;
+        }
+
+        stats_capability->count = SAI_QUEUE_STAT_DELAY_WATERMARK_NS;
+
+        for(uint32_t i = 0; i < stats_capability->count; i++)
+        {
+            stats_capability->list[i].stat_modes = SAI_STATS_MODE_READ_AND_CLEAR | SAI_STATS_MODE_READ;
+            stats_capability->list[i].stat_enum = i;
+        }
+
+        return SAI_STATUS_SUCCESS;
+    }
+    else if (objectType == SAI_OBJECT_TYPE_PORT)
+    {
+        if (stats_capability->count < 51)
+        {
+            stats_capability->count = 51;
+            return SAI_STATUS_BUFFER_OVERFLOW;
+        }
+
+        stats_capability->count = 51;
+        stats_capability->list[0].stat_enum = SAI_PORT_STAT_IF_IN_OCTETS;
+        stats_capability->list[1].stat_enum = SAI_PORT_STAT_IF_IN_UCAST_PKTS;
+        stats_capability->list[2].stat_enum = SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS;
+        stats_capability->list[3].stat_enum = SAI_PORT_STAT_IF_IN_DISCARDS;
+        stats_capability->list[4].stat_enum = SAI_PORT_STAT_IF_IN_ERRORS;
+        stats_capability->list[5].stat_enum = SAI_PORT_STAT_IF_IN_UNKNOWN_PROTOS;
+        stats_capability->list[6].stat_enum = SAI_PORT_STAT_IF_IN_BROADCAST_PKTS;
+        stats_capability->list[7].stat_enum = SAI_PORT_STAT_IF_IN_MULTICAST_PKTS;
+        stats_capability->list[8].stat_enum = SAI_PORT_STAT_IF_IN_VLAN_DISCARDS;
+        stats_capability->list[9].stat_enum = SAI_PORT_STAT_IF_OUT_OCTETS;
+        stats_capability->list[10].stat_enum = SAI_PORT_STAT_IF_OUT_UCAST_PKTS;
+        stats_capability->list[11].stat_enum = SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS;
+        stats_capability->list[12].stat_enum = SAI_PORT_STAT_IF_OUT_DISCARDS;
+        stats_capability->list[13].stat_enum = SAI_PORT_STAT_IF_OUT_ERRORS;
+        stats_capability->list[14].stat_enum = SAI_PORT_STAT_IF_OUT_QLEN;
+        stats_capability->list[15].stat_enum = SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS;
+        stats_capability->list[16].stat_enum = SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS;
+        stats_capability->list[17].stat_enum = SAI_PORT_STAT_ETHER_STATS_DROP_EVENTS;
+        stats_capability->list[18].stat_enum = SAI_PORT_STAT_ETHER_STATS_MULTICAST_PKTS;
+        stats_capability->list[19].stat_enum = SAI_PORT_STAT_ETHER_STATS_BROADCAST_PKTS;
+        stats_capability->list[20].stat_enum = SAI_PORT_STAT_ETHER_STATS_UNDERSIZE_PKTS;
+        stats_capability->list[21].stat_enum = SAI_PORT_STAT_ETHER_STATS_FRAGMENTS;
+        stats_capability->list[22].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_64_OCTETS;
+        stats_capability->list[23].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_65_TO_127_OCTETS;
+        stats_capability->list[24].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_128_TO_255_OCTETS;
+        stats_capability->list[25].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_256_TO_511_OCTETS;
+        stats_capability->list[26].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_512_TO_1023_OCTETS;
+        stats_capability->list[27].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_1024_TO_1518_OCTETS;
+        stats_capability->list[28].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_1519_TO_2047_OCTETS;
+        stats_capability->list[29].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_2048_TO_4095_OCTETS;
+        stats_capability->list[30].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_4096_TO_9216_OCTETS;
+        stats_capability->list[31].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS_9217_TO_16383_OCTETS;
+        stats_capability->list[32].stat_enum = SAI_PORT_STAT_ETHER_STATS_OVERSIZE_PKTS;
+        stats_capability->list[33].stat_enum = SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS;
+        stats_capability->list[34].stat_enum = SAI_PORT_STAT_ETHER_TX_OVERSIZE_PKTS;
+        stats_capability->list[35].stat_enum = SAI_PORT_STAT_ETHER_STATS_JABBERS;
+        stats_capability->list[36].stat_enum = SAI_PORT_STAT_ETHER_STATS_OCTETS;
+        stats_capability->list[37].stat_enum = SAI_PORT_STAT_ETHER_STATS_PKTS;
+        stats_capability->list[38].stat_enum = SAI_PORT_STAT_ETHER_STATS_COLLISIONS;
+        stats_capability->list[39].stat_enum = SAI_PORT_STAT_ETHER_STATS_CRC_ALIGN_ERRORS;
+        stats_capability->list[40].stat_enum = SAI_PORT_STAT_ETHER_STATS_TX_NO_ERRORS;
+        stats_capability->list[41].stat_enum = SAI_PORT_STAT_ETHER_STATS_RX_NO_ERRORS;
+        stats_capability->list[42].stat_enum = SAI_PORT_STAT_GREEN_WRED_DROPPED_PACKETS;
+        stats_capability->list[43].stat_enum = SAI_PORT_STAT_GREEN_WRED_DROPPED_BYTES;
+        stats_capability->list[44].stat_enum = SAI_PORT_STAT_YELLOW_WRED_DROPPED_PACKETS;
+        stats_capability->list[45].stat_enum = SAI_PORT_STAT_YELLOW_WRED_DROPPED_BYTES;
+        stats_capability->list[46].stat_enum = SAI_PORT_STAT_RED_WRED_DROPPED_PACKETS;
+        stats_capability->list[47].stat_enum = SAI_PORT_STAT_RED_WRED_DROPPED_BYTES;
+        stats_capability->list[48].stat_enum = SAI_PORT_STAT_WRED_DROPPED_PACKETS;
+        stats_capability->list[49].stat_enum = SAI_PORT_STAT_WRED_DROPPED_BYTES;
+        stats_capability->list[50].stat_enum = SAI_PORT_STAT_ECN_MARKED_PACKETS;
+
+        for(uint32_t i = 0; i < stats_capability->count; i++)
+        {
+            stats_capability->list[i].stat_modes = SAI_STATS_MODE_READ_AND_CLEAR | SAI_STATS_MODE_READ ;
+        }
+
+        return SAI_STATUS_SUCCESS;
+    }
+
     return ss->queryStatsCapability(
             switchId,
             objectType,


### PR DESCRIPTION
* Stats capability query API support is added

Details : 
- Changes are done to support the stats capability query from Swss to SAI.
- This was implemented as part of WRED and ECN statistics
- Statistics capability query is implemented in sairedis/syncd

HLD : https://github.com/sonic-net/SONiC/blob/master/doc/qos/ECN_and_WRED_statistics_HLD.md

Expected order of pull-request commits :

1) sonic-swss common pull request : https://github.com/sonic-net/sonic-swss-common/pull/777
2) sonic-yang-model pull requests : https://github.com/sonic-net/sonic-buildimage/pull/14758
3) sonic-sairedis pull request : https://github.com/sonic-net/sonic-sairedis/pull/1234
4) sonic-swss : pull request : https://github.com/sonic-net/sonic-swss/pull/2750
5) sonic-utilities pull request : https://github.com/sonic-net/sonic-utilities/pull/2807


