### PR TITLE
[syncd] Check for minimal SAI version

### DIFF
--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -69,9 +69,15 @@ sai_status_t VendorSai::initialize(
         return api_status;
     }
 
-    SWSS_LOG_NOTICE("SAI API version: %" PRId64, version);
+    // please refer to https://github.com/sonic-net/sonic-sairedis/pull/1246 or commit 606703e1
 
-    if (version != SAI_API_VERSION)
+    sai_api_version_t minversion = SAI_VERSION(1,9,0);
+
+    SWSS_LOG_NOTICE("SAI API vendor version: %" PRId64, version);
+    SWSS_LOG_NOTICE("SAI API min version: %" PRId64, minversion);
+    SWSS_LOG_NOTICE("SAI API headers version: %" PRId64, SAI_API_VERSION);
+
+    if ((version < minversion) || (SAI_API_VERSION < minversion))
     {
         SWSS_LOG_ERROR("SAI implementation API version %" PRId64 " does not match SAI headers API version %" PRId64,
                        version, SAI_API_VERSION);

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -79,8 +79,8 @@ sai_status_t VendorSai::initialize(
 
     if ((version < minversion) || (SAI_API_VERSION < minversion))
     {
-        SWSS_LOG_ERROR("SAI implementation API version %" PRId64 " does not match SAI headers API version %" PRId64,
-                       version, SAI_API_VERSION);
+        SWSS_LOG_ERROR("SAI implementation API version %" PRId64 " or SAI headers API version %" PRId64 " does not meet minimum version requirements, min version required: %" PRId64,
+                       version, SAI_API_VERSION, minversion);
 
         return SAI_STATUS_FAILURE;
     }


### PR DESCRIPTION
since commit 8e1fb37 (v1.8.0) there is check enum binary backward compatibility so we are relaxing this check below, versions do not have to be equal but both need to be at least 2ebde24 (v1.9.0), this will make sure that enums are always ok, but since that commit some data structures changed and are not binary backwad compatible like next hop group api, acl_capability, structs are backward binary compatible from commit aed34c8, which closest tag version for it is commit 3ff228a (v1.12.0), so min version check should be set to (v1.12.0), but some production branches do not use that high SAI version yet, some use even version v1.7.0 which then it is impossible to provide even enum backward compatibility