### PR TITLE
Remove return failure when SAI version mismatch

### DIFF
--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -73,10 +73,10 @@ sai_status_t VendorSai::initialize(
 
     if (version != SAI_API_VERSION)
     {
-        SWSS_LOG_ERROR("SAI implementation API version %" PRId64 " does not match SAI headers API version %" PRId64,
+        SWSS_LOG_NOTICE("SAI implementation API version %" PRId64 " does not match SAI headers API version %" PRId64,
                        version, SAI_API_VERSION);
 
-        return SAI_STATUS_FAILURE;
+        // return SAI_STATUS_FAILURE;
     }
 #endif
 

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -75,8 +75,6 @@ sai_status_t VendorSai::initialize(
     {
         SWSS_LOG_NOTICE("SAI implementation API version %" PRId64 " does not match SAI headers API version %" PRId64,
                        version, SAI_API_VERSION);
-
-        // return SAI_STATUS_FAILURE;
     }
 #endif
 


### PR DESCRIPTION
# What is the motivation for this PR?
After advancing SAI version to 1.12 and still using SAI v1.11 in the SDK, switch cannot start up due to following reason:
```
May 26 09:27:12.708367 str2-7050cx3-acs-02 WARNING syncd#syncd: :- Syncd: enable sync mode is deprecated, please use communication mode, FORCING redis sync mode
May 26 09:27:12.709654 str2-7050cx3-acs-02 NOTICE syncd#syncd: :- RedisSelectableChannel: opened redis channel
May 26 09:27:12.711334 str2-7050cx3-acs-02 NOTICE syncd#syncd: :- isVeryFirstRun: First Run: True
May 26 09:27:12.711334 str2-7050cx3-acs-02 NOTICE syncd#syncd: :- initialize: SAI API version: 11100
May 26 09:27:12.711370 str2-7050cx3-acs-02 ERR syncd#syncd: :- initialize: SAI implementation API version 11100 does not match SAI headers API version 11200
May 26 09:27:12.711370 str2-7050cx3-acs-02 ERR syncd#syncd: :- Syncd: FATAL: failed to sai_api_initialize: SAI_STATUS_FAILURE
```

# How did you do it?
Remove the return failure and change log level to NOTICE when SAI version mismatch.

# How did you verify/test it?
Build a image with this fix and run test with it.

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
