### PR TITLE
docker prefer COPY to ADD in dockerfile

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -2,7 +2,7 @@ FROM docker-sonic-vs
 
 ARG docker_container_name
 
-ADD ["debs", "/debs"]
+COPY ["debs", "/debs"]
 
 RUN dpkg --purge python-swsscommon python3-swsscommon swss libsairedis sonic-db-cli libswsscommon libsaimetadata libsaivs syncd-vs
 


### PR DESCRIPTION
#### Why I did it
Docker best practices prefer COPY to ADD
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
##### Work item tracking
- Microsoft ADO **(number only)**: 17418730
#### How I did it
Use the COPY command as opposed to ADD unless working with a tar file.