### PR TITLE
[warmboot] Add workaround for `INIT_VIEW` failure 

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -4309,6 +4309,11 @@ void Syncd::onSwitchCreateInInitViewMode(
                 sai_serialize_object_id(switchVid).c_str(),
                 newHw.c_str());
 
+        /*
+         * The line below is added due to a behavior change of SAI call.
+         *
+         * TODO: remove the line when SAI vendor agrees fix on their end.
+        */
         currentHw = currentHw == "none"? "":currentHw;
 
         if (currentHw != newHw)

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -4309,6 +4309,8 @@ void Syncd::onSwitchCreateInInitViewMode(
                 sai_serialize_object_id(switchVid).c_str(),
                 newHw.c_str());
 
+        currentHw = currentHw == "none"? "":currentHw;
+
         if (currentHw != newHw)
         {
             SWSS_LOG_THROW("hardware info mismatch: current '%s' vs new '%s'", currentHw.c_str(), newHw.c_str());

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -4313,8 +4313,8 @@ void Syncd::onSwitchCreateInInitViewMode(
          * The line below is added due to a behavior change of SAI call.
          *
          * TODO: remove the line when SAI vendor agrees fix on their end.
-        */
-        currentHw = currentHw == "none"? "":currentHw;
+         */
+        currentHw = currentHw == "none"? "" : currentHw;
 
         if (currentHw != newHw)
         {


### PR DESCRIPTION
**MICROSOFT ADO#: 24107886**

## why change is needed
"SaiGetHardwareInfo" is now returning string "none" instead of empty string (""), which is causing INIT_VIEW failure:
```
May 26 18:57:33.577868 NOTICE syncd#syncd: :- onSwitchCreateInInitViewMode: new switch oid:0x21000000000000 contains hardware info: ''
May 26 18:57:33.577868 ERR syncd#syncd: :- onSwitchCreateInInitViewMode: hardware info mismatch: current 'none' vs new ''
May 26 18:57:33.578017 ERR syncd#syncd: :- run: Runtime error: :- onSwitchCreateInInitViewMode: hardware info mismatch: current 'none' vs new ''
```

Adding this change as a temp workaround before CSP is resolved with BRCM. 

## how I verify 
Test syncd build on lab device, able to pass INIT_VIEW stage. 

sign-off: Jing Zhang zhangjing@microsoft.com