### PR TITLE
disable GCC VTA for SWIG-generated file to reduce build time

### DIFF
--- a/pyext/pysairedis.i
+++ b/pyext/pysairedis.i
@@ -3,6 +3,8 @@
 %include "carrays.i"
 
 %{
+#pragma GCC optimize("no-var-tracking-assignments")
+
 #include "pysairedis.h"
 
 extern "C"{


### PR DESCRIPTION
Fix https://github.com/sonic-net/sonic-buildimage/issues/13775

-fvar-tracking-assignments
Annotate assignments to user variables early in the compilation and attempt to carry the annotations over throughout the compilation all the way to the end, in an attempt to improve debug information while optimizing. 
By default, this flag is enabled.

There is no reason to use this flag for auto-generated code.