### PR TITLE
Fix RPC package build failure due to shell syntax issue

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,8 +21,6 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 # package maintainers to append LDFLAGS
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
-DOPACKAGES = $(shell dh_listpackages)
-
 configure_opts = --disable-static
 ifeq ($(ENABLE_ASAN), y)
 	configure_opts += --enable-asan
@@ -61,11 +59,8 @@ override_dh_auto_configure:
 
 override_dh_install:
 	dh_install
-	# Note: escape $ with an extra $ symbol
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
-	if [ -f debian/syncd-rpc/usr/bin/syncd_init_common.sh ] ; then
-		sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
-	fi
+	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 endif
 
 override_dh_installinit:


### PR DESCRIPTION
PR #1194 removed the .ONESHELL flag, causing commands for a target to be executed in separate shell environments. Because of that, multi-line shell code blocks aren't parsed correctly.

Since the `syncd_init_common.sh` file should always exist anyways (it's unconditionally sourced by an init script and a start script), remove the if-check around it, and always run `sed` when building rpc packages.