### PR TITLE
Make sure new binaries replace existing binaries in docker-sonic-vs

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -5,6 +5,10 @@ ARG need_dbg
 
 COPY ["debs", "/debs"]
 
+# Remove existing packages first before installing the new/current packages. This is to overcome limitations with
+# Docker's diff detection mechanism, where only the file size and the modification timestamp (which will remain the
+# same, even though contents have changed) are checked between the previous and current layer.
+RUN dpkg --purge libswsscommon python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb \
             /debs/python3-swsscommon_1.0.0_amd64.deb \
             /debs/sonic-db-cli_1.0.0_amd64.deb \


### PR DESCRIPTION
PR #1225 removed a step where existing deb packages were removed before installing the new deb packages. The problem is that due to Docker's change detection code, where it only checks the file size and the modification timestamp, even if the file gets modified when installing a newer debian package, the file size may remain the same, and the modification timestamp will remain the same (since this is based on the debian/changelog timestamp). This caused changed binaries to not actually replace the existing binaries.

Fix this by re-adding the line that removed existing packages first.