### PR TITLE
[FEC] Adding support for vs testing for SAI_PORT_ATTR_AUTO_NEG_FEC_MODE_OVERRIDE

### DIFF
--- a/unittest/vslib/TestSwitchBCM56850.cpp
+++ b/unittest/vslib/TestSwitchBCM56850.cpp
@@ -479,3 +479,38 @@ TEST(SwitchBCM56850, test_nexthop_group_type_enum_values_capability)
 
     EXPECT_EQ(nexthop_group_types_found, 5);
 }
+
+TEST(SwitchBCM56850, test_port_autoneg_fec_override_support)
+{
+    auto sc = std::make_shared<SwitchConfig>(0, "");
+    auto signal = std::make_shared<Signal>();
+    auto eventQueue = std::make_shared<EventQueue>(signal);
+
+    sc->m_saiSwitchType = SAI_SWITCH_TYPE_NPU;
+    sc->m_switchType = SAI_VS_SWITCH_TYPE_BCM56850;
+    sc->m_bootType = SAI_VS_BOOT_TYPE_COLD;
+    sc->m_useTapDevice = false;
+    sc->m_laneMap = LaneMap::getDefaultLaneMap(0);
+    sc->m_eventQueue = eventQueue;
+
+    auto scc = std::make_shared<SwitchConfigContainer>();
+
+    scc->insert(sc);
+
+    SwitchBCM56850 sw(
+            0x2100000000,
+            std::make_shared<RealObjectIdManager>(0, scc),
+            sc);
+
+    sai_attr_capability_t attr_capability;
+
+    EXPECT_EQ(sw.queryAttributeCapability(0x2100000000,
+                                          SAI_OBJECT_TYPE_PORT,
+                                          SAI_PORT_ATTR_AUTO_NEG_FEC_MODE_OVERRIDE,
+                                          &attr_capability),
+                                          SAI_STATUS_SUCCESS);
+
+    EXPECT_EQ(attr_capability.create_implemented, false);
+    EXPECT_EQ(attr_capability.set_implemented, false);
+    EXPECT_EQ(attr_capability.get_implemented, false);
+}

--- a/unittest/vslib/TestSwitchMLNX2700.cpp
+++ b/unittest/vslib/TestSwitchMLNX2700.cpp
@@ -542,3 +542,38 @@ TEST(SwitchMLNX2700, test_vlan_flood_capability)
 
     EXPECT_EQ(flood_types_found, 4);
 }
+
+TEST(SwitchMLNX2700, test_port_autoneg_fec_override_support)
+{
+    auto sc = std::make_shared<SwitchConfig>(0, "");
+    auto signal = std::make_shared<Signal>();
+    auto eventQueue = std::make_shared<EventQueue>(signal);
+
+    sc->m_saiSwitchType = SAI_SWITCH_TYPE_NPU;
+    sc->m_switchType = SAI_VS_SWITCH_TYPE_MLNX2700;
+    sc->m_bootType = SAI_VS_BOOT_TYPE_COLD;
+    sc->m_useTapDevice = false;
+    sc->m_laneMap = LaneMap::getDefaultLaneMap(0);
+    sc->m_eventQueue = eventQueue;
+
+    auto scc = std::make_shared<SwitchConfigContainer>();
+
+    scc->insert(sc);
+
+    SwitchMLNX2700 sw(
+            0x2100000000,
+            std::make_shared<RealObjectIdManager>(0, scc),
+            sc);
+
+    sai_attr_capability_t attr_capability;
+
+    EXPECT_EQ(sw.queryAttributeCapability(0x2100000000,
+                                          SAI_OBJECT_TYPE_PORT,
+                                          SAI_PORT_ATTR_AUTO_NEG_FEC_MODE_OVERRIDE,
+                                          &attr_capability),
+                                          SAI_STATUS_SUCCESS);
+
+    EXPECT_EQ(attr_capability.create_implemented, true);
+    EXPECT_EQ(attr_capability.set_implemented, true);
+    EXPECT_EQ(attr_capability.get_implemented, true);
+}

--- a/vslib/SwitchMLNX2700.cpp
+++ b/vslib/SwitchMLNX2700.cpp
@@ -459,6 +459,17 @@ sai_status_t SwitchMLNX2700::queryTunnelPeerModeCapability(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchMLNX2700::queryPortAutonegFecOverrideSupportCapability(
+                   _Out_ sai_attr_capability_t *capability)
+{
+    SWSS_LOG_ENTER();
+
+    capability->create_implemented = true;
+    capability->set_implemented    = true;
+    capability->get_implemented    = true;
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t SwitchMLNX2700::create_port_serdes()
 {
     SWSS_LOG_ENTER();

--- a/vslib/SwitchMLNX2700.h
+++ b/vslib/SwitchMLNX2700.h
@@ -54,6 +54,7 @@ namespace saivs
                                       _Inout_ sai_s32_list_t *enum_values_capability) override;
             virtual sai_status_t queryVlanfloodTypeCapability(
                                       _Inout_ sai_s32_list_t *enum_values_capability) override;
-
+            virtual sai_status_t queryPortAutonegFecOverrideSupportCapability(
+                                      _Out_ sai_attr_capability_t *attr_capability) override;
     };
 }

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3641,6 +3641,17 @@ sai_status_t SwitchStateBase::queryTunnelPeerModeCapability(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchStateBase::queryPortAutonegFecOverrideSupportCapability(
+                   _Out_ sai_attr_capability_t *capability)
+{
+    SWSS_LOG_ENTER();
+
+    capability->create_implemented = false;
+    capability->set_implemented    = false;
+    capability->get_implemented    = false;
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t SwitchStateBase::queryVlanfloodTypeCapability(
                    _Inout_ sai_s32_list_t *enum_values_capability)
 {
@@ -3741,4 +3752,23 @@ sai_status_t SwitchStateBase::queryAttrEnumValuesCapability(
     }
 
     return SAI_STATUS_NOT_SUPPORTED;
+}
+
+sai_status_t SwitchStateBase::queryAttributeCapability(
+                              _In_ sai_object_id_t switch_id,
+                              _In_ sai_object_type_t object_type,
+                              _In_ sai_attr_id_t attr_id,
+                              _Out_ sai_attr_capability_t *capability)
+{
+    SWSS_LOG_ENTER();
+
+    if (object_type == SAI_OBJECT_TYPE_PORT && attr_id == SAI_PORT_ATTR_AUTO_NEG_FEC_MODE_OVERRIDE)
+    {
+        return queryPortAutonegFecOverrideSupportCapability(capability);
+    }
+    capability->create_implemented = true;
+    capability->set_implemented    = true;
+    capability->get_implemented    = true;
+
+    return SAI_STATUS_SUCCESS;
 }

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -295,6 +295,12 @@ namespace saivs
                               _In_ sai_attr_id_t attr_id,
                              _Inout_ sai_s32_list_t *enum_values_capability);
 
+           virtual sai_status_t queryAttributeCapability(
+                              _In_ sai_object_id_t switch_id,
+                              _In_ sai_object_type_t object_type,
+                              _In_ sai_attr_id_t attr_id,
+                             _Out_ sai_attr_capability_t *attr_capability);
+
         protected:
 
             virtual sai_status_t remove_internal(
@@ -688,6 +694,9 @@ namespace saivs
 
             virtual sai_status_t queryHashNativeHashFieldListCapability(
                                       _Inout_ sai_s32_list_t *enum_values_capability);
+
+            virtual sai_status_t queryPortAutonegFecOverrideSupportCapability(
+                                      _Out_ sai_attr_capability_t *attr_capability);
 
         public: // TODO private
 

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -861,8 +861,6 @@ sai_status_t VirtualSwitchSaiInterface::queryAttributeCapability(
 
     auto ss = m_switchStateMap.at(switch_id);
     return ss->queryAttributeCapability(switch_id, object_type, attr_id, capability);
-
-    return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t VirtualSwitchSaiInterface::queryAattributeEnumValuesCapability(

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -859,14 +859,8 @@ sai_status_t VirtualSwitchSaiInterface::queryAttributeCapability(
 {
     SWSS_LOG_ENTER();
 
-    // TODO: We should generate this metadata for the virtual switch rather
-    // than hard-coding it here.
-
-    // in virtual switch by default all apis are implemented for all objects. SUCCESS for all attributes
-
-    capability->create_implemented = true;
-    capability->set_implemented    = true;
-    capability->get_implemented    = true;
+    auto ss = m_switchStateMap.at(switch_id);
+    return ss->queryAttributeCapability(switch_id, object_type, attr_id, capability);
 
     return SAI_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Adding support to test SAI_PORT_ATTR_AUTO_NEG_FEC_MODE_OVERRIDE. We need to test two flows one with attribute supported and one without.
Added logic where MLNX2700 has support for the attribute wheile BCM56850 doesn't have support
Added UT to verify.