### PR TITLE
[submodule] Update SAI to latest v1.12 branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,7 +247,8 @@ https://github.com/opencomputeproject/SAI/pull/1795 (structs)
 }],
 [AC_MSG_RESULT(ok)],
 [AC_MSG_RESULT(failed)
-AC_MSG_ERROR("SAI headers API version and library version mismatch")])])
+AC_MSG_ERROR("SAI headers API version and library version mismatch")])],
+[AC_MSG_ERROR("SAI library libsai.so does not have sai_query_api_version API which is required")])
 CXXFLAGS="$SAVED_FLAGS"
 ])])
 

--- a/lib/sai_redis_interfacequery.cpp
+++ b/lib/sai_redis_interfacequery.cpp
@@ -258,7 +258,20 @@ sai_status_t sai_query_api_version(
 {
     SWSS_LOG_ENTER();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    if (version)
+    {
+        *version = SAI_API_VERSION;
+
+        // TODO FIXME implement proper query for syncd, currently this is not an issue since swss is not using this API
+
+        SWSS_LOG_WARN("retruning SAI API version %d with sairedis compiled SAI headers, not actual libsai.so", SAI_API_VERSION);
+
+        return SAI_STATUS_SUCCESS;
+    }
+
+    SWSS_LOG_ERROR("version parameter is NULL");
+
+    return SAI_STATUS_INVALID_PARAMETER;
 }
 
 sai_status_t sai_bulk_object_get_stats(

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -210,5 +210,7 @@ namespace syncd
             sai_service_method_table_t m_service_method_table;
 
             sai_apis_t m_apis;
+
+            sai_global_apis_t m_globalApis;
     };
 }

--- a/syncd/tests.cpp
+++ b/syncd/tests.cpp
@@ -770,7 +770,7 @@ int main()
 
         printf("\n[ %s ]\n\n", sai_serialize_status(SAI_STATUS_SUCCESS).c_str());
 
-        test_watchdog_timer_clock_rollback();
+        // test_watchdog_timer_clock_rollback();
 
         test_invoke_dump();
     }

--- a/syncd/tests.cpp
+++ b/syncd/tests.cpp
@@ -770,7 +770,7 @@ int main()
 
         printf("\n[ %s ]\n\n", sai_serialize_status(SAI_STATUS_SUCCESS).c_str());
 
-        // test_watchdog_timer_clock_rollback();
+        test_watchdog_timer_clock_rollback();
 
         test_invoke_dump();
     }

--- a/unittest/lib/test_sai_redis_interfacequery.cpp
+++ b/unittest/lib/test_sai_redis_interfacequery.cpp
@@ -105,3 +105,11 @@ TEST(libsairedis, sai_bulk_object_clear_stats)
                                                                       SAI_STATS_MODE_BULK_CLEAR,
                                                                       nullptr));
 }
+
+TEST(libsairedis, sai_query_api_version)
+{
+    sai_api_version_t version;
+
+    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, sai_query_api_version(nullptr));
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai_query_api_version(&version));
+}


### PR DESCRIPTION
Also update VendorSai class to use latest generic api from SAI metadata.

Since latest SAI uses version v1.12 on master branch, force require sai_query_api_version to be present at all SAI libs