### PR TITLE
Build both the regular and RPC version when the RPC profile is enabled

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 1.0.0
 
 Package: syncd
 Architecture: any
-Build-Profiles: <syncd !rpc !vs>
+Build-Profiles: <syncd !vs>
 Depends: ${misc:Pre-Depends}
 Recommends: ${shlibs:Depends}
 Conflicts: syncd-rpc, syncd-vs

--- a/debian/rules
+++ b/debian/rules
@@ -35,9 +35,6 @@ configure_opts += --disable-python2
 endif
 
 ifneq ($(filter syncd,$(DEB_BUILD_PROFILES)),)
-ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
-configure_opts += --enable-rpcserver
-endif
 ifneq ($(filter vs,$(DEB_BUILD_PROFILES)),)
 configure_opts += --with-sai=vs
 endif
@@ -58,7 +55,17 @@ override_dh_auto_configure:
 	dh_auto_configure -- ${SWSS_COMMON_CONFIG} $(configure_opts)
 
 override_dh_install:
+ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
+	dh_install -N syncd-rpc
+	# This is to build a RPC-enabled version, and package that version into syncd-rpc
+	dh_auto_configure -- ${SWSS_COMMON_CONFIG} $(configure_opts) --enable-rpcserver
+	make clean
+	dh_auto_build
+	make install DESTDIR=$(shell pwd)/debian/tmp
+	dh_install -N syncd
+else
 	dh_install
+endif
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 endif


### PR DESCRIPTION
When the RPC version needs to be built, the regular version of syncd also needs to be built. Unfortunately, this is not easy to do with the current build infra except for manually rerunning configure, removing the built object files/binaries, and building the new config.