### PR TITLE
[azp] Attempt to fix swss missing libs

### DIFF
--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -109,6 +109,10 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-route*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
         target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
+        target/debs/${{ parameters.debian_version }}/libprotoc*.deb
+        target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb
+        target/debs/${{ parameters.debian_version }}/libdashapi*.deb
     displayName: "Download common libs"
 
   - script: |


### PR DESCRIPTION
Swss containter needs dash_api to properly build, based on https://github.com/sonic-net/sonic-swss/pull/2722, attempting to add missing libs