### PR TITLE
Use json.hpp from nlohmann-json-dev instead of swss-common

### DIFF
--- a/lib/ClientConfig.cpp
+++ b/lib/ClientConfig.cpp
@@ -1,7 +1,7 @@
 #include "ClientConfig.h"
 
 #include "swss/logger.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include <cstring>
 #include <fstream>

--- a/lib/ContextConfigContainer.cpp
+++ b/lib/ContextConfigContainer.cpp
@@ -1,7 +1,7 @@
 #include "ContextConfigContainer.h"
 
 #include "swss/logger.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include <cstring>
 #include <fstream>

--- a/lib/ServerConfig.cpp
+++ b/lib/ServerConfig.cpp
@@ -1,7 +1,7 @@
 #include "ServerConfig.h"
 
 #include "swss/logger.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include <cstring>
 #include <fstream>

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -3,10 +3,7 @@
 
 #include "swss/tokenize.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#include "swss/json.hpp"
-#pragma GCC diagnostic pop
+#include <nlohmann/json.hpp>
 
 #include <inttypes.h>
 #include <vector>

--- a/saiasiccmp/View.h
+++ b/saiasiccmp/View.h
@@ -5,7 +5,7 @@ extern "C" {
 #include "saimetadata.h"
 }
 
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 #include "swss/table.h"
 
 #include "syncd/AsicView.h"

--- a/unittest/meta/TestNotificationFactory.cpp
+++ b/unittest/meta/TestNotificationFactory.cpp
@@ -4,6 +4,7 @@
 #include "sai_serialize.h"
 
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 #include <memory>
 
@@ -13,7 +14,7 @@ TEST(NotificationFactory, deserialize)
 {
     EXPECT_THROW(NotificationFactory::deserialize("foo", "bar"), std::runtime_error);
 
-    EXPECT_THROW(NotificationFactory::deserialize(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT, "bar"), std::invalid_argument);
+    EXPECT_THROW(NotificationFactory::deserialize(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT, "bar"), nlohmann::detail::parse_error);
 }
 
 TEST(NotificationFactory, deserialize_fdb_event)

--- a/vslib/ContextConfigContainer.cpp
+++ b/vslib/ContextConfigContainer.cpp
@@ -1,7 +1,7 @@
 #include "ContextConfigContainer.h"
 
 #include "swss/logger.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include <cstring>
 #include <fstream>

--- a/vslib/FdbInfo.cpp
+++ b/vslib/FdbInfo.cpp
@@ -6,7 +6,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 #pragma GCC diagnostic pop
 
 using namespace saivs;


### PR DESCRIPTION
This header file comes from an external package, and a very old version of the header file has been checked into swss-common. This will cause problems for the upcoming Bookworm upgrade.

Change references to the header file to use the Debian package nlohmann-json-dev (added in https://github.com/sonic-net/sonic-buildimage/pull/16308), instead of from swss-common.