### PR TITLE
[syncd] Change sai discovery log priority to info

### DIFF
--- a/syncd/SaiDiscovery.cpp
+++ b/syncd/SaiDiscovery.cpp
@@ -313,7 +313,7 @@ void SaiDiscovery::setApiLogLevel(
 
         if (status == SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_NOTICE("Setting SAI loglevel %s on %s",
+            SWSS_LOG_INFO("setting SAI loglevel %s on %s",
                     sai_serialize_log_level(logLevel).c_str(),
                     sai_serialize_api((sai_api_t)api).c_str());
         }


### PR DESCRIPTION
When multiple asic are present and multiple ports are created then those log lines willpollute logs for no reason