### PR TITLE
[syncd] Respect each api log level after sai discovery

### DIFF
--- a/meta/SaiInterface.cpp
+++ b/meta/SaiInterface.cpp
@@ -329,3 +329,13 @@ sai_status_t SaiInterface::switchMdioCl22Write(
 
     return SAI_STATUS_FAILURE;
 }
+
+sai_log_level_t SaiInterface::logGet(
+        _In_ sai_api_t api)
+{
+    SWSS_LOG_ENTER();
+
+    // default for all apis
+
+    return SAI_LOG_LEVEL_NOTICE;
+}

--- a/meta/SaiInterface.h
+++ b/meta/SaiInterface.h
@@ -316,5 +316,10 @@ namespace sairedis
             virtual sai_status_t logSet(
                     _In_ sai_api_t api,
                     _In_ sai_log_level_t log_level) = 0;
+
+        public: // non SAI API
+
+            virtual sai_log_level_t logGet(
+                    _In_ sai_api_t api);
     };
 }

--- a/syncd/SaiDiscovery.h
+++ b/syncd/SaiDiscovery.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <set>
+#include <map>
 #include <unordered_map>
 
 namespace syncd
@@ -49,6 +50,11 @@ namespace syncd
 
             void setApiLogLevel(
                     _In_ sai_log_level_t logLevel);
+
+            void setApiLogLevel(
+                    _In_ const std::map<sai_api_t, sai_log_level_t>& levels);
+
+            std::map<sai_api_t, sai_log_level_t> getApiLogLevel();
 
         private:
 

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -1681,5 +1681,24 @@ sai_status_t VendorSai::logSet(
 {
     SWSS_LOG_ENTER();
 
+    m_logLevelMap[api] = log_level;
+
     return m_globalApis.log_set(api, log_level);
+}
+
+sai_log_level_t VendorSai::logGet(
+        _In_ sai_api_t api)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_logLevelMap.find(api);
+
+    if (it != m_logLevelMap.end())
+    {
+        return it->second;
+    }
+
+    // no level defined yet, just return default
+
+    return SAI_LOG_LEVEL_NOTICE;
 }

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -10,6 +10,7 @@ extern "C" {
 #include <vector>
 #include <memory>
 #include <mutex>
+#include <map>
 
 namespace syncd
 {
@@ -201,6 +202,11 @@ namespace syncd
                     _In_ sai_api_t api,
                     _In_ sai_log_level_t log_level) override;
 
+        public: // extra API
+
+            virtual sai_log_level_t logGet(
+                    _In_ sai_api_t api) override;
+
         private:
 
             bool m_apiInitialized;
@@ -212,5 +218,7 @@ namespace syncd
             sai_apis_t m_apis;
 
             sai_global_apis_t m_globalApis;
+
+            std::map<sai_api_t, sai_log_level_t> m_logLevelMap;
     };
 }


### PR DESCRIPTION
Previously log after sai discovery log level was set to NOTICE not respecting actual API log level or what user set via swsslog

fixes: https://github.com/sonic-net/sonic-sairedis/issues/1300