### PR TITLE
Support TWAMP Light notification in syncd

### DIFF
--- a/lib/Switch.cpp
+++ b/lib/Switch.cpp
@@ -123,6 +123,11 @@ void Switch::updateNotifications(
                     (sai_port_host_tx_ready_notification_fn)attr.value.ptr;
                 break;
 
+            case SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY:
+                m_switchNotifications.on_twamp_session_event =
+                    (sai_twamp_session_event_notification_fn)attr.value.ptr;
+                break;
+
             default:
                 SWSS_LOG_ERROR("pointer for %s is not handled, FIXME!", meta->attridname);
                 break;

--- a/meta/Makefile.am
+++ b/meta/Makefile.am
@@ -35,6 +35,7 @@ libsaimeta_la_SOURCES = \
 				NotificationSwitchShutdownRequest.cpp \
 				NotificationSwitchStateChange.cpp \
 				NotificationBfdSessionStateChange.cpp \
+				NotificationTwampSessionEvent.cpp \
 				NotificationPortHostTxReadyEvent.cpp \
 				NumberOidIndexGenerator.cpp \
 				OidRefCounter.cpp \

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -225,6 +225,10 @@ namespace saimeta
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_port_host_tx_ready_status_t host_tx_ready_status);
 
+            void meta_sai_on_twamp_session_event(
+                    _In_ uint32_t count,
+                    _In_ const sai_twamp_session_event_notification_data_t *data);
+
         private: // notifications helpers
 
             void meta_sai_on_fdb_flush_event_consolidated(
@@ -247,6 +251,9 @@ namespace saimeta
 
             void meta_sai_on_bfd_session_state_change_single(
                     _In_ const sai_bfd_session_state_notification_t& data);
+
+            void meta_sai_on_twamp_session_event_single(
+                    _In_ const sai_twamp_session_event_notification_data_t& data);
 
         private: // validation helpers
 

--- a/meta/NotificationFactory.cpp
+++ b/meta/NotificationFactory.cpp
@@ -6,6 +6,7 @@
 #include "NotificationSwitchShutdownRequest.h"
 #include "NotificationSwitchStateChange.h"
 #include "NotificationBfdSessionStateChange.h"
+#include "NotificationTwampSessionEvent.h"
 #include "NotificationPortHostTxReadyEvent.h"
 #include "sairediscommon.h"
 
@@ -42,6 +43,9 @@ std::shared_ptr<Notification> NotificationFactory::deserialize(
 
     if (name == SAI_SWITCH_NOTIFICATION_NAME_BFD_SESSION_STATE_CHANGE)
         return std::make_shared<NotificationBfdSessionStateChange>(serializedNotification);
+
+    if (name == SAI_SWITCH_NOTIFICATION_NAME_TWAMP_SESSION_EVENT)
+        return std::make_shared<NotificationTwampSessionEvent>(serializedNotification);
 
     SWSS_LOG_THROW("unknown notification: '%s', FIXME", name.c_str());
 }

--- a/meta/NotificationTwampSessionEvent.cpp
+++ b/meta/NotificationTwampSessionEvent.cpp
@@ -1,0 +1,77 @@
+#include "NotificationTwampSessionEvent.h"
+
+#include "swss/logger.h"
+
+#include "meta/sai_serialize.h"
+
+using namespace sairedis;
+
+NotificationTwampSessionEvent::NotificationTwampSessionEvent(
+        _In_ const std::string& serializedNotification):
+    Notification(
+            SAI_SWITCH_NOTIFICATION_TYPE_TWAMP_SESSION_EVENT,
+            serializedNotification),
+    m_twampSessionEventNotificationData(nullptr)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_twamp_session_event_ntf(
+            serializedNotification,
+            m_count,
+            &m_twampSessionEventNotificationData);
+}
+
+NotificationTwampSessionEvent::~NotificationTwampSessionEvent()
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_free_twamp_session_event_ntf(m_count, m_twampSessionEventNotificationData);
+}
+
+sai_object_id_t NotificationTwampSessionEvent::getSwitchId() const
+{
+    SWSS_LOG_ENTER();
+
+    // this notification don't contain switch id field
+
+    return SAI_NULL_OBJECT_ID;
+}
+
+sai_object_id_t NotificationTwampSessionEvent::getAnyObjectId() const
+{
+    SWSS_LOG_ENTER();
+
+    if (m_twampSessionEventNotificationData == nullptr)
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    for (uint32_t idx = 0; idx < m_count; idx++)
+    {
+        if (m_twampSessionEventNotificationData[idx].twamp_session_id != SAI_NULL_OBJECT_ID)
+        {
+            return m_twampSessionEventNotificationData[idx].twamp_session_id;
+        }
+    }
+
+    return SAI_NULL_OBJECT_ID;
+}
+
+void NotificationTwampSessionEvent::processMetadata(
+        _In_ std::shared_ptr<saimeta::Meta> meta) const
+{
+    SWSS_LOG_ENTER();
+
+    meta->meta_sai_on_twamp_session_event(m_count, m_twampSessionEventNotificationData);
+}
+
+void NotificationTwampSessionEvent::executeCallback(
+        _In_ const sai_switch_notifications_t& switchNotifications) const
+{
+    SWSS_LOG_ENTER();
+
+    if (switchNotifications.on_twamp_session_event)
+    {
+        switchNotifications.on_twamp_session_event(m_count, m_twampSessionEventNotificationData);
+    }
+}

--- a/meta/NotificationTwampSessionEvent.h
+++ b/meta/NotificationTwampSessionEvent.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Notification.h"
+
+namespace sairedis
+{
+    class NotificationTwampSessionEvent:
+        public Notification
+    {
+        public:
+
+            NotificationTwampSessionEvent(
+                    _In_ const std::string& serializedNotification);
+
+            virtual ~NotificationTwampSessionEvent();
+
+        public:
+
+            virtual sai_object_id_t getSwitchId() const override;
+
+            virtual sai_object_id_t getAnyObjectId() const override;
+
+            virtual void processMetadata(
+                    _In_ std::shared_ptr<saimeta::Meta> meta) const override;
+
+            virtual void executeCallback(
+                    _In_ const sai_switch_notifications_t& switchNotifications) const override;
+
+        private:
+
+            uint32_t m_count;
+
+            sai_twamp_session_event_notification_data_t *m_twampSessionEventNotificationData;
+    };
+}

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -253,6 +253,9 @@ std::string sai_serialize_nat_entry_type(
 std::string sai_serialize_qos_map_item(
         _In_ const sai_qos_map_t& qosmap);
 
+std::string sai_serialize_twamp_session_stat(
+        _In_ const sai_twamp_session_stat_t counter);
+
 // serialize notifications
 
 std::string sai_serialize_fdb_event_ntf(
@@ -279,6 +282,10 @@ std::string sai_serialize_port_host_tx_ready_ntf(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_id_t port_id,
         _In_ sai_port_host_tx_ready_status_t host_tx_ready_status);
+
+std::string sai_serialize_twamp_session_event_ntf(
+        _In_ uint32_t count,
+        _In_ const sai_twamp_session_event_notification_data_t* twamp_session_event);
 
 // sairedis
 
@@ -496,6 +503,11 @@ void sai_deserialize_port_host_tx_ready_ntf(
         _Out_ sai_port_host_tx_ready_status_t& host_tx_ready_status);
 
 
+void sai_deserialize_twamp_session_event_ntf(
+        _In_ const std::string& s,
+        _Out_ uint32_t &count,
+        _Out_ sai_twamp_session_event_notification_data_t** twamp_session_data);
+
 // free methods
 
 void sai_deserialize_free_attribute_value(
@@ -527,6 +539,10 @@ void sai_deserialize_free_bfd_session_state_ntf(
 void sai_deserialize_ingress_priority_group_attr(
         _In_ const std::string& s,
         _Out_ sai_ingress_priority_group_attr_t& attr);
+
+void sai_deserialize_free_twamp_session_event_ntf(
+        _In_ uint32_t count,
+        _In_ sai_twamp_session_event_notification_data_t* twamp_session_event);
 
 void sai_deserialize_queue_attr(
         _In_ const std::string& s,

--- a/syncd/NotificationHandler.cpp
+++ b/syncd/NotificationHandler.cpp
@@ -120,6 +120,10 @@ void NotificationHandler::updateNotificationsPointers(
                 attr.value.ptr = (void*)m_switchNotifications.on_bfd_session_state_change;
                 break;
 
+            case SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY:
+                attr.value.ptr = (void*)m_switchNotifications.on_twamp_session_event;
+                break;
+
             default:
 
                 SWSS_LOG_ERROR("pointer for %s is not handled, FIXME!", meta->attridname);
@@ -238,6 +242,17 @@ void NotificationHandler::enqueueNotification(
     {
         m_processor->signal();
     }
+}
+
+void NotificationHandler::onTwampSessionEvent(
+        _In_ uint32_t count,
+        _In_ const sai_twamp_session_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    std::string s = sai_serialize_twamp_session_event_ntf(count, data);
+
+    enqueueNotification(SAI_SWITCH_NOTIFICATION_NAME_TWAMP_SESSION_EVENT, s);
 }
 
 void NotificationHandler::enqueueNotification(

--- a/syncd/NotificationHandler.h
+++ b/syncd/NotificationHandler.h
@@ -69,6 +69,10 @@ namespace syncd
                     _In_ uint32_t count,
                     _In_ const sai_bfd_session_state_notification_t *data);
 
+            void onTwampSessionEvent(
+                    _In_ uint32_t count,
+                    _In_ const sai_twamp_session_event_notification_data_t *data);
+
         private:
 
             void enqueueNotification(

--- a/syncd/NotificationProcessor.h
+++ b/syncd/NotificationProcessor.h
@@ -100,6 +100,10 @@ namespace syncd
             void process_on_switch_shutdown_request(
                     _In_ sai_object_id_t switch_rid);
 
+            void process_on_twamp_session_event(
+                    _In_ uint32_t count,
+                    _In_ sai_twamp_session_event_notification_data_t *data);
+
         private: // handlers
 
             void handle_switch_state_change(
@@ -124,6 +128,9 @@ namespace syncd
                     _In_ const std::string &data);
 
             void handle_port_host_tx_ready_change(
+                    _In_ const std::string &data);
+
+            void handle_twamp_session_event(
                     _In_ const std::string &data);
 
             void processNotification(

--- a/syncd/SwitchNotifications.cpp
+++ b/syncd/SwitchNotifications.cpp
@@ -117,6 +117,16 @@ void SwitchNotifications::SlotBase::onSwitchStateChange(
     return m_slots.at(context)->m_handler->onSwitchStateChange(switch_id, switch_oper_status);
 }
 
+void SwitchNotifications::SlotBase::onTwampSessionEvent(
+        _In_ int context,
+        _In_ uint32_t count,
+        _In_ const sai_twamp_session_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    return m_slots.at(context)->m_handler->onTwampSessionEvent(count, data);
+}
+
 const sai_switch_notifications_t& SwitchNotifications::SlotBase::getSwitchNotifications() const
 {
     SWSS_LOG_ENTER();

--- a/syncd/SwitchNotifications.h
+++ b/syncd/SwitchNotifications.h
@@ -76,6 +76,11 @@ namespace syncd
                             _In_ uint32_t count,
                             _In_ const sai_bfd_session_state_notification_t *data);
 
+                    static void onTwampSessionEvent(
+                            _In_ int context,
+                            _In_ uint32_t count,
+                            _In_ const sai_twamp_session_event_notification_data_t *data);
+
                 protected:
 
                     SwitchNotifications* m_handler;
@@ -103,7 +108,7 @@ namespace syncd
                             .on_nat_event = &Slot<context>::onNatEvent,
                             .on_switch_asic_sdk_health_event = nullptr,
                             .on_port_host_tx_ready = &Slot<context>::onPortHostTxReady,
-                            .on_twamp_session_event = nullptr,
+                            .on_twamp_session_event = &Slot<context>::onTwampSessionEvent,
                             }) { }
 
                 virtual ~Slot() {}
@@ -181,6 +186,15 @@ namespace syncd
 
                     return SlotBase::onSwitchStateChange(context, switch_id, switch_oper_status);
                 }
+
+                static void onTwampSessionEvent(
+                        _In_ uint32_t count,
+                        _In_ const sai_twamp_session_event_notification_data_t *data)
+                {
+                    SWSS_LOG_ENTER();
+
+                    return SlotBase::onTwampSessionEvent(context, count, data);
+                }
         };
 
             static std::vector<SwitchNotifications::SlotBase*> m_slots;
@@ -205,6 +219,7 @@ namespace syncd
             std::function<void(sai_object_id_t)>                                                    onSwitchShutdownRequest;
             std::function<void(sai_object_id_t switch_id, sai_switch_oper_status_t)>                onSwitchStateChange;
             std::function<void(uint32_t, const sai_bfd_session_state_notification_t*)>              onBfdSessionStateChange;
+            std::function<void(uint32_t, const sai_twamp_session_event_notification_data_t*)>       onTwampSessionEvent;
 
         private:
 

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -159,6 +159,7 @@ Syncd::Syncd(
     m_sn.onSwitchStateChange = std::bind(&NotificationHandler::onSwitchStateChange, m_handler.get(), _1, _2);
     m_sn.onBfdSessionStateChange = std::bind(&NotificationHandler::onBfdSessionStateChange, m_handler.get(), _1, _2);
     m_sn.onPortHostTxReady = std::bind(&NotificationHandler::onPortHostTxReady, m_handler.get(), _1, _2, _3);
+    m_sn.onTwampSessionEvent = std::bind(&NotificationHandler::onTwampSessionEvent, m_handler.get(), _1, _2);
 
     m_handler->setSwitchNotifications(m_sn.getSwitchNotifications());
 

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -471,3 +471,4 @@ zmq
 ZMQ
 ZMQ
 uncreated
+TWAMP


### PR DESCRIPTION
For supporting TWAMP Light, it requires vendor-sai to report TWAMP Light mearsurement data from silicon.

And, so it defines the notification event and getting statistics function in SAI and invokes them in syncd.