### PR TITLE
The meta_sai_validate_fdb_entry() validates the input FDB entry for the set/remove operation. (#1154)

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -3827,7 +3827,7 @@ sai_status_t Meta::meta_sai_validate_fdb_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                 sai_serialize_object_meta_key(meta_key_fdb).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     // fdb entry is valid


### PR DESCRIPTION
When there is no matching FDB entry found in the database, then an incorrect SAI error code (SAI_STATUS_INVALID_PARAMETER) is returned. As a port of this fix, the correct SAI error return code (SAI_STATUS_ITEM_NOT_FOUND) is returned.
This Return code can be used by the callers to take approprite actions, if the FDB entry is indeed not available during the set/remove operations.