### PR TITLE
[Link Event Damping] Add Abstract SelectEventHandler class to handle link event damping timer events.

### DIFF
--- a/syncd/SelectableEventHandler.h
+++ b/syncd/SelectableEventHandler.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace syncd
+{
+    // This class implements handler for Selectable events.
+    class SelectableEventHandler
+    {
+        public:
+
+            virtual ~SelectableEventHandler() = default;
+
+            virtual void handleSelectableEvent() = 0;
+
+        protected:
+
+            SelectableEventHandler() = default;
+    };
+
+}  // namespace syncd


### PR DESCRIPTION

- Handler in the class will be used to handle the timer event of link event dampers.

HLD: sonic-net/SONiC#1071