### PR TITLE
[Link Event Damping] Add link event damping sairedis port attributes.

### DIFF
--- a/lib/sairedis.h
+++ b/lib/sairedis.h
@@ -250,3 +250,58 @@ typedef enum _sai_redis_switch_attr_t
      */
     SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT,
 } sai_redis_switch_attr_t;
+
+/**
+ * @brief Link event damping algorithms.
+ */
+typedef enum _sai_link_event_damping_algorithm_t
+{
+    /** Link event damping algorithm disabled. */
+    SAI_LINK_EVENT_DAMPING_ALGORITHM_DISABLED = 0,
+
+    /** Additive increase exponential decrease based link event damping algorithm. */
+    SAI_LINK_EVENT_DAMPING_ALGORITHM_AIED = 1,
+
+} sai_link_event_damping_algorithm_t;
+
+typedef struct _sai_redis_link_event_damping_algo_aied_config_t
+{
+    /** Max link event damping suppression time (in milliseconds). */
+    sai_uint32_t max_suppress_time;
+
+    /** Link event damping suppress threshold. */
+    sai_uint32_t suppress_threshold;
+
+    /** Link event damping reuse threshold. */
+    sai_uint32_t reuse_threshold;
+
+    /** Link event damping decay half time duration (in milliseconds). */
+    sai_uint32_t decay_half_life;
+
+    /** Link event flap penalty. */
+    sai_uint32_t flap_penalty;
+
+} sai_redis_link_event_damping_algo_aied_config_t;
+
+typedef enum _sai_redis_port_attr_t
+{
+    /**
+     * @brief Link event damping algorithm.
+     *
+     * @type sai_link_event_damping_algorithm_t
+     * @flags CREATE_AND_SET
+     * @default SAI_LINK_EVENT_DAMPING_ALGORITHM_DISABLED
+     */
+    SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM = SAI_PORT_ATTR_CUSTOM_RANGE_START,
+
+    /**
+     * @brief Link event damping AIED configuration.
+     *
+     * @type sai_redis_link_event_damping_algo_aied_config_t
+     * @flags CREATE_AND_SET
+     * @validonly SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM = SAI_LINK_EVENT_DAMPING_ALGORITHM_AIED
+     * @default internal
+     */
+    SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGO_AIED_CONFIG,
+
+} sai_redis_port_attr_t;

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -3,6 +3,7 @@ acl
 ACL
 ACLs
 AES
+AIED
 API
 APIs
 ASAN
@@ -437,6 +438,7 @@ updatable
 upgradable
 util
 utils
+validonly
 versa
 veth
 vEthernetX


### PR DESCRIPTION
- Add link event damping sairedis port attributes.
- These attributes will be used by OA to set the link event damping algorithm and AIED link event damping config.
- Syncd uses these sairedis port attribute to receive the link event damping algorithm and AIED config to execute syncd-based link event damping.

HLD: sonic-net/SONiC#1071