### PR TITLE
[syncd] Translate removed RID on bfd session state change

### DIFF
--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -528,7 +528,7 @@ void NotificationProcessor::process_on_bfd_session_state_change(
          * switch vid.
          */
 
-        bfd_session_state->bfd_session_id = m_translator->translateRidToVid(bfd_session_state->bfd_session_id, SAI_NULL_OBJECT_ID);
+        bfd_session_state->bfd_session_id = m_translator->translateRidToVid(bfd_session_state->bfd_session_id, SAI_NULL_OBJECT_ID, true);
     }
 
     std::string s = sai_serialize_bfd_session_state_ntf(count, data);


### PR DESCRIPTION
Fixes https://github.com/sonic-net/sonic-buildimage/issues/16992

We will also translate removed RID in notification in case that BFD session was removed, and notification arrived for that session asynchronously 