### PR TITLE
[Link Event Damping] Serialization/deserialization logic for link event damping port attrs

### DIFF
--- a/lib/sairedis.h
+++ b/lib/sairedis.h
@@ -254,15 +254,15 @@ typedef enum _sai_redis_switch_attr_t
 /**
  * @brief Link event damping algorithms.
  */
-typedef enum _sai_link_event_damping_algorithm_t
+typedef enum _sai_redis_link_event_damping_algorithm_t
 {
     /** Link event damping algorithm disabled. */
-    SAI_LINK_EVENT_DAMPING_ALGORITHM_DISABLED = 0,
+    SAI_REDIS_LINK_EVENT_DAMPING_ALGORITHM_DISABLED = 0,
 
     /** Additive increase exponential decrease based link event damping algorithm. */
-    SAI_LINK_EVENT_DAMPING_ALGORITHM_AIED = 1,
+    SAI_REDIS_LINK_EVENT_DAMPING_ALGORITHM_AIED = 1,
 
-} sai_link_event_damping_algorithm_t;
+} sai_redis_link_event_damping_algorithm_t;
 
 typedef struct _sai_redis_link_event_damping_algo_aied_config_t
 {
@@ -288,9 +288,9 @@ typedef enum _sai_redis_port_attr_t
     /**
      * @brief Link event damping algorithm.
      *
-     * @type sai_link_event_damping_algorithm_t
+     * @type sai_redis_link_event_damping_algorithm_t
      * @flags CREATE_AND_SET
-     * @default SAI_LINK_EVENT_DAMPING_ALGORITHM_DISABLED
+     * @default SAI_REDIS_LINK_EVENT_DAMPING_ALGORITHM_DISABLED
      */
     SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM = SAI_PORT_ATTR_CUSTOM_RANGE_START,
 
@@ -299,7 +299,7 @@ typedef enum _sai_redis_port_attr_t
      *
      * @type sai_redis_link_event_damping_algo_aied_config_t
      * @flags CREATE_AND_SET
-     * @validonly SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM = SAI_LINK_EVENT_DAMPING_ALGORITHM_AIED
+     * @validonly SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM = SAI_REDIS_LINK_EVENT_DAMPING_ALGORITHM_AIED
      * @default internal
      */
     SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGO_AIED_CONFIG,

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -288,6 +288,17 @@ std::string sai_serialize(
 std::string sai_serialize_redis_communication_mode(
         _In_ sai_redis_communication_mode_t value);
 
+std::string sai_serialize_redis_port_attr_id(
+        _In_ const sai_redis_port_attr_t value);
+
+// Link event damping.
+
+std::string sai_serialize_redis_link_event_damping_algorithm(
+        _In_ const sai_redis_link_event_damping_algorithm_t value);
+
+std::string sai_serialize_redis_link_event_damping_aied_config(
+         _In_ const sai_redis_link_event_damping_algo_aied_config_t& value);
+
 // deserialize
 
 void sai_deserialize_enum(
@@ -541,3 +552,17 @@ sai_redis_notify_syncd_t sai_deserialize_redis_notify_syncd(
 void sai_deserialize_redis_communication_mode(
         _In_ const std::string& s,
         _Out_ sai_redis_communication_mode_t& value);
+
+void sai_deserialize_redis_port_attr_id(
+        _In_ const std::string& s,
+        _Out_ sai_redis_port_attr_t& value);
+
+// Link event damping.
+
+void sai_deserialize_redis_link_event_damping_algorithm(
+        _In_ const std::string& s,
+        _Out_ sai_redis_link_event_damping_algorithm_t& value);
+
+void sai_deserialize_redis_link_event_damping_aied_config(
+        _In_ const std::string& s,
+         _Out_ sai_redis_link_event_damping_algo_aied_config_t& value);


### PR DESCRIPTION

- Adding serialization/deserialization logic for link event damping config so that when libsai is sending link event damping algo and config to syncd for set request, it uses serialization logic to serialize the requested data before sending the set request and when syncd receives the link event damping port attribute set request, it uses the deserialization logic to deserialize the data.

HLD: sonic-net/SONiC#1071