### PR TITLE
Fix compilation issue due to PORT_STATE_CHANGE_QUEUE_SIZE undefined reference.

### DIFF
--- a/syncd/PortStateChangeHandler.cpp
+++ b/syncd/PortStateChangeHandler.cpp
@@ -6,6 +6,8 @@
 
 using namespace syncd;
 
+constexpr size_t PortStateChangeHandler::PORT_STATE_CHANGE_QUEUE_SIZE;
+
 PortStateChangeHandler::PortStateChangeHandler(
         _In_ std::shared_ptr<swss::SelectableEvent> portStateChangeEvent)
 {


### PR DESCRIPTION
- In PR https://github.com/sonic-net/sonic-sairedis/pull/1310, a constexpt static data member was added. Since sairedis repo uses c++14, definition of this data member needs to be provided in .cpp file too.