### PR TITLE
[syncd] Set inti switch flag to false when doing warm boot

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -4399,7 +4399,7 @@ void Syncd::performWarmRestartSingleSwitch(
     sai_attribute_t attr;
 
     attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
-    attr.value.booldata = true;
+    attr.value.booldata = false;
 
     attrs.push_back(attr);
 


### PR DESCRIPTION
This flag should be set to false during warm boot. This is a bug.