### PR TITLE
[Azp]: Update dash api source from buildimage to submodule

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -70,6 +70,21 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
+      pipeline: sonic-net.sonic-dash-api
+      ${{ if eq(parameters.arch, 'amd64') }}:
+        artifact: sonic-dash-api
+      ${{ else }}:
+        artifact: sonic-dash-api.${{ parameters.arch }}
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libdashapi*.deb
+    displayName: "Download dash api"
   - script: |
       set -ex
       echo $(Build.DefinitionName).$(Build.BuildNumber)

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -122,8 +122,22 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
         target/debs/${{ parameters.debian_version }}/libprotoc*.deb
         target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb
-        target/debs/${{ parameters.debian_version }}/libdashapi*.deb
     displayName: "Download common libs"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
+      pipeline: sonic-net.sonic-dash-api
+      ${{ if eq(parameters.arch, 'amd64') }}:
+        artifact: sonic-dash-api
+      ${{ else }}:
+        artifact: sonic-dash-api.${{ parameters.arch }}
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libdashapi*.deb
+    displayName: "Download dash api"
 
   - script: |
       set -ex

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -8,8 +8,9 @@ COPY ["debs", "/debs"]
 # Remove existing packages first before installing the new/current packages. This is to overcome limitations with
 # Docker's diff detection mechanism, where only the file size and the modification timestamp (which will remain the
 # same, even though contents have changed) are checked between the previous and current layer.
-RUN dpkg --purge libswsscommon python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd
-RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb \
+RUN dpkg --purge libswsscommon python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi
+RUN dpkg -i /debs/libdashapi_1.0.0_amd64.deb \
+            /debs/libswsscommon_1.0.0_amd64.deb \
             /debs/python3-swsscommon_1.0.0_amd64.deb \
             /debs/sonic-db-cli_1.0.0_amd64.deb \
             /debs/libsaimetadata_1.0.0_amd64.deb \


### PR DESCRIPTION
The Azp pipeline of sonic-dash-api has been moved from buildimage to it's submodule.