### PR TITLE
Fix code coverage and ASAN not being enabled

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -52,7 +52,7 @@ endif
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
 override_dh_auto_configure:
-	dh_auto_configure -- ${SWSS_COMMON_CONFIG} $(configure_opts)
+	dh_auto_configure -- ${SWSS_COMMON_CONFIG} $(configure_opts) $(DEB_CONFIGURE_EXTRA_FLAGS)
 
 override_dh_install:
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)


### PR DESCRIPTION
This fixes a breakage from #1194 where code coverage and ASAN were not enabled, due to DEB_CONFIGURE_EXTRA_FLAGS no longer being used in dh_auto_configure.