### PR TITLE
Revert "add if statement for module control mode support"

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -240,11 +240,6 @@ config_syncd_mlnx()
     if [[ -f /tmp/sai_extra.profile ]]; then
         cat /tmp/sai_extra.profile >> /tmp/sai.profile
     fi
-
-    if [[ -f /$HWSKU_DIR/module_control_support.profile ]]; then
-        cat /$HWSKU_DIR/module_control_support.profile >> /tmp/sai.profile
-    fi
-
 }
 
 config_syncd_centec()


### PR DESCRIPTION
Reverts sonic-net/sonic-sairedis#1305

this logic is not needed. we'll change sai.profile directly