### PR TITLE
Check MDIO server thread joinable before join the thread

### DIFF
--- a/syncd/MdioIpcServer.cpp
+++ b/syncd/MdioIpcServer.cpp
@@ -465,7 +465,10 @@ void MdioIpcServer::stopMdioThread(void)
     }
 
     m_taskAlive = 0;
-    m_taskThread.join();
+    if(m_taskThread.joinable())
+    {
+        m_taskThread.join();
+    }
     SWSS_LOG_NOTICE("IPC task thread is stopped\n");
 }
 


### PR DESCRIPTION
This PR is to address the issue [syncd crash observed during sonic-mgmt reboot tests #17346](https://github.com/sonic-net/sonic-buildimage/issues/17346)