### PR TITLE
Make changes to support compiling on Bookworm (with GCC 12)

### DIFF
--- a/lib/sai_redis_tam.cpp
+++ b/lib/sai_redis_tam.cpp
@@ -23,6 +23,7 @@ REDIS_GENERIC_QUAD(TAM_TELEMETRY,tam_telemetry);
 REDIS_GENERIC_QUAD(TAM_COLLECTOR,tam_collector);
 REDIS_GENERIC_QUAD(TAM_EVENT_ACTION,tam_event_action);
 REDIS_GENERIC_QUAD(TAM_EVENT,tam_event);
+REDIS_GENERIC_QUAD(TAM_COUNTER_SUBSCRIPTION,tam_counter_subscription);
 
 const sai_tam_api_t redis_tam_api = {
 
@@ -37,4 +38,5 @@ const sai_tam_api_t redis_tam_api = {
     REDIS_GENERIC_QUAD_API(tam_collector)
     REDIS_GENERIC_QUAD_API(tam_event_action)
     REDIS_GENERIC_QUAD_API(tam_event)
+    REDIS_GENERIC_QUAD_API(tam_counter_subscription)
 };

--- a/syncd/ServiceMethodTable.cpp
+++ b/syncd/ServiceMethodTable.cpp
@@ -2,6 +2,7 @@
 
 #include "swss/logger.h"
 
+#include <array>
 #include <utility>
 
 using namespace syncd;

--- a/syncd/SwitchNotifications.cpp
+++ b/syncd/SwitchNotifications.cpp
@@ -1,6 +1,7 @@
 #include "SwitchNotifications.h"
 
 #include "swss/logger.h"
+#include <array>
 
 using namespace syncd;
 

--- a/unittest/lib/test_sai_redis_tam.cpp
+++ b/unittest/lib/test_sai_redis_tam.cpp
@@ -70,6 +70,11 @@ TEST(libsairedis, tam)
     EXPECT_NE(SAI_STATUS_SUCCESS, api->remove_tam_event(0));
     EXPECT_NE(SAI_STATUS_SUCCESS, api->set_tam_event_attribute(0,0));
     EXPECT_NE(SAI_STATUS_SUCCESS, api->get_tam_event_attribute(0,0,0));
+
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->create_tam_counter_subscription(&id,0,0,0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->remove_tam_counter_subscription(0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->set_tam_counter_subscription_attribute(0,0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->get_tam_counter_subscription_attribute(0,0,0));
 }
 
 TEST(libsairedis, sai_tam_telemetry_get_data)

--- a/unittest/vslib/test_sai_vs_tam.cpp
+++ b/unittest/vslib/test_sai_vs_tam.cpp
@@ -70,6 +70,11 @@ TEST(libsaivs, tam)
     EXPECT_NE(SAI_STATUS_SUCCESS, api->remove_tam_event(0));
     EXPECT_NE(SAI_STATUS_SUCCESS, api->set_tam_event_attribute(0,0));
     EXPECT_NE(SAI_STATUS_SUCCESS, api->get_tam_event_attribute(0,0,0));
+
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->create_tam_counter_subscription(&id,0,0,0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->remove_tam_counter_subscription(0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->set_tam_counter_subscription_attribute(0,0));
+    EXPECT_NE(SAI_STATUS_SUCCESS, api->get_tam_counter_subscription_attribute(0,0,0));
 }
 
 TEST(libsairedis, sai_tam_telemetry_get_data)

--- a/vslib/sai_vs_tam.cpp
+++ b/vslib/sai_vs_tam.cpp
@@ -23,6 +23,7 @@ VS_GENERIC_QUAD(TAM_TELEMETRY,tam_telemetry);
 VS_GENERIC_QUAD(TAM_COLLECTOR,tam_collector);
 VS_GENERIC_QUAD(TAM_EVENT_ACTION,tam_event_action);
 VS_GENERIC_QUAD(TAM_EVENT,tam_event);
+VS_GENERIC_QUAD(TAM_COUNTER_SUBSCRIPTION,tam_counter_subscription);
 
 const sai_tam_api_t vs_tam_api = {
 
@@ -37,5 +38,6 @@ const sai_tam_api_t vs_tam_api = {
     VS_GENERIC_QUAD_API(tam_collector)
     VS_GENERIC_QUAD_API(tam_event_action)
     VS_GENERIC_QUAD_API(tam_event)
+    VS_GENERIC_QUAD_API(tam_counter_subscription)
 
 };


### PR DESCRIPTION
This adds support for sairedis to compile on Debian Bookworm (with GCC 12). This PR also includes a SAI submodule update that brings in other unrelated changes; this is needed because of a change in Doxyfile that would cause warnings/errors in newer versions of Doxygen.

The SAI submodule update brings in the following changes:
* Update the Doxyfile for doxygen in Debian Bookworm (opencomputeproject/SAI#1946)
* Enable sai_uint16_t in ProcessStructValueType Struct Member (opencomputeproject/SAI#1949)
* [meta] Add support for port stat extensions (opencomputeproject/SAI#1947)
* [meta] Add custom range start end values check (opencomputeproject/SAI#1945)
* Cable diagnostics attribute added (opencomputeproject/SAI#1894)
* Add attributes to disable L3 rewrites (opencomputeproject/SAI#1924)
* Add MAC remote loopback to the port loopback enums. (opencomputeproject/SAI#1934)
* [TAM] Granular counter subscription (opencomputeproject/SAI#1670)

Note that runtime functionality testing has not been done; only compilation (with the build-time tests) has been done.