### PR TITLE
[syncd] Add workaround for SET operation on SAI_HOSTIF_ATTR_QUEUE

### DIFF
--- a/syncd/Workaround.cpp
+++ b/syncd/Workaround.cpp
@@ -12,6 +12,11 @@ using namespace syncd;
  * Some attributes are not supported on SET API on different platforms.
  * For example SAI_SWITCH_ATTR_SRC_MAC_ADDRESS.
  *
+ * Some attributes like SAI_HOSTIF_ATTR_QUEUE may not be supported on BRCM
+ * platform until vendor will implement them, but it will return success on
+ * querySwitchCapability on OA. Support for query switch capability can show up
+ * on warm boot when booting new SAI firmware.
+ *
  * @param[in] objectType Object type.
  * @param[in] attrId Attribute Id.
  * @param[in] status Status from SET API.
@@ -32,6 +37,16 @@ bool Workaround::isSetAttributeWorkaround(
 
     if (objectType == SAI_OBJECT_TYPE_SWITCH &&
             attrId == SAI_SWITCH_ATTR_SRC_MAC_ADDRESS)
+    {
+        SWSS_LOG_WARN("setting %s failed: %s, not all platforms support this attribute",
+                sai_metadata_get_attr_metadata(objectType, attrId)->attridname,
+                sai_serialize_status(status).c_str());
+
+        return true;
+    }
+
+    if (objectType == SAI_OBJECT_TYPE_HOSTIF &&
+            attrId == SAI_HOSTIF_ATTR_QUEUE)
     {
         SWSS_LOG_WARN("setting %s failed: %s, not all platforms support this attribute",
                 sai_metadata_get_attr_metadata(objectType, attrId)->attridname,

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -17,6 +17,7 @@ tests_SOURCES = main.cpp \
 				TestNotificationHandler.cpp \
 				TestMdioIpcServer.cpp \
 				TestPortStateChangeHandler.cpp \
+				TestWorkaround.cpp \
 				TestVendorSai.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)

--- a/unittest/syncd/TestWorkaround.cpp
+++ b/unittest/syncd/TestWorkaround.cpp
@@ -1,0 +1,21 @@
+#include <cstdint>
+
+#include <memory>
+#include <vector>
+#include <array>
+
+#include <gtest/gtest.h>
+#include "Workaround.h"
+#include "swss/logger.h"
+
+#include <arpa/inet.h>
+
+using namespace syncd;
+
+TEST(Workaround, isSetAttributeWorkaround)
+{
+    ASSERT_EQ(Workaround::isSetAttributeWorkaround(SAI_OBJECT_TYPE_HOSTIF, SAI_HOSTIF_ATTR_QUEUE, SAI_STATUS_FAILURE), true);
+    ASSERT_EQ(Workaround::isSetAttributeWorkaround(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, SAI_STATUS_FAILURE), true);
+    ASSERT_EQ(Workaround::isSetAttributeWorkaround(SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_TYPE, SAI_STATUS_FAILURE), false);
+    ASSERT_EQ(Workaround::isSetAttributeWorkaround(SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_TYPE, SAI_STATUS_SUCCESS), false);
+}


### PR DESCRIPTION
On broadcom platform it may happen on warm boot that new firmware will support query switch capability SET operation for this attribute, but firmware is not actually implementing that operation, OA in this case will add new attribute SAI_HOSTIF_ATTR_QUEUE to create HOSTIF object, and comparison logic will generate SET operation to update existing object. If set is not supported, then this will cause syncd to crash because operation will be not successfull.

We are adding this workaround for time being until this will be supported, then this needs to be removed.