### PR TITLE
[VOQ][saidump] Enhance saidump with new option -r to parser the JSON file and displays/format the right output, fix compiling error #1335, to fix dpkg-checkbuilddeps: error

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,6 +69,7 @@ jobs:
             autoconf-archive \
             uuid-dev \
             libjansson-dev \
+            nlohmann-json3-dev \
             python
 
     - if: matrix.language == 'cpp'


### PR DESCRIPTION
Why I did it
During the process of fix PR1335, 
https://github.com/sonic-net/sonic-sairedis/pull/1335
There was an error:
dpkg-checkbuilddeps: error: Unmet build dependencies: nlohmann-json3-dev.

I checked the building scripts and found that they didn't include nlohmann-json3-dev. So, I think I need to create a separate PR that only installs nlohmann-json3-dev. After merging that PR, the PR1335 could be checked successfully.
sudo apt-get install -y libxml-simple-perl
aspell
... ...
libjansson-dev
python

 
How I did it




 

