### PR TITLE
Enable 8 Lanes Support in vslib

### DIFF
--- a/vslib/LaneMapFileParser.cpp
+++ b/vslib/LaneMapFileParser.cpp
@@ -64,7 +64,7 @@ void LaneMapFileParser::parse(
 
     size_t n = tokens.size();
 
-    if (n != 1 && n != 2 && n != 4)
+    if (n != 1 && n != 2 && n != 4 && n != 8)
     {
         SWSS_LOG_ERROR("invalid number of lanes (%zu) assigned to interface %s", n, ifname.c_str());
         return;


### PR DESCRIPTION
Enable 8 lanes support in vslib. This is needed to emulate HW SKUs which contains 8 lanes in their port_config.ini.

Tested bring up of vs image with HWSKU containing 8 lanes in their port_config.ini/lanemap.ini files. 