### PR TITLE
[asan] Disable the "maybe-uninitialized" warning when compiled with ASAN enabled.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ if test "x$asan_enabled" = "xtrue"; then
     CFLAGS_ASAN+=" -fsanitize=address"
     CFLAGS_ASAN+=" -DASAN_ENABLED"
     CFLAGS_ASAN+=" -ggdb -fno-omit-frame-pointer -U_FORTIFY_SOURCE"
+    CFLAGS_ASAN+=" -Wno-maybe-uninitialized"
     AC_SUBST(CFLAGS_ASAN)
 
     LDFLAGS_ASAN+=" -lasan"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix compilation with ASAN enabled for the Debian Bookworm with GCC version 12.2.0 (Debian 12.2.0-14).

**Why I did it**
The compilation fails due to the issue in GGC compiler: [GCC Bugzilla – Bug 105562](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562)
The suggested fix is suppressing the `maybe-uninitialized` warning to overcome the problem and may be removed when the GCC version is upgraded to the one that includes the fix.

**How I verified it**
Compile SWSS package with ASAN enabled.

**Details if related**
Related to: https://github.com/sonic-net/sonic-swss/pull/3062
