### PR TITLE
Update ip commands for MACsec for Bookworm

### DIFF
--- a/unittest/vslib/TestMACsecManager.cpp
+++ b/unittest/vslib/TestMACsecManager.cpp
@@ -30,6 +30,27 @@ TEST(MACsecManager, create_macsec_ingress_sa)
     manager.create_macsec_ingress_sa(attr);
 }
 
+TEST(MACsecManager, create_macsec_egress_sa)
+{
+    // This is a system call that may not be valid in the test environment,
+    // So, this case is just for the testing coverage checking.
+
+    MACsecManager manager;
+
+    MACsecAttr attr;
+    attr.m_vethName = "eth0";
+    attr.m_macsecName = "macsec_eth0";
+    attr.m_sci = "02:42:ac:11:00:03";
+    attr.m_an = 0;
+    attr.m_pn = 1;
+    attr.m_cipher = MACsecAttr::CIPHER_NAME_GCM_AES_XPN_128;
+    attr.m_ssci = 0x1;
+    attr.m_salt = "";
+    attr.m_authKey = "";
+    attr.m_sak = "";
+    manager.create_macsec_egress_sa(attr);
+}
+
 TEST(MACsecManager, update_macsec_sa_pn)
 {
     // This is a system call that may not be valid in the test environment,

--- a/vslib/MACsecManager.cpp
+++ b/vslib/MACsecManager.cpp
@@ -319,7 +319,7 @@ bool MACsecManager::update_macsec_sa_pn(
         ostream << " ssci " << attr.m_ssci;
     }
 
-    ostream << " pn " << pn;
+    ostream << ( attr.is_xpn() ? " xpn " : " pn " ) << pn;
 
     SWSS_LOG_NOTICE("%s", ostream.str().c_str());
 
@@ -447,7 +447,7 @@ bool MACsecManager::create_macsec_egress_sa(
         << shellquote(attr.m_macsecName)
         << " tx sa "
         << attr.m_an
-        << " pn "
+        << ( attr.is_xpn() ? " xpn " : " pn ")
         << attr.m_pn
         << ( attr.is_xpn() ? " ssci " : "" )
         << ( attr.is_xpn() ? std::to_string(attr.m_ssci) : "" )
@@ -484,7 +484,7 @@ bool MACsecManager::create_macsec_ingress_sa(
         << attr.m_sci
         << " sa "
         << attr.m_an
-        << " pn "
+        << ( attr.is_xpn() ? " xpn " : " pn " )
         << attr.m_pn
         << ( attr.is_xpn() ? " ssci " : "" )
         << ( attr.is_xpn() ? std::to_string(attr.m_ssci) : "" )


### PR DESCRIPTION
Bookworm's iproute2 has built-in support for configuring MACsec with XPN ciphers. Unfortunately, the syntax is slightly different, which means changes are needed for this to work on Bookworm.

Update the iproute2 commands run for Bookworm. This does mean compatibility with Bullseye will break.