### PR TITLE
Add Bookworm build to PR checks

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -98,7 +98,7 @@ jobs:
       sudo mkdir -m 755 /var/run/sswsyncd
 
       sudo apt-get install -y rsyslog
-      sudo service rsyslog start
+      sudo rsyslogd
 
       cat /etc/apt/sources.list
       dpkg --list | grep libnl
@@ -167,7 +167,8 @@ jobs:
     displayName: "Compile sonic sairedis with coverage enabled"
   - script: |
       sudo cp azsyslog.conf /etc/rsyslog.conf
-      sudo service rsyslog restart
+      sudo killall rsyslogd
+      sudo rsyslogd
     displayName: "Update rsyslog.conf"
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,7 @@ stages:
       swss_common_artifact_name: sonic-swss-common-bookworm
       artifact_name: sonic-sairedis-bookworm
       syslog_artifact_name: sonic-sairedis-bookworm.syslog
+      run_unit_test: true
       debian_version: ${{ parameters.debian_version }}
 
   - template: .azure-pipelines/build-template.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,41 @@ stages:
       syslog_artifact_name: sonic-sairedis.syslog.arm64
       debian_version: ${{ parameters.debian_version }}
 
+- stage: BuildBookworm
+  dependsOn: BuildArm
+  condition: succeeded('BuildArm')
+  jobs:
+  - template: .azure-pipelines/build-template.yml
+    parameters:
+      arch: amd64
+      sonic_slave: sonic-slave-bookworm
+      swss_common_artifact_name: sonic-swss-common-bookworm
+      artifact_name: sonic-sairedis-bookworm
+      syslog_artifact_name: sonic-sairedis-bookworm.syslog
+      debian_version: ${{ parameters.debian_version }}
+
+  - template: .azure-pipelines/build-template.yml
+    parameters:
+      arch: armhf
+      timeout: 180
+      pool: sonicbld-armhf
+      sonic_slave: sonic-slave-bookworm-armhf
+      swss_common_artifact_name: sonic-swss-common-bookworm.armhf
+      artifact_name: sonic-sairedis-bookworm.armhf
+      syslog_artifact_name: sonic-sairedis-bookworm.syslog.armhf
+      debian_version: ${{ parameters.debian_version }}
+
+  - template: .azure-pipelines/build-template.yml
+    parameters:
+      arch: arm64
+      timeout: 180
+      pool: sonicbld-arm64
+      sonic_slave: sonic-slave-bookworm-arm64
+      swss_common_artifact_name: sonic-swss-common-bookworm.arm64
+      artifact_name: sonic-sairedis-bookworm.arm64
+      syslog_artifact_name: sonic-sairedis-bookworm.syslog.arm64
+      debian_version: ${{ parameters.debian_version }}
+
 - stage: BuildSwss
   dependsOn: Build
   condition: succeeded('Build')


### PR DESCRIPTION
Add a step to verify the build for Bookworm for amd64, armhf, and arm64.