### PR TITLE
[proxy] Support notifications

### DIFF
--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -90,6 +90,8 @@ sai_status_t DummySaiInterface::create(
 {
     SWSS_LOG_ENTER();
 
+    // TODO impelement some dummy OID handling
+
     if (objectId && m_status == SAI_STATUS_SUCCESS)
     {
         *objectId = (sai_object_id_t)1;
@@ -557,48 +559,34 @@ void DummySaiInterface::updateNotificationPointers(
         switch (attr.id)
         {
             case SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY:
-                m_sn.on_switch_state_change =
-                    (sai_switch_state_change_notification_fn)attr.value.ptr;
+                m_sn.on_switch_state_change = (sai_switch_state_change_notification_fn)attrs[idx].value.ptr;
                 break;
-
-            case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
-                m_sn.on_switch_asic_sdk_health_event =
-                    (sai_switch_asic_sdk_health_event_notification_fn)attr.value.ptr;
+            case SAI_SWITCH_ATTR_SWITCH_SHUTDOWN_REQUEST_NOTIFY:
+                m_sn.on_switch_shutdown_request = (sai_switch_shutdown_request_notification_fn)attrs[idx].value.ptr;
                 break;
-
-            case SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY:
-                m_sn.on_switch_shutdown_request =
-                    (sai_switch_shutdown_request_notification_fn)attr.value.ptr;
-                break;
-
             case SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY:
-                m_sn.on_fdb_event =
-                    (sai_fdb_event_notification_fn)attr.value.ptr;
+                m_sn.on_fdb_event = (sai_fdb_event_notification_fn)attrs[idx].value.ptr;
                 break;
-
             case SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY:
-                m_sn.on_port_state_change =
-                    (sai_port_state_change_notification_fn)attr.value.ptr;
+                m_sn.on_port_state_change = (sai_port_state_change_notification_fn)attrs[idx].value.ptr;
                 break;
-
-            case SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY:
-                m_sn.on_port_host_tx_ready =
-                    (sai_port_host_tx_ready_notification_fn)attr.value.ptr;
-                break;
-
-            case SAI_SWITCH_ATTR_PACKET_EVENT_NOTIFY:
-                m_sn.on_packet_event =
-                    (sai_packet_event_notification_fn)attr.value.ptr;
-                break;
-
             case SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY:
-                m_sn.on_queue_pfc_deadlock =
-                    (sai_queue_pfc_deadlock_notification_fn)attr.value.ptr;
+                m_sn.on_queue_pfc_deadlock = (sai_queue_pfc_deadlock_notification_fn)attrs[idx].value.ptr;
                 break;
-
             case SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY:
-                m_sn.on_bfd_session_state_change =
-                    (sai_bfd_session_state_change_notification_fn)attr.value.ptr;
+                m_sn.on_bfd_session_state_change = (sai_bfd_session_state_change_notification_fn)attrs[idx].value.ptr;
+                break;
+            case SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY:
+                m_sn.on_nat_event = (sai_nat_event_notification_fn)attrs[idx].value.ptr;
+                break;
+            case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
+                m_sn.on_switch_asic_sdk_health_event = (sai_switch_asic_sdk_health_event_notification_fn)attrs[idx].value.ptr;
+                break;
+            case SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY:
+                m_sn.on_port_host_tx_ready = (sai_port_host_tx_ready_notification_fn)attrs[idx].value.ptr;
+                break;
+            case SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY:
+                m_sn.on_twamp_session_event = (sai_twamp_session_event_notification_fn)attrs[idx].value.ptr;
                 break;
 
             default:
@@ -731,7 +719,7 @@ void DummySaiInterface::sendNotification(
 
             if (sn.on_switch_state_change)
             {
-                SWSS_LOG_NOTICE("sending sn.on_switch_state_change(0x1, SAI_SWITCH_OPER_STATUS_UP)");
+                SWSS_LOG_NOTICE("sending sn.on_switch_state_change");
 
                 sn.on_switch_state_change(0x1, SAI_SWITCH_OPER_STATUS_UP);
             }
@@ -745,7 +733,7 @@ void DummySaiInterface::sendNotification(
 
             if (sn.on_fdb_event)
             {
-                SWSS_LOG_NOTICE("sending sn.on_fdb_event(1,data)");
+                SWSS_LOG_NOTICE("sending sn.on_fdb_event");
 
                 sai_fdb_event_notification_data_t data;
 
@@ -798,6 +786,140 @@ void DummySaiInterface::sendNotification(
             else
             {
                 SWSS_LOG_WARN("pointer sn.on_switch_shutdown_request is NULL");
+            }
+            break;
+
+        case SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY:
+
+            if (sn.on_nat_event)
+            {
+                SWSS_LOG_NOTICE("sending sn.on_nat_event");
+
+                sai_nat_event_notification_data_t data;
+
+                data.event_type = SAI_NAT_EVENT_NONE;
+                data.nat_entry.switch_id = 0x1;
+                data.nat_entry.vr_id = 0x2;
+                data.nat_entry.nat_type = SAI_NAT_TYPE_NONE;
+
+                memset(&data.nat_entry.data, 0, sizeof(data.nat_entry.data));
+
+                sn.on_nat_event(1, &data);
+            }
+            else
+            {
+                SWSS_LOG_WARN("pointer sn.on_nat_event is NULL");
+            }
+            break;
+
+
+        case SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY:
+
+            if (sn.on_nat_event)
+            {
+                SWSS_LOG_NOTICE("sending sn.on_port_host_tx_ready");
+
+                sn.on_port_host_tx_ready(0x1, 0x2, SAI_PORT_HOST_TX_READY_STATUS_NOT_READY);
+            }
+            else
+            {
+                SWSS_LOG_WARN("pointer sn.on_port_host_tx_readyis NULL");
+            }
+            break;
+
+        case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
+
+            if (sn.on_nat_event)
+            {
+                SWSS_LOG_NOTICE("sending sn.on_switch_asic_sdk_health_event");
+
+                sai_timespec_t timespec;
+
+                timespec.tv_sec = 0;
+                timespec.tv_nsec = 0;
+
+                sai_switch_health_data_t hd;
+
+                hd.data_type = SAI_HEALTH_DATA_TYPE_GENERAL;
+
+                sai_u8_list_t desc;
+                desc.count = 0;
+                desc.list = NULL;
+
+                sn.on_switch_asic_sdk_health_event(
+                        0x1,
+                        SAI_SWITCH_ASIC_SDK_HEALTH_SEVERITY_NOTICE,
+                        timespec,
+                        SAI_SWITCH_ASIC_SDK_HEALTH_CATEGORY_SW,
+                        hd,
+                        desc);
+            }
+            else
+            {
+                SWSS_LOG_WARN("pointer sn.sn.on_switch_asic_sdk_health_event");
+            }
+            break;
+
+        case SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY:
+
+            if (sn.on_queue_pfc_deadlock)
+            {
+                SWSS_LOG_NOTICE("sending sn.on_queue_pfc_deadlock");
+
+                sai_queue_deadlock_notification_data_t data;
+
+                data.queue_id = 0x2;
+                data.event = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+                data.app_managed_recovery = true;
+
+                sn.on_queue_pfc_deadlock(1, &data);
+            }
+            else
+            {
+                SWSS_LOG_WARN("pointer sn.on_port_host_tx_readyis NULL");
+            }
+            break;
+
+        case SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY:
+
+            if (sn.on_bfd_session_state_change)
+            {
+                SWSS_LOG_NOTICE("sending sn.on_bfd_session_state_change");
+
+                sai_bfd_session_state_notification_t data;
+
+                data.bfd_session_id = 0x2;
+                data.session_state = SAI_BFD_SESSION_STATE_ADMIN_DOWN;
+
+                sn.on_bfd_session_state_change(1, &data);
+            }
+            else
+            {
+                SWSS_LOG_WARN("pointer sn.on_bfd_session_state_change");
+            }
+            break;
+
+        case SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY:
+
+            if (sn.on_twamp_session_event)
+            {
+                SWSS_LOG_NOTICE("sending sn.on_twamp_session_event");
+
+                sai_twamp_session_event_notification_data_t data;
+
+                data.twamp_session_id = 0x1;
+                data.session_state = SAI_TWAMP_SESSION_STATE_INACTIVE;
+
+                data.session_stats.index = 0;
+                data.session_stats.number_of_counters = 0;
+                data.session_stats.counters_ids = nullptr;
+                data.session_stats.counters = nullptr;
+
+                sn.on_twamp_session_event(1, &data);
+            }
+            else
+            {
+                SWSS_LOG_WARN("pointer sn.on_twamp_session_event");
             }
             break;
 

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -746,6 +746,8 @@ void DummySaiInterface::sendNotification(
                 data.fdb_entry.mac_address[4] = 0x55;
                 data.fdb_entry.mac_address[5] = 0x66;
                 data.fdb_entry.bv_id = 0x2;
+                data.attr_count = 0;
+                data.attr = nullptr;
 
                 sn.on_fdb_event(1, &data);
             }

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -90,7 +90,7 @@ sai_status_t DummySaiInterface::create(
 {
     SWSS_LOG_ENTER();
 
-    // TODO impelement some dummy OID handling
+    // TODO implement some dummy OID handling
 
     if (objectId && m_status == SAI_STATUS_SUCCESS)
     {

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -546,6 +546,14 @@ void DummySaiInterface::updateNotificationPointers(
     {
         auto &attr = attrs[idx];
 
+        auto* meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_SWITCH, attr.id);
+
+        if (meta && meta->attrvaluetype != SAI_ATTR_VALUE_TYPE_POINTER)
+        {
+            // skip non pointers
+            continue;
+        }
+
         switch (attr.id)
         {
             case SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY:
@@ -594,7 +602,7 @@ void DummySaiInterface::updateNotificationPointers(
                 break;
 
             default:
-                SWSS_LOG_ERROR("pointer for attr id %d is not handled, FIXME!", attr.id);
+                SWSS_LOG_ERROR("pointer for attr id %d (%s) is not handled, FIXME!", attr.id, (meta ? meta->attridname : "UNKNOWN"));
                 continue;
         }
     }

--- a/meta/DummySaiInterface.h
+++ b/meta/DummySaiInterface.h
@@ -245,6 +245,8 @@ namespace saimeta
             sai_status_t enqueueNotificationToSend(
                     _In_ sai_attr_id_t id);
 
+        protected:
+
             /**
              * @brief Try get notification to send.
              *

--- a/meta/DummySaiInterface.h
+++ b/meta/DummySaiInterface.h
@@ -3,6 +3,9 @@
 #include "SaiInterface.h"
 
 #include <memory>
+#include <thread>
+#include <mutex>
+#include <queue>
 
 namespace saimeta
 {
@@ -18,7 +21,7 @@ namespace saimeta
 
             DummySaiInterface();
 
-            virtual ~DummySaiInterface() = default;
+            virtual ~DummySaiInterface();
 
         public:
 
@@ -222,6 +225,48 @@ namespace saimeta
                     _In_ uint32_t count,
                     _In_ const sai_attribute_t* attrs);
 
+        public:
+
+            /**
+             * @brief Will start sending notifications
+             */
+            sai_status_t start();
+
+            /**
+             * @brief Will stop sending notifications
+             */
+            sai_status_t stop();
+
+            /**
+             * @brief Enqueue notification to send. Will send specific dummy
+             * notification from notifications thread.
+             */
+
+            sai_status_t enqueueNotificationToSend(
+                    _In_ sai_attr_id_t id);
+
+            /**
+             * @brief Try get notification to send.
+             *
+             * If notification queue is not empty, it will return true and
+             * set id to attribute of notification.
+             */
+            bool tryGetNotificationToSend(
+                    _Out_ sai_attr_id_t& id);
+
+            /**
+             * @brief Send notification.
+             *
+             * Will actually send notification if expected pointer for
+             * notification is not null.
+             */
+            void sendNotification(
+                    _In_ sai_attr_id_t id);
+
+        protected:
+
+            void run();
+
         protected:
 
             sai_switch_notifications_t m_sn;
@@ -229,5 +274,16 @@ namespace saimeta
             sai_status_t m_status;
 
             bool m_apiInitialized;
+
+            /**
+             * @brief Thread that will be used to send notifications
+             */
+            std::shared_ptr<std::thread> m_thread;
+
+            std::mutex m_mutex;
+
+            bool m_runThread;
+
+            std::queue<sai_attr_id_t> m_queue;
     };
 }

--- a/meta/DummySaiInterface.h
+++ b/meta/DummySaiInterface.h
@@ -218,6 +218,16 @@ namespace saimeta
 
         protected:
 
+            void updateNotificationPointers(
+                    _In_ uint32_t count,
+                    _In_ const sai_attribute_t* attrs);
+
+        protected:
+
+            sai_switch_notifications_t m_sn;
+
             sai_status_t m_status;
+
+            bool m_apiInitialized;
     };
 }

--- a/meta/Makefile.am
+++ b/meta/Makefile.am
@@ -50,6 +50,7 @@ libsaimeta_la_SOURCES = \
 				SaiObjectCollection.cpp \
 				SaiSerialize.cpp \
 				SelectableChannel.cpp \
+				DummySaiInterface.cpp \
 				ZeroMQSelectableChannel.cpp
 
 libsaimeta_la_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)

--- a/proxylib/Makefile.am
+++ b/proxylib/Makefile.am
@@ -5,6 +5,7 @@ lib_LTLIBRARIES = libsaiproxy.la
 noinst_LIBRARIES = libSaiProxy.a
 
 libSaiProxy_a_SOURCES = \
+						 Options.cpp \
 						 Proxy.cpp \
 						 Sai.cpp
 

--- a/proxylib/Options.cpp
+++ b/proxylib/Options.cpp
@@ -1,0 +1,30 @@
+#include "Options.h"
+
+#include "swss/logger.h"
+
+#include <sstream>
+
+using namespace saiproxy;
+
+Options::Options()
+{
+    SWSS_LOG_ENTER();
+
+    m_config = "config.ini";
+
+    m_zmqChannel = "tcp://127.0.0.1:5555";
+    m_zmqNtfChannel = "tcp://127.0.0.1:5556";
+}
+
+std::string Options::getString() const
+{
+    SWSS_LOG_ENTER();
+
+    std::stringstream ss;
+
+    ss << " Config=" << m_config;
+    ss << " ZmqChannel=" << m_zmqChannel;
+    ss << " ZmqNtfChannel=" << m_zmqChannel;
+
+    return ss.str();
+}

--- a/proxylib/Options.cpp
+++ b/proxylib/Options.cpp
@@ -24,7 +24,7 @@ std::string Options::getString() const
 
     ss << " Config=" << m_config;
     ss << " ZmqChannel=" << m_zmqChannel;
-    ss << " ZmqNtfChannel=" << m_zmqChannel;
+    ss << " ZmqNtfChannel=" << m_zmqNtfChannel;
 
     return ss.str();
 }

--- a/proxylib/Options.h
+++ b/proxylib/Options.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+namespace saiproxy
+{
+    class Options
+    {
+        public:
+
+            Options();
+
+            ~Options() = default;
+
+        public:
+
+            std::string getString() const;
+
+        public:
+
+            std::string m_config;
+            std::string m_zmqChannel;
+            std::string m_zmqNtfChannel;
+    };
+}

--- a/proxylib/Proxy.cpp
+++ b/proxylib/Proxy.cpp
@@ -1362,7 +1362,7 @@ void Proxy::sendNotification(
 
     swss::KeyOpFieldsValuesTuple item(op, data, entry);
 
-    SWSS_LOG_WARN("%s %s", op.c_str(), data.c_str());
+    SWSS_LOG_INFO("%s %s", op.c_str(), data.c_str());
 
     m_notificationsSentCount++;
 

--- a/proxylib/Proxy.cpp
+++ b/proxylib/Proxy.cpp
@@ -10,6 +10,8 @@
 
 #include "syncd/ZeroMQNotificationProducer.h"
 
+#include <inttypes.h>
+
 #include <iterator>
 #include <algorithm>
 
@@ -33,7 +35,8 @@ Proxy::Proxy(
         _In_ std::shared_ptr<Options> options):
     m_vendorSai(vendorSai),
     m_options(options),
-    m_apiInitialized(false)
+    m_apiInitialized(false),
+    m_notificationsSentCount(0)
 {
     SWSS_LOG_ENTER();
 
@@ -48,6 +51,21 @@ Proxy::Proxy(
     m_smt.profileGetNextValue = std::bind(&Proxy::profileGetNextValue, this, _1, _2, _3);
 
     m_test_services = m_smt.getServiceMethodTable();
+
+    memset(&m_sn, 0, sizeof(m_sn));
+
+    m_swNtf.onFdbEvent = std::bind(&Proxy::onFdbEvent, this, _1, _2);
+    m_swNtf.onNatEvent = std::bind(&Proxy::onNatEvent, this, _1, _2);
+    m_swNtf.onPortStateChange = std::bind(&Proxy::onPortStateChange, this, _1, _2);
+    m_swNtf.onQueuePfcDeadlock = std::bind(&Proxy::onQueuePfcDeadlock, this, _1, _2);
+    m_swNtf.onSwitchAsicSdkHealthEvent = std::bind(&Proxy::onSwitchAsicSdkHealthEvent, this, _1, _2, _3, _4, _5, _6);
+    m_swNtf.onSwitchShutdownRequest = std::bind(&Proxy::onSwitchShutdownRequest, this, _1);
+    m_swNtf.onSwitchStateChange = std::bind(&Proxy::onSwitchStateChange, this, _1, _2);
+    m_swNtf.onBfdSessionStateChange = std::bind(&Proxy::onBfdSessionStateChange, this, _1, _2);
+    m_swNtf.onPortHostTxReady = std::bind(&Proxy::onPortHostTxReady, this, _1, _2, _3);
+    m_swNtf.onTwampSessionEvent = std::bind(&Proxy::onTwampSessionEvent, this, _1, _2);
+
+    m_sn = m_swNtf.getSwitchNotifications();
 
     sai_status_t status = m_vendorSai->apiInitialize(0, &m_test_services);
 
@@ -377,12 +395,10 @@ void Proxy::processCreate(
     if (metaKey.objecttype == SAI_OBJECT_TYPE_SWITCH)
     {
         /*
-         * TODO: translate notification pointers
          * TODO: must be done per switch, and switch may not exists yet
          */
 
-        // TODO
-        // m_handler->updateNotificationsPointers(attr_count, attr_list);
+        updateAttributteNotificationPointers(attr_count, attr_list);
     }
 
     sai_object_id_t newObjectId = SAI_NULL_OBJECT_ID;;
@@ -455,12 +471,10 @@ void Proxy::processSet(
     if (metaKey.objecttype == SAI_OBJECT_TYPE_SWITCH)
     {
         /*
-         * TODO: translate notification pointers
          * TODO: must be done per switch, and switch may not exists yet
          */
 
-        // TODO
-        // m_handler->updateNotificationsPointers(attr_count, attr_list);
+        updateAttributteNotificationPointers(1, attr_list);
     }
 
     sai_status_t status = m_vendorSai->set(metaKey, attr_list);
@@ -1059,4 +1073,293 @@ void Proxy::processClearStats(
     std::string strStatus = sai_serialize_status(status);
 
     m_selectableChannel->set(strStatus, entry, "clear_stats_response");
+}
+
+// TODO replace this method with with new SAI submodule for:
+// sai_metadata_update_switch_notification_pointers
+
+void Proxy::updateAttributteNotificationPointers(
+        _In_ uint32_t count,
+        _Inout_ sai_attribute_t* attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    for (uint32_t index = 0; index < count; ++index)
+    {
+        sai_attribute_t &attr = attr_list[index];
+
+        auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_SWITCH, attr.id);
+
+        if (meta->attrvaluetype != SAI_ATTR_VALUE_TYPE_POINTER)
+        {
+            continue;
+        }
+
+        /*
+         * Does not matter if pointer is valid or not, we just want the
+         * previous value.
+         */
+
+        sai_pointer_t prev = attr.value.ptr;
+
+        if (prev == NULL)
+        {
+            /*
+             * If pointer is NULL, then fine, let it be.
+             */
+
+            continue;
+        }
+
+        switch (attr.id)
+        {
+            case SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_switch_state_change;
+                break;
+
+            case SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_switch_shutdown_request;
+                break;
+
+            case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_switch_asic_sdk_health_event;
+                break;
+
+            case SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_fdb_event;
+                break;
+
+            case SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_nat_event;
+                break;
+
+            case SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_port_state_change;
+                break;
+
+            case SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_port_host_tx_ready;
+                break;
+
+            case SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_queue_pfc_deadlock;
+                break;
+
+            case SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_bfd_session_state_change;
+                break;
+
+            case SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY:
+                attr.value.ptr = (void*)m_sn.on_twamp_session_event;
+                break;
+
+            default:
+
+                SWSS_LOG_ERROR("pointer for %s is not handled, FIXME!", meta->attridname);
+                continue;
+        }
+
+        // Here we translated pointer, just log it.
+
+        SWSS_LOG_NOTICE("%s: 0x%" PRIx64 " (orch) => 0x%" PRIx64 " (syncd)", meta->attridname, (uint64_t)prev, (uint64_t)attr.value.ptr);
+    }
+}
+
+void Proxy::updateNotificationPointers(
+        _In_ uint32_t count,
+        _In_ const sai_attribute_t* attrs)
+{
+    SWSS_LOG_ENTER();
+
+    // NOTE this is done under mutex
+
+    for (uint32_t idx = 0; idx < count; idx++)
+    {
+        auto &attr = attrs[idx];
+
+        switch (attr.id)
+        {
+            case SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY:
+                m_sn.on_switch_state_change =
+                    (sai_switch_state_change_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
+                m_sn.on_switch_asic_sdk_health_event =
+                    (sai_switch_asic_sdk_health_event_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY:
+                m_sn.on_switch_shutdown_request =
+                    (sai_switch_shutdown_request_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY:
+                m_sn.on_fdb_event =
+                    (sai_fdb_event_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY:
+                m_sn.on_port_state_change =
+                    (sai_port_state_change_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY:
+                m_sn.on_port_host_tx_ready =
+                    (sai_port_host_tx_ready_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_PACKET_EVENT_NOTIFY:
+                m_sn.on_packet_event =
+                    (sai_packet_event_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY:
+                m_sn.on_queue_pfc_deadlock =
+                    (sai_queue_pfc_deadlock_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY:
+                m_sn.on_bfd_session_state_change =
+                    (sai_bfd_session_state_change_notification_fn)attr.value.ptr;
+                break;
+
+            default:
+                SWSS_LOG_ERROR("pointer for attr id %d is not handled, FIXME!", attr.id);
+                continue;
+        }
+    }
+}
+
+// TODO move to notification handler class
+
+void Proxy::onFdbEvent(
+        _In_ uint32_t count,
+        _In_ const sai_fdb_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    std::string s = sai_serialize_fdb_event_ntf(count, data);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT, s);
+}
+
+void Proxy::onNatEvent(
+        _In_ uint32_t count,
+        _In_ const sai_nat_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    std::string s = sai_serialize_nat_event_ntf(count, data);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_NAT_EVENT, s);
+}
+
+void Proxy::onPortStateChange(
+        _In_ uint32_t count,
+        _In_ const sai_port_oper_status_notification_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    auto s = sai_serialize_port_oper_status_ntf(count, data);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_PORT_STATE_CHANGE, s);
+}
+
+void Proxy::onPortHostTxReady(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_id_t port_id,
+        _In_ sai_port_host_tx_ready_status_t host_tx_ready_status)
+{
+    SWSS_LOG_ENTER();
+
+    auto s = sai_serialize_port_host_tx_ready_ntf(switch_id, port_id, host_tx_ready_status);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_PORT_HOST_TX_READY, s);
+}
+
+void Proxy::onQueuePfcDeadlock(
+        _In_ uint32_t count,
+        _In_ const sai_queue_deadlock_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    auto s = sai_serialize_queue_deadlock_ntf(count, data);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_QUEUE_PFC_DEADLOCK, s);
+}
+
+void Proxy::onSwitchShutdownRequest(
+        _In_ sai_object_id_t switch_id)
+{
+    SWSS_LOG_ENTER();
+
+    auto s = sai_serialize_switch_shutdown_request(switch_id);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_SWITCH_SHUTDOWN_REQUEST, s);
+}
+
+void Proxy::onSwitchAsicSdkHealthEvent(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    std::string s = sai_serialize_switch_asic_sdk_health_event(switch_id, severity, timestamp, category, data, description);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_SWITCH_ASIC_SDK_HEALTH_EVENT, s);
+}
+
+void Proxy::onSwitchStateChange(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_oper_status_t switch_oper_status)
+{
+    SWSS_LOG_ENTER();
+
+    auto s = sai_serialize_switch_oper_status(switch_id, switch_oper_status);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_SWITCH_STATE_CHANGE, s);
+}
+
+void Proxy::onBfdSessionStateChange(
+        _In_ uint32_t count,
+        _In_ const sai_bfd_session_state_notification_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    std::string s = sai_serialize_bfd_session_state_ntf(count, data);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_BFD_SESSION_STATE_CHANGE, s);
+}
+
+void Proxy::onTwampSessionEvent(
+        _In_ uint32_t count,
+        _In_ const sai_twamp_session_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    std::string s = sai_serialize_twamp_session_event_ntf(count, data);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_TWAMP_SESSION_EVENT, s);
+}
+
+void Proxy::sendNotification(
+        _In_ const std::string& op,
+        _In_ const std::string& data)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<swss::FieldValueTuple> entry;
+
+    swss::KeyOpFieldsValuesTuple item(op, data, entry);
+
+    SWSS_LOG_WARN("%s %s", op.c_str(), data.c_str());
+
+    m_notificationsSentCount++;
+
+    m_notifications->send(op, data, entry);
 }

--- a/proxylib/Proxy.cpp
+++ b/proxylib/Proxy.cpp
@@ -1177,6 +1177,8 @@ void Proxy::updateNotificationPointers(
     {
         auto &attr = attrs[idx];
 
+        auto* meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_SWITCH, attr.id);
+
         switch (attr.id)
         {
             case SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY:
@@ -1225,7 +1227,7 @@ void Proxy::updateNotificationPointers(
                 break;
 
             default:
-                SWSS_LOG_ERROR("pointer for attr id %d is not handled, FIXME!", attr.id);
+                SWSS_LOG_ERROR("pointer for attr id %d (%s) is not handled, FIXME!", attr.id, (meta ? meta->attridname : "UNKNOWN"));
                 continue;
         }
     }
@@ -1362,4 +1364,11 @@ void Proxy::sendNotification(
     m_notificationsSentCount++;
 
     m_notifications->send(op, data, entry);
+}
+
+uint64_t Proxy::getNotificationsSentCount() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_notificationsSentCount;
 }

--- a/proxylib/Proxy.cpp
+++ b/proxylib/Proxy.cpp
@@ -1165,6 +1165,9 @@ void Proxy::updateAttributteNotificationPointers(
     }
 }
 
+// TODO replace this method with with new SAI submodule for:
+// sai_metadata_update_switch_notification_pointers
+
 void Proxy::updateNotificationPointers(
         _In_ uint32_t count,
         _In_ const sai_attribute_t* attrs)

--- a/proxylib/Proxy.h
+++ b/proxylib/Proxy.h
@@ -8,6 +8,8 @@
 #include "syncd/ServiceMethodTable.h"
 #include "syncd/NotificationProducerBase.h"
 
+#include "Options.h"
+
 #include <map>
 #include <memory>
 #include <thread>
@@ -21,6 +23,10 @@ namespace saiproxy
 
             Proxy(
                     _In_ std::shared_ptr<sairedis::SaiInterface> vendorSai);
+
+            Proxy(
+                    _In_ std::shared_ptr<sairedis::SaiInterface> vendorSai,
+                    _In_ std::shared_ptr<Options> options);
 
             virtual ~Proxy();
 
@@ -121,7 +127,7 @@ namespace saiproxy
 
             std::shared_ptr<syncd::NotificationProducerBase> m_notifications;
 
-            std::string m_configFile;
+            std::shared_ptr<Options> m_options;
 
             /**
              * @brief Mutex for synchronizing api execution and notifications

--- a/proxylib/Proxy.h
+++ b/proxylib/Proxy.h
@@ -203,6 +203,12 @@ namespace saiproxy
 
             syncd::SwitchNotifications m_swNtf;
 
+            /**
+             * @brief Notifications sent count.
+             *
+             * This value can be used to write unittests when testing
+             * notifications.
+             */
             uint64_t m_notificationsSentCount;
     };
 }

--- a/proxylib/Proxy.h
+++ b/proxylib/Proxy.h
@@ -168,6 +168,10 @@ namespace saiproxy
                     _In_ uint32_t count,
                     _Inout_ sai_attribute_t* attr_list);
 
+        public:
+
+            uint64_t getNotificationsSentCount() const;
+
         private:
 
             syncd::ServiceMethodTable m_smt;

--- a/proxylib/Proxy.h
+++ b/proxylib/Proxy.h
@@ -7,6 +7,7 @@
 
 #include "syncd/ServiceMethodTable.h"
 #include "syncd/NotificationProducerBase.h"
+#include "syncd/SwitchNotifications.h"
 
 #include "Options.h"
 
@@ -105,9 +106,67 @@ namespace saiproxy
             void processClearStats(
                     _In_ const swss::KeyOpFieldsValuesTuple &kco);
 
+        private: // notifications
+
+            void onFdbEvent(
+                    _In_ uint32_t count,
+                    _In_ const sai_fdb_event_notification_data_t *data);
+
+            void onNatEvent(
+                    _In_ uint32_t count,
+                    _In_ const sai_nat_event_notification_data_t *data);
+
+            void onPortStateChange(
+                    _In_ uint32_t count,
+                    _In_ const sai_port_oper_status_notification_t *data);
+
+            void onPortHostTxReady(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_id_t port_id,
+                    _In_ sai_port_host_tx_ready_status_t host_tx_ready_status);
+
+            void onQueuePfcDeadlock(
+                    _In_ uint32_t count,
+                    _In_ const sai_queue_deadlock_notification_data_t *data);
+
+            void onSwitchShutdownRequest(
+                    _In_ sai_object_id_t switch_id);
+
+            void onSwitchAsicSdkHealthEvent(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_switch_asic_sdk_health_severity_t severity,
+                    _In_ sai_timespec_t timestamp,
+                    _In_ sai_switch_asic_sdk_health_category_t category,
+                    _In_ sai_switch_health_data_t data,
+                    _In_ const sai_u8_list_t description);
+
+            void onSwitchStateChange(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_switch_oper_status_t switch_oper_status);
+
+            void onBfdSessionStateChange(
+                    _In_ uint32_t count,
+                    _In_ const sai_bfd_session_state_notification_t *data);
+
+            void onTwampSessionEvent(
+                    _In_ uint32_t count,
+                    _In_ const sai_twamp_session_event_notification_data_t *data);
+
+            void sendNotification(
+                    _In_ const std::string& op,
+                    _In_ const std::string& data);
+
         private:
 
             void loadProfileMap();
+
+            void updateNotificationPointers(
+                    _In_ uint32_t count,
+                    _In_ const sai_attribute_t* attrs);
+
+            void updateAttributteNotificationPointers(
+                    _In_ uint32_t count,
+                    _Inout_ sai_attribute_t* attr_list);
 
         private:
 
@@ -135,5 +194,11 @@ namespace saiproxy
             std::mutex m_mutex;
 
             bool m_apiInitialized;
+
+            sai_switch_notifications_t m_sn;
+
+            syncd::SwitchNotifications m_swNtf;
+
+            uint64_t m_notificationsSentCount;
     };
 }

--- a/proxylib/Sai.cpp
+++ b/proxylib/Sai.cpp
@@ -20,6 +20,8 @@ using namespace std::placeholders;
         SWSS_LOG_ERROR("entry pointer " # pointer " is null");              \
         return SAI_STATUS_INVALID_PARAMETER; }
 
+// TODO add support for notifications
+
 Sai::Sai()
 {
     SWSS_LOG_ENTER();
@@ -71,11 +73,13 @@ sai_status_t Sai::apiInitialize(
 
     memcpy(&m_service_method_table, service_method_table, sizeof(m_service_method_table));
 
-    // TODO move hard coded values to config
+    m_options = std::make_shared<Options>(); // load default options
+
+    // TODO options should be obtained from service method table
 
     m_communicationChannel = std::make_shared<sairedis::ZeroMQChannel>(
-            "tcp://127.0.0.1:5555",
-            "tcp://127.0.0.1:5556",
+            m_options->m_zmqChannel,
+            m_options->m_zmqNtfChannel,
             std::bind(&Sai::handleNotification, this, _1, _2, _3));
 
     m_apiInitialized = true;
@@ -89,6 +93,8 @@ sai_status_t Sai::apiUninitialize(void)
     PROXY_CHECK_API_INITIALIZED();
 
     SWSS_LOG_NOTICE("begin");
+
+    m_communicationChannel = nullptr; // will stop the thread
 
     m_apiInitialized = false;
 
@@ -1109,7 +1115,7 @@ void Sai::handleNotification(
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_ERROR("FIXME");
+    SWSS_LOG_ERROR("not implemented, FIXME");
 }
 
 //sai_switch_notifications_t Sai::handle_notification(

--- a/proxylib/Sai.cpp
+++ b/proxylib/Sai.cpp
@@ -1115,7 +1115,7 @@ void Sai::handleNotification(
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_ERROR("not implemented, FIXME");
+    SWSS_LOG_ERROR("SAI: not implemented, FIXME");
 }
 
 //sai_switch_notifications_t Sai::handle_notification(

--- a/proxylib/Sai.cpp
+++ b/proxylib/Sai.cpp
@@ -3,6 +3,7 @@
 #include "SaiInternal.h"
 #include "ZeroMQChannel.h"
 #include "SaiAttributeList.h"
+#include "NotificationFactory.h"
 
 #include "meta/Meta.h"
 #include "meta/sai_serialize.h"
@@ -19,8 +20,6 @@ using namespace std::placeholders;
     if ((pointer) == nullptr) {                                             \
         SWSS_LOG_ERROR("entry pointer " # pointer " is null");              \
         return SAI_STATUS_INVALID_PARAMETER; }
-
-// TODO add support for notifications
 
 Sai::Sai()
 {
@@ -72,6 +71,8 @@ sai_status_t Sai::apiInitialize(
     }
 
     memcpy(&m_service_method_table, service_method_table, sizeof(m_service_method_table));
+
+    memset(&m_sn, 0, sizeof(m_sn));
 
     m_options = std::make_shared<Options>(); // load default options
 
@@ -132,10 +133,13 @@ sai_status_t Sai::create(
 
     auto status = m_communicationChannel->wait("create_response", kco);
 
-    // TODO SAVE pointers for notifications
-
     if (status == SAI_STATUS_SUCCESS)
     {
+        if (objectType == SAI_OBJECT_TYPE_SWITCH)
+        {
+            updateNotifications(attr_count, attr_list); // TODO should be per switch
+        }
+
         auto& values = kfvFieldsValues(kco);
 
         if (values.size() == 0)
@@ -273,8 +277,6 @@ sai_status_t Sai::create(
 
     std::string key = serializedObjectType + ":" + entry;
 
-    // TODO SAVE pointers for notifications
-
     m_communicationChannel->set(key, vals, "create_entry");
 
     swss::KeyOpFieldsValuesTuple kco;
@@ -308,8 +310,6 @@ sai_status_t Sai::set(
 
     auto val = saimeta::SaiAttributeList::serialize_attr_list(objectType, 1, attr, false);
 
-    // TODO SAVE pointers for notifications
-
     auto serializedObjectType = sai_serialize_object_type(objectType);
 
     std::string key = serializedObjectType + ":" + entry;
@@ -318,7 +318,14 @@ sai_status_t Sai::set(
 
     swss::KeyOpFieldsValuesTuple kco;
 
-    return m_communicationChannel->wait("set_response", kco);
+    auto status = m_communicationChannel->wait("set_response", kco);
+
+    if (objectType == SAI_OBJECT_TYPE_SWITCH && status == SAI_STATUS_SUCCESS)
+    {
+        updateNotifications(1, attr);
+    }
+
+    return status;
 }
 
 sai_status_t Sai::get(
@@ -1108,47 +1115,115 @@ sai_status_t Sai::queryApiVersion(
     return status;
 }
 
+// TODO use function from SAI metadata to populate those
+
+void Sai::updateNotifications(
+        _In_ uint32_t attrCount,
+        _In_ const sai_attribute_t *attrList)
+{
+    SWSS_LOG_ENTER();
+
+    /*
+     * This function should only be called on CREATE/SET
+     * api when object is SWITCH.
+     */
+
+    for (uint32_t index = 0; index < attrCount; ++index)
+    {
+        auto &attr = attrList[index];
+
+        auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_SWITCH, attr.id);
+
+        if (meta == NULL)
+            SWSS_LOG_THROW("failed to find metadata for switch attr %d", attr.id);
+
+        if (meta->attrvaluetype != SAI_ATTR_VALUE_TYPE_POINTER)
+            continue;
+
+        switch (attr.id)
+        {
+            case SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY:
+                m_sn.on_switch_state_change =
+                    (sai_switch_state_change_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
+                m_sn.on_switch_asic_sdk_health_event =
+                    (sai_switch_asic_sdk_health_event_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY:
+                m_sn.on_switch_shutdown_request =
+                    (sai_switch_shutdown_request_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY:
+                m_sn.on_fdb_event =
+                    (sai_fdb_event_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY:
+                m_sn.on_nat_event =
+                    (sai_nat_event_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY:
+                m_sn.on_port_state_change =
+                    (sai_port_state_change_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY:
+                m_sn.on_queue_pfc_deadlock =
+                    (sai_queue_pfc_deadlock_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY:
+                m_sn.on_bfd_session_state_change =
+                    (sai_bfd_session_state_change_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY:
+                m_sn.on_port_host_tx_ready =
+                    (sai_port_host_tx_ready_notification_fn)attr.value.ptr;
+                break;
+
+            case SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY:
+                m_sn.on_twamp_session_event =
+                    (sai_twamp_session_event_notification_fn)attr.value.ptr;
+                break;
+
+            default:
+                SWSS_LOG_ERROR("pointer for %s is not handled, FIXME!", meta->attridname);
+                break;
+        }
+    }
+}
+
 void Sai::handleNotification(
         _In_ const std::string &name,
         _In_ const std::string &serializedNotification,
         _In_ const std::vector<swss::FieldValueTuple> &values)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_ERROR("SAI: not implemented, FIXME");
-}
+    if (!m_apiInitialized)
+    {
+        SWSS_LOG_ERROR("%s: api not initialized", __PRETTY_FUNCTION__);
 
-//sai_switch_notifications_t Sai::handle_notification(
-//        _In_ std::shared_ptr<Notification> notification)
-//{
-//    MUTEX();
-//    SWSS_LOG_ENTER();
-//
-//    if (!m_apiInitialized)
-//    {
-//        SWSS_LOG_ERROR("%s: api not initialized", __PRETTY_FUNCTION__);
-//
-//        return { };
-//    }
-//
-//    return context->m_redisSai->syncProcessNotification(notification);
-//}
-//
-//void Sai::handleNotification(
-//        _In_ const std::string &name,
-//        _In_ const std::string &serializedNotification,
-//        _In_ const std::vector<swss::FieldValueTuple> &values)
-//{
-//    SWSS_LOG_ENTER();
-//
-//    auto notification = NotificationFactory::deserialize(name, serializedNotification);
-//
-//    if (notification)
-//    {
-//        auto _sn = m_notificationCallback(notification); // will be synchronized to api mutex
-//
-//        // execute callback from notification thread
-//
-//        notification->executeCallback(_sn);
-//    }
-//}
+        return;
+    }
+
+    // TODO should be per switch, and we should know on which switch call notification
+
+    auto notification = sairedis::NotificationFactory::deserialize(name, serializedNotification);
+
+    if (notification)
+    {
+        SWSS_LOG_INFO("got notification: %s, executing callback!", serializedNotification.c_str());
+
+        // execute callback from notification thread
+
+        notification->executeCallback(m_sn);
+    }
+}

--- a/proxylib/Sai.h
+++ b/proxylib/Sai.h
@@ -215,13 +215,17 @@ namespace saiproxy
 
         private:
 
-            sai_switch_notifications_t handle_notification(
-                    _In_ std::shared_ptr<sairedis::Notification> notification);
+            //sai_switch_notifications_t handle_notification(
+            //        _In_ std::shared_ptr<sairedis::Notification> notification);
 
             void handleNotification(
                     _In_ const std::string &name,
                     _In_ const std::string &serializedNotification,
                     _In_ const std::vector<swss::FieldValueTuple> &values);
+
+            void updateNotifications(
+                    _In_ uint32_t attrCount,
+                    _In_ const sai_attribute_t *attrList);
 
         private:
 
@@ -233,8 +237,10 @@ namespace saiproxy
 
             std::shared_ptr<sairedis::Channel> m_communicationChannel;
 
-            std::function<sai_switch_notifications_t(std::shared_ptr<sairedis::Notification>)> m_notificationCallback;
+            //std::function<sai_switch_notifications_t(std::shared_ptr<sairedis::Notification>)> m_notificationCallback;
 
             std::shared_ptr<Options> m_options;
+
+            sai_switch_notifications_t m_sn;
     };
 }

--- a/proxylib/Sai.h
+++ b/proxylib/Sai.h
@@ -8,6 +8,8 @@
 
 #include "swss/logger.h"
 
+#include "Options.h"
+
 #include <string>
 #include <vector>
 #include <memory>
@@ -232,5 +234,7 @@ namespace saiproxy
             std::shared_ptr<sairedis::Channel> m_communicationChannel;
 
             std::function<sai_switch_notifications_t(std::shared_ptr<sairedis::Notification>)> m_notificationCallback;
+
+            std::shared_ptr<Options> m_options;
     };
 }

--- a/proxylib/saiproxy.h
+++ b/proxylib/saiproxy.h
@@ -1,0 +1,9 @@
+#pragma once
+
+/**
+ * @brief Proxy config.
+ *
+ * Optional. Should point to a config.ini/profile.ini which will contain
+ * profile variables that should be put into service method table.
+ */
+#define SAI_PROXY_KEY_CONFIG              "SAI_PROXY_CONFIG

--- a/stub.pl
+++ b/stub.pl
@@ -270,7 +270,7 @@ sub CreateApiStricts()
             Write "";
         }
 
-        Write "const sai_${api}_api_t ${STUB}_${api} = {";
+        Write "static const sai_${api}_api_t ${STUB}_${api} = {";
 
         while ($struct =~ /(sai_\w+_fn)\s+(\w+)/gms)
         {

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -475,3 +475,5 @@ ZMQ
 uncreated
 TWAMP
 saiproxy
+submodule
+Enqueue

--- a/unittest/meta/Makefile.am
+++ b/unittest/meta/Makefile.am
@@ -6,7 +6,6 @@ LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
 
 tests_SOURCES = \
 				main.cpp \
-				../../meta/DummySaiInterface.cpp \
 				../../meta/MetaTestSaiInterface.cpp \
 				../../lib/VirtualObjectIdManager.cpp \
 				../../lib/SwitchConfig.cpp \

--- a/unittest/meta/TestDummySaiInterface.cpp
+++ b/unittest/meta/TestDummySaiInterface.cpp
@@ -51,3 +51,22 @@ TEST(DummySaiInterface, create)
 
     EXPECT_NE(oid, SAI_NULL_OBJECT_ID);
 }
+
+TEST(DummySaiInterface, updateNotificationPointers)
+{
+    DummySaiInterface sai;
+
+    sai.apiInitialize(0,0);
+
+    for (uint32_t idx = 0 ; idx < sai_metadata_switch_notify_attr_count; idx++)
+    {
+        sai_attribute_t attr;
+
+        attr.id = sai_metadata_switch_notify_attr[idx]->attrid;
+        attr.value.ptr = NULL;
+
+        auto status = sai.set(SAI_OBJECT_TYPE_SWITCH, 0x0, &attr);
+
+        EXPECT_EQ(status, SAI_STATUS_SUCCESS);
+    }
+}

--- a/unittest/meta/TestDummySaiInterface.cpp
+++ b/unittest/meta/TestDummySaiInterface.cpp
@@ -137,6 +137,77 @@ static void onSwitchShutdownRequest(
     ntfCounter++;
 }
 
+static void onNatEvent(
+        _In_ uint32_t count,
+        _In_ const sai_nat_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onNatEvent");
+
+    ntfCounter++;
+}
+
+static void onPortHostTxReady(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_id_t port_id,
+        _In_ sai_port_host_tx_ready_status_t host_tx_ready_status)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onPortHostTxReady");
+
+    ntfCounter++;
+}
+
+static void onQueuePfcDeadlock(
+        _In_ uint32_t count,
+        _In_ const sai_queue_deadlock_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onQueuePfcDeadlock");
+
+    ntfCounter++;
+}
+
+static void onSwitchAsicSdkHealthEvent(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onSwitchAsicSdkHealthEvent");
+
+    ntfCounter++;
+}
+
+static void onBfdSessionStateChange(
+        _In_ uint32_t count,
+        _In_ const sai_bfd_session_state_notification_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onBfdSessionStateChange");
+
+    ntfCounter++;
+}
+
+void onTwampSessionEvent(
+        _In_ uint32_t count,
+        _In_ const sai_twamp_session_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onTwampSessionEvent");
+
+    ntfCounter++;
+}
+
 TEST(DummySaiInterface, sendNotification)
 {
     DummySaiInterface sai;
@@ -149,6 +220,11 @@ TEST(DummySaiInterface, sendNotification)
     EXPECT_EQ(sai.apiInitialize(0,0), SAI_STATUS_SUCCESS);
 
     EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
 
     EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
     EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
@@ -157,21 +233,48 @@ TEST(DummySaiInterface, sendNotification)
 
     sai_attribute_t attr;
 
+    sai_object_id_t switch_id = 0x1;
+
     attr.id = SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY;
     attr.value.ptr = (void*)&onSwitchStateChange;
-    sai.set(SAI_OBJECT_TYPE_SWITCH, 0x1, &attr);
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
 
     attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
     attr.value.ptr = (void*)&onFdbEvent;
-    sai.set(SAI_OBJECT_TYPE_SWITCH, 0x1, &attr);
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
 
     attr.id = SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY;
     attr.value.ptr = (void*)&onPortStateChange;
-    sai.set(SAI_OBJECT_TYPE_SWITCH, 0x1, &attr);
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
 
     attr.id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
     attr.value.ptr = (void*)&onSwitchShutdownRequest;
-    sai.set(SAI_OBJECT_TYPE_SWITCH, 0x1, &attr);
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+
+    attr.id = SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onSwitchAsicSdkHealthEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onNatEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY;
+    attr.value.ptr = (void*)&onPortHostTxReady;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY;
+    attr.value.ptr = (void*)&onQueuePfcDeadlock;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY;
+    attr.value.ptr = (void*)&onBfdSessionStateChange;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onTwampSessionEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
 
     EXPECT_EQ(sai.start(), SAI_STATUS_SUCCESS);
 
@@ -179,5 +282,5 @@ TEST(DummySaiInterface, sendNotification)
 
     EXPECT_EQ(sai.stop(), SAI_STATUS_SUCCESS);
 
-    EXPECT_EQ(ntfCounter, 4);
+    EXPECT_EQ(ntfCounter, 4 + 6);
 }

--- a/unittest/meta/TestDummySaiInterface.cpp
+++ b/unittest/meta/TestDummySaiInterface.cpp
@@ -1,5 +1,7 @@
 #include "DummySaiInterface.h"
 
+#include "swss/logger.h"
+
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -69,4 +71,113 @@ TEST(DummySaiInterface, updateNotificationPointers)
 
         EXPECT_EQ(status, SAI_STATUS_SUCCESS);
     }
+}
+
+TEST(DummySaiInterface, start_stop)
+{
+    DummySaiInterface sai;
+
+    EXPECT_EQ(sai.start(), SAI_STATUS_FAILURE); // api not initialized
+
+    EXPECT_EQ(sai.apiInitialize(0,0), SAI_STATUS_SUCCESS);
+
+    EXPECT_EQ(sai.stop(), SAI_STATUS_SUCCESS); // not running
+
+    EXPECT_EQ(sai.start(), SAI_STATUS_SUCCESS); // api initialized
+
+    EXPECT_EQ(sai.start(), SAI_STATUS_SUCCESS); // 2nd time is ok to start, already running
+
+    sleep(1);
+
+    EXPECT_EQ(sai.stop(), SAI_STATUS_SUCCESS);
+}
+
+static int ntfCounter = 0;
+
+static void onSwitchStateChange(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_oper_status_t switch_oper_status)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received onSwitchStateChange");
+
+    ntfCounter++;
+}
+
+static void onFdbEvent(
+        _In_ uint32_t count,
+        _In_ const sai_fdb_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received onFdbEvent");
+
+    ntfCounter++;
+}
+
+static void onPortStateChange(
+        _In_ uint32_t count,
+        _In_ const sai_port_oper_status_notification_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received onPortStateChange");
+
+    ntfCounter++;
+}
+
+static void onSwitchShutdownRequest(
+        _In_ sai_object_id_t switch_id)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onSwitchShutdownRequest");
+
+    ntfCounter++;
+}
+
+TEST(DummySaiInterface, sendNotification)
+{
+    DummySaiInterface sai;
+
+    ntfCounter = 0;
+
+    // api not initialized
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY), SAI_STATUS_FAILURE);
+
+    EXPECT_EQ(sai.apiInitialize(0,0), SAI_STATUS_SUCCESS);
+
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(sai.enqueueNotificationToSend(SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY), SAI_STATUS_SUCCESS);
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY;
+    attr.value.ptr = (void*)&onSwitchStateChange;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, 0x1, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onFdbEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, 0x1, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY;
+    attr.value.ptr = (void*)&onPortStateChange;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, 0x1, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
+    attr.value.ptr = (void*)&onSwitchShutdownRequest;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, 0x1, &attr);
+
+    EXPECT_EQ(sai.start(), SAI_STATUS_SUCCESS);
+
+    sleep(1);
+
+    EXPECT_EQ(sai.stop(), SAI_STATUS_SUCCESS);
+
+    EXPECT_EQ(ntfCounter, 4);
 }

--- a/unittest/proxylib/Makefile.am
+++ b/unittest/proxylib/Makefile.am
@@ -5,7 +5,6 @@ bin_PROGRAMS = tests
 LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
 
 tests_SOURCES = \
-				../../meta/DummySaiInterface.cpp \
 				main.cpp \
 				TestProxy.cpp \
 				TestSai.cpp

--- a/unittest/proxylib/TestProxy.cpp
+++ b/unittest/proxylib/TestProxy.cpp
@@ -71,6 +71,109 @@ static void onSwitchStateChange(
     ntfCounter++;
 }
 
+static void onFdbEvent(
+        _In_ uint32_t count,
+        _In_ const sai_fdb_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received onFdbEvent");
+
+    ntfCounter++;
+}
+
+static void onPortStateChange(
+        _In_ uint32_t count,
+        _In_ const sai_port_oper_status_notification_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received onPortStateChange");
+
+    ntfCounter++;
+}
+
+static void onSwitchShutdownRequest(
+        _In_ sai_object_id_t switch_id)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onSwitchShutdownRequest");
+
+    ntfCounter++;
+}
+
+static void onNatEvent(
+        _In_ uint32_t count,
+        _In_ const sai_nat_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onNatEvent");
+
+    ntfCounter++;
+}
+
+static void onPortHostTxReady(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_id_t port_id,
+        _In_ sai_port_host_tx_ready_status_t host_tx_ready_status)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onPortHostTxReady");
+
+    ntfCounter++;
+}
+
+static void onQueuePfcDeadlock(
+        _In_ uint32_t count,
+        _In_ const sai_queue_deadlock_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onQueuePfcDeadlock");
+
+    ntfCounter++;
+}
+
+static void onSwitchAsicSdkHealthEvent(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onSwitchAsicSdkHealthEvent");
+
+    ntfCounter++;
+}
+
+static void onBfdSessionStateChange(
+        _In_ uint32_t count,
+        _In_ const sai_bfd_session_state_notification_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onBfdSessionStateChange");
+
+    ntfCounter++;
+}
+
+void onTwampSessionEvent(
+        _In_ uint32_t count,
+        _In_ const sai_twamp_session_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onTwampSessionEvent");
+
+    ntfCounter++;
+}
+
 TEST(Proxy, notifications)
 {
     Sai sai;
@@ -82,9 +185,15 @@ TEST(Proxy, notifications)
     auto proxy = std::make_shared<Proxy>(dummy);
 
     EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
-//    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
-//    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
-//    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
 
     auto thread = std::make_shared<std::thread>(fun,proxy);
 
@@ -106,11 +215,47 @@ TEST(Proxy, notifications)
     EXPECT_EQ(status, SAI_STATUS_SUCCESS);
     EXPECT_NE(switch_id, SAI_NULL_OBJECT_ID);
 
+    // set notification pointer
+
     attr.id = SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY;
     attr.value.ptr = (void*)&onSwitchStateChange;
-
-    // set notification pointer
     EXPECT_EQ(sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onFdbEvent;
+    EXPECT_EQ(sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY;
+    attr.value.ptr = (void*)&onPortStateChange;
+    EXPECT_EQ(sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
+    attr.value.ptr = (void*)&onSwitchShutdownRequest;
+    EXPECT_EQ(sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onSwitchAsicSdkHealthEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onNatEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY;
+    attr.value.ptr = (void*)&onPortHostTxReady;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY;
+    attr.value.ptr = (void*)&onQueuePfcDeadlock;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY;
+    attr.value.ptr = (void*)&onBfdSessionStateChange;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onTwampSessionEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
 
     // dummy start sending notifications
     EXPECT_EQ(dummy->start(), SAI_STATUS_SUCCESS);
@@ -120,7 +265,7 @@ TEST(Proxy, notifications)
     // dummy stop sending notifications
     EXPECT_EQ(dummy->stop(), SAI_STATUS_SUCCESS);
 
-    EXPECT_EQ(proxy->getNotificationsSentCount(), 1);
+    EXPECT_EQ(proxy->getNotificationsSentCount(), 4+6);
 
     proxy->stop();
 

--- a/unittest/proxylib/TestProxy.cpp
+++ b/unittest/proxylib/TestProxy.cpp
@@ -163,7 +163,7 @@ static void onBfdSessionStateChange(
     ntfCounter++;
 }
 
-void onTwampSessionEvent(
+static void onTwampSessionEvent(
         _In_ uint32_t count,
         _In_ const sai_twamp_session_event_notification_data_t *data)
 {

--- a/unittest/proxylib/TestSai.cpp
+++ b/unittest/proxylib/TestSai.cpp
@@ -600,3 +600,220 @@ TEST(Sai, clearStats)
     thread->join();
 }
 
+static int ntfCounter = 0;
+
+static void onSwitchStateChange(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_oper_status_t switch_oper_status)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received onSwitchStateChange");
+
+    ntfCounter++;
+}
+
+static void onFdbEvent(
+        _In_ uint32_t count,
+        _In_ const sai_fdb_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received onFdbEvent");
+
+    ntfCounter++;
+}
+
+static void onPortStateChange(
+        _In_ uint32_t count,
+        _In_ const sai_port_oper_status_notification_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received onPortStateChange");
+
+    ntfCounter++;
+}
+
+static void onSwitchShutdownRequest(
+        _In_ sai_object_id_t switch_id)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onSwitchShutdownRequest");
+
+    ntfCounter++;
+}
+
+static void onNatEvent(
+        _In_ uint32_t count,
+        _In_ const sai_nat_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onNatEvent");
+
+    ntfCounter++;
+}
+
+static void onPortHostTxReady(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_id_t port_id,
+        _In_ sai_port_host_tx_ready_status_t host_tx_ready_status)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onPortHostTxReady");
+
+    ntfCounter++;
+}
+
+static void onQueuePfcDeadlock(
+        _In_ uint32_t count,
+        _In_ const sai_queue_deadlock_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onQueuePfcDeadlock");
+
+    ntfCounter++;
+}
+
+static void onSwitchAsicSdkHealthEvent(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onSwitchAsicSdkHealthEvent");
+
+    ntfCounter++;
+}
+
+static void onBfdSessionStateChange(
+        _In_ uint32_t count,
+        _In_ const sai_bfd_session_state_notification_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onBfdSessionStateChange");
+
+    ntfCounter++;
+}
+
+static void onTwampSessionEvent(
+        _In_ uint32_t count,
+        _In_ const sai_twamp_session_event_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onTwampSessionEvent");
+
+    ntfCounter++;
+}
+
+TEST(Sai, handleNotification)
+{
+    Sai sai;
+
+    EXPECT_EQ(sai.apiInitialize(0, &test_services), SAI_STATUS_SUCCESS);
+
+    std::shared_ptr<saimeta::DummySaiInterface> dummy = std::make_shared<saimeta::DummySaiInterface>();
+
+    auto proxy = std::make_shared<Proxy>(dummy);
+
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY), SAI_STATUS_SUCCESS);
+    EXPECT_EQ(dummy->enqueueNotificationToSend(SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY), SAI_STATUS_SUCCESS);
+
+    auto thread = std::make_shared<std::thread>(fun, proxy);
+
+    sai_object_id_t switch_id;
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    // create oid
+    auto status = sai.create(
+            SAI_OBJECT_TYPE_SWITCH,
+            &switch_id,
+            SAI_NULL_OBJECT_ID, // creating switch
+            1,
+            &attr);
+
+    EXPECT_EQ(status, SAI_STATUS_SUCCESS);
+    EXPECT_NE(switch_id, SAI_NULL_OBJECT_ID);
+
+    // set notification pointer
+
+    attr.id = SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY;
+    attr.value.ptr = (void*)&onSwitchStateChange;
+    EXPECT_EQ(sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onFdbEvent;
+    EXPECT_EQ(sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY;
+    attr.value.ptr = (void*)&onPortStateChange;
+    EXPECT_EQ(sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
+    attr.value.ptr = (void*)&onSwitchShutdownRequest;
+    EXPECT_EQ(sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr), SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onSwitchAsicSdkHealthEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onNatEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY;
+    attr.value.ptr = (void*)&onPortHostTxReady;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY;
+    attr.value.ptr = (void*)&onQueuePfcDeadlock;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY;
+    attr.value.ptr = (void*)&onBfdSessionStateChange;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onTwampSessionEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    // dummy start sending notifications
+    EXPECT_EQ(dummy->start(), SAI_STATUS_SUCCESS);
+
+    sleep(1); // give some time for proxy to receive notification
+
+    // dummy stop sending notifications
+    EXPECT_EQ(dummy->stop(), SAI_STATUS_SUCCESS);
+
+    EXPECT_EQ(proxy->getNotificationsSentCount(), 10);
+
+    // important check, whether Sai class processed notifications correctly
+    EXPECT_EQ(ntfCounter, 10);
+
+    proxy->stop();
+
+    thread->join();
+}
+

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -5,7 +5,6 @@ bin_PROGRAMS = tests
 LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
 
 tests_SOURCES = main.cpp \
-                ../../meta/DummySaiInterface.cpp \
                 MockableSaiInterface.cpp \
                 MockHelper.cpp \
 				TestCommandLineOptions.cpp \


### PR DESCRIPTION
This proxy class will be used in DASH application.

This change contains:
* Update DummySaiInterface do support dummy notifications for testing
* DummySaiInterface unittests
* Proxy class support notifications
* Proxy class unittests
* Sai class support notifications
* Sai class unittests
* Added Options class for handy zmq options configuration
* Move DummySaiInterface to saimeta library
* Added TODO which functions should be replaced after SAI submodule update
* Update aspell