### PR TITLE
optimize for best candidate find

### DIFF
--- a/syncd/BestCandidateFinder.cpp
+++ b/syncd/BestCandidateFinder.cpp
@@ -1886,6 +1886,9 @@ std::shared_ptr<SaiObj> BestCandidateFinder::findCurrentBestMatchForGenericObjec
                 soci.equal_attributes);
 
         candidateObjects.push_back(soci);
+        if (soci.equal_attributes == attrs.size()
+            && (object_type == SAI_OBJECT_TYPE_VLAN || object_type == SAI_OBJECT_TYPE_VLAN_MEMBER))
+            break;
     }
 
     SWSS_LOG_INFO("number candidate objects for %s is %zu",


### PR DESCRIPTION
why I did:
    in best candidate, it looking for all items of this type to search
    for the most seamful item, when their is too many vlan member, we
    can wait very long.
what I did:
    since VLAN and VLAN MEMBER is unique, so if we find one with all attr
    matched, we break and do not compare others.