### PR TITLE
after apply_view, use malloc_trim to release memory to system

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -36,6 +36,8 @@
 #include <iterator>
 #include <algorithm>
 
+#include <malloc.h>
+
 #define DEF_SAI_WARM_BOOT_DATA_FILE "/var/warmboot/sai-warmboot.bin"
 #define SAI_FAILURE_DUMP_SCRIPT "/usr/bin/sai_failure_dump.sh"
 
@@ -3872,6 +3874,7 @@ sai_status_t Syncd::processNotifySyncd(
         try
         {
             status = applyView();
+            (void)malloc_trim(0);
         }
         catch(...)
         {


### PR DESCRIPTION
why I did:
    after warm-reboot with all vlan members, syncd use memory up to 1.8g,
    and can not reduce to its normal state.
what I did:
    this come from the glibc behavior, in the main heap, it almost not release
    memory to system, in apply view, huge memory used for compare logic, and
    do not use it again. so I add malloc_trim to release it.