### PR TITLE
Moving SAI failure dump handling above the ignore for non temp view

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -3753,16 +3753,6 @@ sai_status_t Syncd::processNotifySyncd(
 
     auto& key = kfvKey(kco);
     sai_status_t status = SAI_STATUS_SUCCESS;
-
-    if (!m_commandLineOptions->m_enableTempView)
-    {
-        SWSS_LOG_NOTICE("received %s, ignored since TEMP VIEW is not used, returning success", key.c_str());
-
-        sendNotifyResponse(SAI_STATUS_SUCCESS);
-
-        return SAI_STATUS_SUCCESS;
-    }
-
     auto redisNotifySyncd = sai_deserialize_redis_notify_syncd(key);
 
     if (redisNotifySyncd == SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP)
@@ -3777,6 +3767,15 @@ sai_status_t Syncd::processNotifySyncd(
         }
         sendNotifyResponse(status);
         return status;
+    }
+
+    if (!m_commandLineOptions->m_enableTempView)
+    {
+        SWSS_LOG_NOTICE("received %s, ignored since TEMP VIEW is not used, returning success", key.c_str());
+
+        sendNotifyResponse(SAI_STATUS_SUCCESS);
+
+        return SAI_STATUS_SUCCESS;
     }
 
     if (m_veryFirstRun && m_firstInitWasPerformed && redisNotifySyncd == SAI_REDIS_NOTIFY_SYNCD_INIT_VIEW)

--- a/syncd/tests.cpp
+++ b/syncd/tests.cpp
@@ -822,7 +822,7 @@ void syncdThread()
 
     auto commandLineOptions = std::make_shared<CommandLineOptions>();
 
-    commandLineOptions->m_enableTempView = true;
+    commandLineOptions->m_enableTempView = false;
     commandLineOptions->m_enableUnittests = false;
     commandLineOptions->m_disableExitSleep = true;
     commandLineOptions->m_profileMapFile = "testprofile.ini";
@@ -856,6 +856,11 @@ void test_invoke_dump()
 
     ASSERT_SUCCESS("Failed to invoke dump");
     assert(mockCallArg == SAI_FAILURE_DUMP_SCRIPT);
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD;
+    attr.value.s32 = SAI_REDIS_NOTIFY_SYNCD_INIT_VIEW;
+    status = sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+    ASSERT_SUCCESS("Notify syncd failed");
 }
 
 void test_watchdog_timer_clock_rollback()


### PR DESCRIPTION
Fixes https://github.com/sonic-net/sonic-buildimage/issues/19411

During fast reboot temp view is not used and any failure will not result in SAI failure dump taken. Hence moving the handling of SAI failure dump above the ignore of non temp view.