### PR TITLE
Change to increase syncd redis default timeout

### DIFF
--- a/lib/sairedis.h
+++ b/lib/sairedis.h
@@ -43,7 +43,7 @@ extern "C" {
 /**
  * @brief Default synchronous operation response timeout in milliseconds.
  */
-#define SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT (60*1000)
+#define SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT (80*1000)
 
 typedef enum _sai_redis_notify_syncd_t
 {


### PR DESCRIPTION
Why I did it:
Migrating some older armhf platform from SONiC 202311 to master and 202405 branch, resulted in syncd create_switch timeout.
It is analyzed to see that SAI SDK code remains the same and time consume by SAI SDK during init when some(snmp mgmt-framework lldp gnmi dhcp_relay radv teamd pmon bgp) of the docker in sonic are disabled is same as running on 202311(with same environment). 
Some of the other observations are:
* Running docker ps -a in 202405 shows all dockers attempting to start, while in 202311 it delays most dockers 
* No single docker seems to have a significant impact

How to verify it:
Was able to run SONIC PTF without switch create timeout with 80sec timeout.