### PR TITLE
[Marvell] platform renaming for innovium

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -366,11 +366,11 @@ config_syncd_soda()
     CMD_ARGS+=" -l -p $HWSKU_DIR/sai.profile"
 }
 
-config_syncd_innovium()
+config_syncd_marvell_teralynx()
 {
     CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
     ulimit -s 65536
-    export II_ROOT="/var/log/invm"
+    export II_ROOT="/var/log/mrvl_teralynx"
     export II_APPEND_LOG=1
     mkdir -p $II_ROOT
 }
@@ -496,8 +496,8 @@ config_syncd()
         config_syncd_vs
     elif [ "$SONIC_ASIC_TYPE" == "vpp" ]; then
         config_syncd_vpp
-    elif [ "$SONIC_ASIC_TYPE" == "innovium" ]; then
-        config_syncd_innovium
+    elif [ "$SONIC_ASIC_TYPE" == "marvell-teralynx" ]; then
+        config_syncd_marvell_teralynx
     elif [ "$SONIC_ASIC_TYPE" == "soda" ]; then
         config_syncd_soda
     elif [ "$SONIC_ASIC_TYPE" == "nvidia-bluefield" ]; then


### PR DESCRIPTION
#### What i did
=======
this is one of the dependent set of PRs being raised for changing the innovium asic type to marvell-teralynx

#### How i did
=======
syncd based logging enablement inside syncd docker and its related asic type checks are modified as per the renaming

#### How to verify
==========
Verfify syncd docker configs are applied properly in teralynx platform