### PR TITLE
add support for "sai_dbg_generate_dump" API

### DIFF
--- a/lib/ClientSai.cpp
+++ b/lib/ClientSai.cpp
@@ -1549,3 +1549,23 @@ sai_status_t ClientSai::queryApiVersion(
 
     return SAI_STATUS_NOT_IMPLEMENTED;
 }
+
+sai_status_t ClientSai::dbgGenerateDump(
+        _In_ const char *dump_file_name)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    const std::vector<swss::FieldValueTuple> entry =
+    {
+        swss::FieldValueTuple("DBG_GENERATE_DUMP", dump_file_name),
+    };
+
+    std::string key = "DBG_GEN_DUMP:01";
+    
+    m_communicationChannel->set(key, entry, REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMP);
+ 
+    swss::KeyOpFieldsValuesTuple kco;
+    return m_communicationChannel->wait(REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMPRESPONSE, kco);
+}

--- a/lib/ClientSai.h
+++ b/lib/ClientSai.h
@@ -187,6 +187,9 @@ namespace sairedis
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;
+
         private: // QUAD API helpers
 
             sai_status_t create(

--- a/lib/ClientServerSai.cpp
+++ b/lib/ClientServerSai.cpp
@@ -638,3 +638,13 @@ sai_status_t ClientServerSai::queryApiVersion(
 
     return m_sai->queryApiVersion(version);
 }
+
+sai_status_t ClientServerSai::dbgGenerateDump(
+        _In_ const char *dump_file_name)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+     
+    return m_sai->dbgGenerateDump(dump_file_name);
+}

--- a/lib/ClientServerSai.h
+++ b/lib/ClientServerSai.h
@@ -179,6 +179,9 @@ namespace sairedis
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;       
+
         private:
 
             bool m_apiInitialized;

--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -316,6 +316,14 @@ void Recorder::recordFlushFdbEntriesResponse(
     recordLine("F|" + sai_serialize_status(status));
 }
 
+void Recorder::recordDbgGenDumpResponse(
+        _In_ sai_status_t status)
+{
+    SWSS_LOG_ENTER();
+
+    recordLine("F|" + sai_serialize_status(status));
+}
+
 void Recorder::recordQueryAttributeCapability(
         _In_ const std::string& key,
         _In_ const std::vector<swss::FieldValueTuple>& arguments)

--- a/lib/Recorder.h
+++ b/lib/Recorder.h
@@ -317,6 +317,9 @@ namespace sairedis
             void recordFlushFdbEntriesResponse(
                     _In_ sai_status_t status);
 
+            void recordDbgGenDumpResponse(
+                    _In_ sai_status_t status);        
+
         public: // SAI global interface API
 
             void recordObjectTypeGetAvailability(

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -1910,6 +1910,32 @@ sai_status_t RedisRemoteSaiInterface::queryApiVersion(
     return SAI_STATUS_INVALID_PARAMETER;
 }
 
+
+sai_status_t RedisRemoteSaiInterface::dbgGenerateDump(
+        _In_ const char *dump_file_name)
+{
+    SWSS_LOG_ENTER();
+
+    const std::vector<swss::FieldValueTuple> entry =
+    {
+        swss::FieldValueTuple("DBG_GENERATE_DUMP", dump_file_name),
+    };
+    
+    std::string key = "DBG_GEN_DUMP:01";
+    m_communicationChannel->set(key, entry, REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMP);
+ 
+    if (m_syncMode)
+    {
+	SWSS_LOG_DEBUG("wait for generate dump response");
+        swss::KeyOpFieldsValuesTuple kco;
+        auto status = m_communicationChannel->wait(REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMPRESPONSE, kco);
+        m_recorder->recordDbgGenDumpResponse(status);        
+        return status;
+    }
+
+    return SAI_STATUS_SUCCESS;  
+}
+
 sai_status_t RedisRemoteSaiInterface::sai_redis_notify_syncd(
         _In_ sai_object_id_t switchId,
         _In_ const sai_attribute_t *attr)

--- a/lib/RedisRemoteSaiInterface.h
+++ b/lib/RedisRemoteSaiInterface.h
@@ -198,6 +198,9 @@ namespace sairedis
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;
+
         public: // notify syncd
 
             virtual sai_status_t notifySyncd(

--- a/lib/Sai.cpp
+++ b/lib/Sai.cpp
@@ -765,6 +765,23 @@ sai_status_t Sai::queryApiVersion(
     return SAI_STATUS_FAILURE;
 }
 
+sai_status_t Sai::dbgGenerateDump(
+        _In_ const char *dump_file_name)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    REDIS_CHECK_API_INITIALIZED();
+
+    for (auto&kvp: m_contextMap)
+    {
+        return kvp.second->m_meta->dbgGenerateDump(dump_file_name);
+    }
+
+    SWSS_LOG_ERROR("context map is empty");
+
+    return SAI_STATUS_FAILURE; 
+}
+
 /*
  * NOTE: Notifications during switch create and switch remove.
  *

--- a/lib/Sai.h
+++ b/lib/Sai.h
@@ -188,6 +188,9 @@ namespace sairedis
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;
+
         private:
 
             sai_switch_notifications_t handle_notification(

--- a/lib/ServerSai.h
+++ b/lib/ServerSai.h
@@ -184,6 +184,9 @@ namespace sairedis
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;       
+
         private:
 
             void serverThreadFunction();
@@ -293,6 +296,9 @@ namespace sairedis
 
             sai_status_t processObjectTypeGetAvailabilityQuery(
                     _In_ const swss::KeyOpFieldsValuesTuple &kco);
+
+           sai_status_t processDbgGenerateDump(
+                    _In_ const swss::KeyOpFieldsValuesTuple &kco); 
 
         private:
 

--- a/lib/sairediscommon.h
+++ b/lib/sairediscommon.h
@@ -52,6 +52,9 @@
 #define REDIS_ASIC_STATE_COMMAND_OBJECT_TYPE_GET_AVAILABILITY_QUERY     "object_type_get_availability_query"
 #define REDIS_ASIC_STATE_COMMAND_OBJECT_TYPE_GET_AVAILABILITY_RESPONSE  "object_type_get_availability_response"
 
+#define REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMP            "dbg_gen_dump"
+#define REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMPRESPONSE    "dbg_gen_dumpresponse"
+
 #define REDIS_FLEX_COUNTER_COMMAND_START_POLL       "start_poll"
 #define REDIS_FLEX_COUNTER_COMMAND_STOP_POLL        "stop_poll"
 #define REDIS_FLEX_COUNTER_COMMAND_SET_GROUP        "set_counter_group"

--- a/meta/DummySaiInterface.cpp
+++ b/meta/DummySaiInterface.cpp
@@ -530,6 +530,16 @@ sai_status_t DummySaiInterface::queryApiVersion(
     return m_status;
 }
 
+sai_status_t DummySaiInterface::dbgGenerateDump(
+         _In_ const char *dump_file_name)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_ERROR("not implemented, FIXME");
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
 void DummySaiInterface::updateNotificationPointers(
         _In_ uint32_t count,
         _In_ const sai_attribute_t* attrs)

--- a/meta/DummySaiInterface.h
+++ b/meta/DummySaiInterface.h
@@ -219,6 +219,9 @@ namespace saimeta
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;
+
         protected:
 
             void updateNotificationPointers(

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1420,6 +1420,14 @@ sai_status_t Meta::queryApiVersion(
     return m_implementation->queryApiVersion(version);
 }
 
+sai_status_t Meta::dbgGenerateDump(
+        _In_ const char *dump_file_name)
+{
+    SWSS_LOG_ENTER();
+    
+    return m_implementation->dbgGenerateDump(dump_file_name);
+}
+
 void Meta::clean_after_switch_remove(
         _In_ sai_object_id_t switchId)
 {

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -195,6 +195,9 @@ namespace saimeta
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;
+
         public:
 
             void meta_init_db();

--- a/meta/SaiInterface.h
+++ b/meta/SaiInterface.h
@@ -342,7 +342,10 @@ namespace sairedis
 
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) = 0;
-
+            
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) = 0;
+                    
         public: // non SAI API
 
             virtual sai_log_level_t logGet(

--- a/proxylib/Sai.cpp
+++ b/proxylib/Sai.cpp
@@ -1117,6 +1117,25 @@ sai_status_t Sai::queryApiVersion(
 
 // TODO use function from SAI metadata to populate those
 
+sai_status_t Sai::dbgGenerateDump(
+       _In_ const char *dump_file_name)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    PROXY_CHECK_API_INITIALIZED();
+
+    const std::vector<swss::FieldValueTuple> entry =
+    {
+        swss::FieldValueTuple("DBG_GENERATE_DUMP", dump_file_name),
+    };
+
+    std::string key = "DBG_GEN_DUMP:01";
+
+    m_communicationChannel->set(key, entry, "dbg_gen_dump");
+
+    return SAI_STATUS_SUCCESS;
+}
+
 void Sai::updateNotifications(
         _In_ uint32_t attrCount,
         _In_ const sai_attribute_t *attrList)

--- a/proxylib/Sai.h
+++ b/proxylib/Sai.h
@@ -190,6 +190,9 @@ namespace saiproxy
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;
+                  
         private:    // QUAD helpers for entry
 
             virtual sai_status_t create(

--- a/stub.pl
+++ b/stub.pl
@@ -378,7 +378,7 @@ sub CreateGlobalApis
         Write "    SWSS_LOG_ENTER();";
         Write "";
 
-        if ($fun =~ /(bulkObjectClearStats|bulkObjectGetStats|dbgGenerateDump|getMaximumAttributeCount|getObjectKey|bulkGetAttribute|dbgGenerateDump|tamTelemetryGetData|getObjectCount|queryObjectStage)/)
+        if ($fun =~ /(bulkObjectClearStats|bulkObjectGetStats|getMaximumAttributeCount|getObjectKey|bulkGetAttribute|tamTelemetryGetData|getObjectCount|queryObjectStage)/)
         {
             Write "    SWSS_LOG_ERROR(\"FIXME, no implementation for $fun!\");";
             Write "    return SAI_STATUS_NOT_IMPLEMENTED;";

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -394,9 +394,39 @@ sai_status_t Syncd::processSingleEvent(
 
     if (op == REDIS_FLEX_COUNTER_COMMAND_DEL_GROUP)
         return processFlexCounterGroupEvent(key, DEL_COMMAND, kfvFieldsValues(kco));
+    
+    if (op == REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMP)
+        return processDbgGenerateDump(kco);
 
     SWSS_LOG_THROW("event op '%s' is not implemented, FIXME", op.c_str());
 }
+
+sai_status_t Syncd::processDbgGenerateDump(
+        _In_ const swss::KeyOpFieldsValuesTuple &kco)
+{
+    SWSS_LOG_ENTER();
+
+    const auto& values = kfvFieldsValues(kco);
+    if (values.size() != 1)
+    {
+        SWSS_LOG_ERROR("Invalid input: expected 1 arguments, received %zu", values.size());
+        m_selectableChannel->set(sai_serialize_status(SAI_STATUS_INVALID_PARAMETER), {} , REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMPRESPONSE);
+
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    auto& fieldValues = kfvFieldsValues(kco);
+        
+    auto value = fvValue(fieldValues[0]);
+    const char* value_cstr = value.c_str();
+
+    sai_status_t status = m_vendorSai->dbgGenerateDump(value_cstr);
+
+    m_selectableChannel->set(sai_serialize_status(status), {} , REDIS_ASIC_STATE_COMMAND_DBG_GEN_DUMPRESPONSE);
+
+    return status;
+}
+
 
 sai_status_t Syncd::processAttrCapabilityQuery(
         _In_ const swss::KeyOpFieldsValuesTuple &kco)

--- a/syncd/Syncd.h
+++ b/syncd/Syncd.h
@@ -210,6 +210,9 @@ namespace syncd
                     _In_ const std::vector<swss::FieldValueTuple> &values,
                     _In_ bool fromAsicChannel=true);
 
+            sai_status_t processDbgGenerateDump(
+                    _In_ const swss::KeyOpFieldsValuesTuple &kco);
+
         private: // process quad oid
 
             sai_status_t processOidCreate(

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -41,7 +41,7 @@ VendorSai::VendorSai()
 #else
         .bulk_object_get_stats = nullptr,
 #endif
-        .dbg_generate_dump = nullptr,
+        .dbg_generate_dump = &sai_dbg_generate_dump,
         .get_maximum_attribute_count = nullptr,
         .get_object_count = nullptr,
         .get_object_key = nullptr,
@@ -1747,4 +1747,12 @@ sai_log_level_t VendorSai::logGet(
     // no level defined yet, just return default
 
     return SAI_LOG_LEVEL_NOTICE;
+}
+
+sai_status_t VendorSai::dbgGenerateDump(
+           _In_ const char *dump_file_name)
+{
+    SWSS_LOG_ENTER();
+
+    return m_globalApis.dbg_generate_dump(dump_file_name);
 }

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -214,6 +214,9 @@ namespace syncd
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;                    
+
         public: // extra API
 
             virtual sai_log_level_t logGet(

--- a/vslib/Sai.cpp
+++ b/vslib/Sai.cpp
@@ -853,6 +853,17 @@ sai_status_t Sai::queryApiVersion(
     return m_meta->queryApiVersion(version);
 }
 
+sai_status_t Sai::dbgGenerateDump(
+        _In_ const char *dump_file_name)
+{
+    MUTEX();
+    SWSS_LOG_ENTER();
+    VS_CHECK_API_INITIALIZED();
+
+    return m_meta->dbgGenerateDump(dump_file_name);
+}
+
+
 std::shared_ptr<Context> Sai::getContext(
         _In_ uint32_t globalContext) const
 {

--- a/vslib/Sai.h
+++ b/vslib/Sai.h
@@ -193,6 +193,9 @@ namespace saivs
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;
+                    
         private: // QUAD pre
 
             sai_status_t preSet(

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -1281,6 +1281,14 @@ sai_status_t VirtualSwitchSaiInterface::queryApiVersion(
     return SAI_STATUS_INVALID_PARAMETER;
 }
 
+sai_status_t VirtualSwitchSaiInterface::dbgGenerateDump(
+            _In_ const char *dump_file_name)
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_STATUS_SUCCESS;
+}
+
 bool VirtualSwitchSaiInterface::writeWarmBootFile(
         _In_ const char* warmBootFile) const
 {

--- a/vslib/VirtualSwitchSaiInterface.h
+++ b/vslib/VirtualSwitchSaiInterface.h
@@ -192,6 +192,9 @@ namespace saivs
             virtual sai_status_t queryApiVersion(
                     _Out_ sai_api_version_t *version) override;
 
+            virtual sai_status_t dbgGenerateDump(
+                    _In_ const char *dump_file_name) override;               
+                                    
         private: // QUAD API helpers
 
             sai_status_t create(


### PR DESCRIPTION
This update adds support for the sai_dbg_gen_dump API, enabling the generation of a debug dump file by the SAI when there is no SAI failure. For scenarios involving SAI failures, a separate flow called dump_on_sai_failure is available.

An HLD will be publish soon with all relevant PRs