### PR TITLE
[syncd] Make sure notification queue release memory when drained

### DIFF
--- a/syncd/NotificationQueue.h
+++ b/syncd/NotificationQueue.h
@@ -2,13 +2,14 @@
 
 extern "C" {
 #include <sai.h>
-#include<saimetadata.h>
+#include <saimetadata.h>
 }
 
 #include "swss/table.h"
 
 #include <queue>
 #include <mutex>
+#include <memory>
 
 /**
  * @brief Default notification queue size limit.
@@ -54,7 +55,7 @@ namespace syncd
 
             std::mutex m_mutex;
 
-            std::queue<swss::KeyOpFieldsValuesTuple> m_queue;
+            std::shared_ptr<std::queue<swss::KeyOpFieldsValuesTuple>> m_queue;
 
             size_t m_queueSizeLimit;
 

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -477,3 +477,4 @@ TWAMP
 saiproxy
 submodule
 Enqueue
+deque

--- a/unittest/syncd/TestNotificationQueue.cpp
+++ b/unittest/syncd/TestNotificationQueue.cpp
@@ -66,3 +66,19 @@ TEST(NotificationQueue, EnqueueLimitTest)
     }
 }
 
+TEST(NotificationQueue, tryDequeue)
+{
+    syncd::NotificationQueue nq(5, 3);
+
+    EXPECT_EQ(nq.getQueueSize(), 0);
+
+    swss::KeyOpFieldsValuesTuple item;
+
+    nq.enqueue(item);
+
+    EXPECT_EQ(nq.getQueueSize(), 1);
+
+    EXPECT_EQ(nq.tryDequeue(item), true);
+
+    EXPECT_EQ(nq.getQueueSize(), 0);
+}


### PR DESCRIPTION
Since there could be burst of notifications, that allocated memory can be over 2GB, but when queue will be drained that memory will not be automatically released. Underlying deque container contains function shrink_to_fit but that is just a request, and usually this function does nothing.