### PR TITLE
[syncd] Add workaround for port error status notification

### DIFF
--- a/proxylib/Proxy.h
+++ b/proxylib/Proxy.h
@@ -206,5 +206,7 @@ namespace saiproxy
              * notifications.
              */
             uint64_t m_notificationsSentCount;
+
+            sai_api_version_t m_apiVersion;
     };
 }

--- a/syncd/NotificationHandler.cpp
+++ b/syncd/NotificationHandler.cpp
@@ -38,6 +38,13 @@ void NotificationHandler::setApiVersion(
     m_apiVersion = apiVersion;
 }
 
+sai_api_version_t NotificationHandler::getApiVersion() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_apiVersion;
+}
+
 void NotificationHandler::setSwitchNotifications(
         _In_ const sai_switch_notifications_t& switchNotifications)
 {

--- a/syncd/NotificationHandler.cpp
+++ b/syncd/NotificationHandler.cpp
@@ -1,4 +1,5 @@
 #include "NotificationHandler.h"
+#include "Workaround.h"
 #include "sairediscommon.h"
 
 #include "swss/logger.h"
@@ -10,8 +11,10 @@
 using namespace syncd;
 
 NotificationHandler::NotificationHandler(
-        _In_ std::shared_ptr<NotificationProcessor> processor):
-    m_processor(processor)
+        _In_ std::shared_ptr<NotificationProcessor> processor,
+        _In_ sai_api_version_t apiVersion):
+    m_processor(processor),
+    m_apiVersion(apiVersion)
 {
     SWSS_LOG_ENTER();
 
@@ -25,6 +28,14 @@ NotificationHandler::~NotificationHandler()
     SWSS_LOG_ENTER();
 
     // empty
+}
+
+void NotificationHandler::setApiVersion(
+        _In_ sai_api_version_t apiVersion)
+{
+    SWSS_LOG_ENTER();
+
+    m_apiVersion = apiVersion;
 }
 
 void NotificationHandler::setSwitchNotifications(
@@ -93,7 +104,9 @@ void NotificationHandler::onPortStateChange(
 {
     SWSS_LOG_ENTER();
 
-    auto s = sai_serialize_port_oper_status_ntf(count, data);
+    auto ntfdata = Workaround::convertPortOperStatusNotification(count, data, m_apiVersion);
+
+    auto s = sai_serialize_port_oper_status_ntf((uint32_t)ntfdata.size(), ntfdata.data());
 
     enqueueNotification(SAI_SWITCH_NOTIFICATION_NAME_PORT_STATE_CHANGE, s);
 }

--- a/syncd/NotificationHandler.h
+++ b/syncd/NotificationHandler.h
@@ -20,7 +20,8 @@ namespace syncd
         public:
 
             NotificationHandler(
-                    _In_ std::shared_ptr<NotificationProcessor> processor);
+                    _In_ std::shared_ptr<NotificationProcessor> processor,
+                    _In_ sai_api_version_t apiVersion = SAI_VERSION(0,0,0));
 
             virtual ~NotificationHandler();
 
@@ -34,6 +35,9 @@ namespace syncd
             void updateNotificationsPointers(
                     _In_ uint32_t attr_count,
                     _In_ sai_attribute_t *attr_list) const;
+
+            void setApiVersion(
+                    _In_ sai_api_version_t apiVersion);
 
         public: // members reflecting SAI callbacks
 
@@ -99,5 +103,7 @@ namespace syncd
             std::shared_ptr<NotificationQueue> m_notificationQueue;
 
             std::shared_ptr<NotificationProcessor> m_processor;
+
+            sai_api_version_t m_apiVersion;
     };
 }

--- a/syncd/NotificationHandler.h
+++ b/syncd/NotificationHandler.h
@@ -39,6 +39,8 @@ namespace syncd
             void setApiVersion(
                     _In_ sai_api_version_t apiVersion);
 
+            sai_api_version_t getApiVersion() const;
+
         public: // members reflecting SAI callbacks
 
             void onFdbEvent(

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -206,6 +206,21 @@ Syncd::Syncd(
         abort();
     }
 
+    sai_api_version_t apiVersion = SAI_VERSION(0,0,0); // invalid version
+
+    status = m_vendorSai->queryApiVersion(&apiVersion);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("failed to obtain libsai api version: %s", sai_serialize_status(status).c_str());
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("libsai api version: %lu", apiVersion);
+    }
+
+    m_handler->setApiVersion(apiVersion);
+
     m_breakConfig = BreakConfigParser::parseBreakConfig(m_commandLineOptions->m_breakConfig);
 
     SWSS_LOG_NOTICE("syncd started");

--- a/syncd/Workaround.h
+++ b/syncd/Workaround.h
@@ -4,6 +4,8 @@ extern "C" {
 #include "saimetadata.h"
 }
 
+#include <vector>
+
 namespace syncd
 {
     class Workaround
@@ -31,5 +33,38 @@ namespace syncd
                     _In_ sai_object_type_t objectType,
                     _In_ sai_attr_id_t attrId,
                     _In_ sai_status_t status);
+
+            /**
+             * @brief Convert port status notification from older version.
+             *
+             * This method will convert port status notification from SAI
+             * v1.14.0 to version v1.15.0, since from that version a new
+             * structure field was added, and there is possibility that syncd
+             * compiled against headers v1.15.0 will receive notification from
+             * sai library v1.14.0 or older, and since that change is not
+             * backward compatible, it can cause invalid memory read or garbage
+             * memory read. To prevent that, we will convert structures.
+             *
+             * Similar thing can happen if older syncd will receive
+             * notification from newer version of sai library.
+             */
+            static std::vector<sai_port_oper_status_notification_t> convertPortOperStatusNotification(
+                    _In_ const uint32_t count,
+                    _In_ const sai_port_oper_status_notification_t* data,
+                    _In_ sai_api_version_t version);
+        public:
+
+            /**
+             * @brief Port operational status notification as in SAI version v1.14.0
+             *
+             * This will imitate structure size needed for notification conversion.
+             */
+            typedef struct _sai_port_oper_status_notification_v1_14_0_t
+            {
+                sai_object_id_t port_id;
+
+                sai_port_oper_status_t port_state;
+
+            } sai_port_oper_status_notification_v1_14_0_t;
     };
 }

--- a/unittest/syncd/TestNotificationHandler.cpp
+++ b/unittest/syncd/TestNotificationHandler.cpp
@@ -67,3 +67,12 @@ TEST(NotificationHandler, NotificationHandlerTest)
                                                     data,
                                                     description);
 }
+
+TEST(NotificationHandler, setApiVersion)
+{
+    auto np = std::make_shared<NotificationProcessor>(nullptr, nullptr, nullptr);
+
+    auto nh = std::make_shared<NotificationHandler>(np);
+
+    nh->setApiVersion(SAI_VERSION(1,15,0));
+}

--- a/unittest/syncd/TestNotificationHandler.cpp
+++ b/unittest/syncd/TestNotificationHandler.cpp
@@ -74,5 +74,9 @@ TEST(NotificationHandler, setApiVersion)
 
     auto nh = std::make_shared<NotificationHandler>(np);
 
+    EXPECT_EQ(SAI_VERSION(0,0,0), nh->getApiVersion());
+
     nh->setApiVersion(SAI_VERSION(1,15,0));
+
+    EXPECT_EQ(SAI_VERSION(1,15,0), nh->getApiVersion());
 }

--- a/unittest/syncd/TestWorkaround.cpp
+++ b/unittest/syncd/TestWorkaround.cpp
@@ -19,3 +19,51 @@ TEST(Workaround, isSetAttributeWorkaround)
     ASSERT_EQ(Workaround::isSetAttributeWorkaround(SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_TYPE, SAI_STATUS_FAILURE), false);
     ASSERT_EQ(Workaround::isSetAttributeWorkaround(SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_TYPE, SAI_STATUS_SUCCESS), false);
 }
+
+TEST(Workaround,convertPortOperStatusNotification)
+{
+    sai_port_oper_status_notification_t data[2];
+
+    ASSERT_EQ(Workaround::convertPortOperStatusNotification(0, nullptr, SAI_API_VERSION).size(), 0);
+    ASSERT_EQ(Workaround::convertPortOperStatusNotification(5000, data, SAI_API_VERSION).size(), 0);
+
+    ASSERT_EQ(Workaround::convertPortOperStatusNotification(2, data, SAI_VERSION(1,15,0)).size(), 2);
+    ASSERT_EQ(Workaround::convertPortOperStatusNotification(2, data, SAI_VERSION(1,14,1)).size(), 2);
+
+    // check new structure notifications
+
+    data[0].port_id = 12;
+    data[0].port_state = SAI_PORT_OPER_STATUS_DOWN;
+    data[0].port_error_status = SAI_PORT_ERROR_STATUS_HIGH_BER;
+    data[1].port_id = 22;
+    data[1].port_state = SAI_PORT_OPER_STATUS_UP;
+    data[1].port_error_status = SAI_PORT_ERROR_STATUS_DATA_UNIT_MISALIGNMENT_ERROR;
+
+    auto ntf = Workaround::convertPortOperStatusNotification(2, data, SAI_VERSION(1,14,1));
+
+    ASSERT_EQ(ntf[0].port_id, 12);
+    ASSERT_EQ(ntf[0].port_state, SAI_PORT_OPER_STATUS_DOWN);
+    ASSERT_EQ(ntf[0].port_error_status, SAI_PORT_ERROR_STATUS_HIGH_BER);
+    ASSERT_EQ(ntf[1].port_id, 22);
+    ASSERT_EQ(ntf[1].port_state, SAI_PORT_OPER_STATUS_UP);
+    ASSERT_EQ(ntf[1].port_error_status, SAI_PORT_ERROR_STATUS_DATA_UNIT_MISALIGNMENT_ERROR);
+
+    // check old structure notification
+    Workaround::sai_port_oper_status_notification_v1_14_0_t old[2];
+
+    old[0].port_id = 42;
+    old[0].port_state = SAI_PORT_OPER_STATUS_UP;
+    old[1].port_id = 43;
+    old[1].port_state = SAI_PORT_OPER_STATUS_DOWN;
+
+    auto ntf2 = Workaround::convertPortOperStatusNotification(2, reinterpret_cast<sai_port_oper_status_notification_t*>(old), SAI_VERSION(1,14,0));
+
+    ASSERT_EQ(ntf.size(), 2);
+
+    ASSERT_EQ(ntf2[0].port_id, 42);
+    ASSERT_EQ(ntf2[0].port_state, SAI_PORT_OPER_STATUS_UP);
+    ASSERT_EQ(ntf2[0].port_error_status, 0);
+    ASSERT_EQ(ntf2[1].port_id, 43);
+    ASSERT_EQ(ntf2[1].port_state, SAI_PORT_OPER_STATUS_DOWN);
+    ASSERT_EQ(ntf2[1].port_error_status, 0);
+}


### PR DESCRIPTION
Adding new field in port status notification is breaking
change and can cause some issues when getting notification
from older SAI library, this will add workaround to handle
that case