### PR TITLE
[202405][Mellanox] Resolve New Line Formatting Issues in syncd's sai.profile …

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -225,6 +225,8 @@ config_syncd_mlnx()
         cat $HWSKU_DIR/sai.profile > /tmp/sai-temp.profile
     fi
 
+    echo >> /tmp/sai-temp.profile
+
     if [[ -f $SAI_COMMON_FILE_PATH ]]; then
         cat $SAI_COMMON_FILE_PATH >> /tmp/sai-temp.profile
     fi
@@ -254,6 +256,9 @@ config_syncd_mlnx()
     if [[ -f /tmp/sai_extra.profile ]]; then
         cat /tmp/sai_extra.profile >> /tmp/sai.profile
     fi
+
+    # Ensure no redundant newlines
+    sed -i '/^$/d' /tmp/sai.profile
 }
 
 config_syncd_centec()


### PR DESCRIPTION
…(#1412)

On Mellanox platforms, the /tmp/sai.profile file inside syncd might end up with invalid formatting after running the script modified by this PR, such as missing new lines after concatenation or redundant new lines. This PR aims to fix that.