### PR TITLE
Use a different letter to represent counter polling in sairedis.rec to avoid saiplayer crash

### DIFF
--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -535,6 +535,17 @@ void Recorder::recordGenericSet(
     recordLine("s|" + key + "|" + Globals::joinFieldValues(arguments));
 }
 
+void Recorder::recordGenericCounterPolling(
+        _In_ const std::string& key,
+        _In_ const std::vector<swss::FieldValueTuple>& arguments)
+{
+    SWSS_LOG_ENTER();
+
+    // lower case 'p' stands for counter Polling
+
+    recordLine("p|" + key + "|" + Globals::joinFieldValues(arguments));
+}
+
 void Recorder::recordGenericSetResponse(
         _In_ sai_status_t status)
 {

--- a/lib/Recorder.h
+++ b/lib/Recorder.h
@@ -179,6 +179,10 @@ namespace sairedis
 
         public: // SAI stats API
 
+            void recordGenericCounterPolling(
+                    _In_ const std::string& key,
+                    _In_ const std::vector<swss::FieldValueTuple>& arguments);
+
             void recordGenericGetStats(
                     _In_ sai_object_type_t object_type,
                     _In_ sai_object_id_t object_id,

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -572,7 +572,7 @@ sai_status_t RedisRemoteSaiInterface::notifyCounterGroupOperations(
     emplaceStrings(flexCounterGroupParam->plugin_name, flexCounterGroupParam->plugins, entries);
     emplaceStrings(FLEX_COUNTER_STATUS_FIELD, flexCounterGroupParam->operation, entries);
 
-    m_recorder->recordGenericSet(key, entries);
+    m_recorder->recordGenericCounterPolling(key, entries);
 
     m_communicationChannel->set(key,
                                 entries,
@@ -607,7 +607,7 @@ sai_status_t RedisRemoteSaiInterface::notifyCounterOperations(
         command = REDIS_FLEX_COUNTER_COMMAND_STOP_POLL;
     }
 
-    m_recorder->recordGenericSet(key, entries);
+    m_recorder->recordGenericCounterPolling(key, entries);
     m_communicationChannel->set(key, entries, command);
 
     return waitForResponse(SAI_COMMON_API_SET);

--- a/saiplayer/SaiPlayer.cpp
+++ b/saiplayer/SaiPlayer.cpp
@@ -2607,6 +2607,9 @@ int SaiPlayer::replay()
             case 'q':
                 // TODO: implement SAI player support for query commands
                 continue;
+            case 'p':
+                // TODO: implement SAI player support for counter polling commands
+                continue;
             case 'Q':
                 continue; // skip over query responses
             case '#':


### PR DESCRIPTION
Use a different letter to represent counter polling in sairedis.rec to avoid saiplayer crash

The character `s` was used for counter-polling polling which failed saiplayer because the format differed.
Now the character `p` is used to avoid failure. The saiplayer ignores `p`.