### PR TITLE
[202405] Fix adding flex counter to wrong context (#1421)

### DIFF
--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -1993,6 +1993,21 @@ sai_switch_notifications_t RedisRemoteSaiInterface::syncProcessNotification(
     return { };
 }
 
+bool RedisRemoteSaiInterface::containsSwitch(
+        _In_ sai_object_id_t switchId) const
+{
+    SWSS_LOG_ENTER();
+
+    if (!m_switchContainer->contains(switchId))
+    {
+        SWSS_LOG_INFO("context %s failed to find switch %s",
+                m_contextConfig->m_name.c_str(), sai_serialize_object_id(switchId).c_str());
+        return false;
+    }
+
+    return true;
+}
+
 const std::map<sai_object_id_t, swss::TableDump>& RedisRemoteSaiInterface::getTableDump() const
 {
     SWSS_LOG_ENTER();

--- a/lib/RedisRemoteSaiInterface.h
+++ b/lib/RedisRemoteSaiInterface.h
@@ -215,6 +215,9 @@ namespace sairedis
 
             const std::map<sai_object_id_t, swss::TableDump>& getTableDump() const;
 
+            bool containsSwitch(
+                    _In_ sai_object_id_t switchId) const;
+
         private: // QUAD API helpers
 
             sai_status_t create(

--- a/lib/Sai.cpp
+++ b/lib/Sai.cpp
@@ -224,13 +224,19 @@ sai_status_t Sai::set(
 
         // skip metadata if attribute is redis extension attribute
 
-        // TODO this is setting on all contexts, but maybe we want one specific?
-        // and do set on all if objectId == NULL
-
         bool success = true;
 
+        // Setting on all contexts if objectType != SAI_OBJECT_TYPE_SWITCH or objectId == NULL
         for (auto& kvp: m_contextMap)
         {
+            if (objectType == SAI_OBJECT_TYPE_SWITCH && objectId != SAI_NULL_OBJECT_ID)
+            {
+                if (!kvp.second->m_redisSai->containsSwitch(objectId))
+                {
+                    continue;
+                }
+            }
+
             sai_status_t status = kvp.second->m_redisSai->set(objectType, objectId, attr);
 
             success &= (status == SAI_STATUS_SUCCESS);

--- a/syncd/tests/TestSyncdMlnx.cpp
+++ b/syncd/tests/TestSyncdMlnx.cpp
@@ -284,10 +284,14 @@ TEST_F(SyncdMlnxTest, portBulkAddRemove)
     attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
     attr.value.ptr = (void*)&flexCounterGroupParam;
 
-    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+    // Failed to create if the switchId is invalid for the context
+    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, m_switchId + 1, &attr);
+    std::vector<swss::FieldValueTuple> fvVector, fvVectorExpected;
+    ASSERT_FALSE(m_flexCounterGroupTable->get("PORT_STAT_COUNTER", fvVector));
+
+    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, m_switchId, &attr);
     ASSERT_EQ(status, SAI_STATUS_SUCCESS);
 
-    std::vector<swss::FieldValueTuple> fvVector, fvVectorExpected;
     ASSERT_TRUE(m_flexCounterGroupTable->get("PORT_STAT_COUNTER", fvVector));
     fvVectorExpected.emplace_back(POLL_INTERVAL_FIELD, poll_interval);
     fvVectorExpected.emplace_back(STATS_MODE_FIELD, stats_mode);
@@ -315,7 +319,7 @@ TEST_F(SyncdMlnxTest, portBulkAddRemove)
     attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER;
     attr.value.ptr = (void*)&flexCounterParam;
 
-    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, m_switchId, &attr);
     ASSERT_EQ(status, SAI_STATUS_FAILURE);
     ASSERT_FALSE(m_flexCounterTable->get(key, fvVector));
 
@@ -323,7 +327,7 @@ TEST_F(SyncdMlnxTest, portBulkAddRemove)
     key = "PORT_STAT_COUNTER:" + sai_serialize_object_id(oidList[0]);
     flexCounterParam.counter_key.list = (int8_t*)const_cast<char *>(key.c_str());
     flexCounterParam.counter_key.count = (uint32_t)key.length();
-    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, m_switchId, &attr);
     ASSERT_EQ(status, SAI_STATUS_SUCCESS);
 
     ASSERT_TRUE(m_flexCounterTable->get(key, fvVector));
@@ -336,7 +340,7 @@ TEST_F(SyncdMlnxTest, portBulkAddRemove)
     flexCounterParam.counter_field_name.count = 0;
 
     // 3. Stop counter polling for the port
-    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, m_switchId, &attr);
     ASSERT_EQ(status, SAI_STATUS_SUCCESS);
     ASSERT_FALSE(m_flexCounterTable->get(key, fvVector));
 
@@ -351,7 +355,7 @@ TEST_F(SyncdMlnxTest, portBulkAddRemove)
     attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
     attr.value.ptr = (void*)&flexCounterGroupParam;
 
-    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+    status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, m_switchId, &attr);
     ASSERT_EQ(status, SAI_STATUS_SUCCESS);
     ASSERT_FALSE(m_flexCounterTable->get(key, fvVector));
 


### PR DESCRIPTION
Manually cherry-pick this PR: https://github.com/sonic-net/sonic-sairedis/pull/1421

The counters for syncd (switch chip) were attempted to be added to gbsyncd (gearbox phys), and vice versa. This issue is introduced by #1362 When setting the redis attribute SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP and
SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER, the operation is applied to every contexts (both syncd and gbsyncd). However, the counters to initialize could only exist in one context.

The fix is to check that the target switch id exists in a specific context, for the set operation of any redis type attribute; if not, skip the set on that context.

Before the fix, we see the error below in syslog
ERR gbsyncd#syncd: :- processFlexCounterEvent: port VID oid:0x1000000000002, was not found (probably port was removed/splitted) and will remove from counters now

After the fix, log like below is printed on info level: INFO swss#orchagent: :- containsSwitch: context phys failed to find switch oid:0x21000000000000

This change is needed by the SONiC release 202405 and later.