### PR TITLE
Fix compilation on Buster

### DIFF
--- a/pyext/pysairedis.i
+++ b/pyext/pysairedis.i
@@ -2,6 +2,10 @@
 %include "cpointer.i"
 %include "carrays.i"
 
+// These objects cause issues on Buster because of the function pointers
+%ignore _sai_struct_member_info_t;
+%ignore _sai_object_type_info_t;
+
 %{
 #pragma GCC optimize("no-var-tracking-assignments")
 

--- a/unittest/syncd/TestSyncd.cpp
+++ b/unittest/syncd/TestSyncd.cpp
@@ -210,6 +210,7 @@ TEST(Syncd, inspectAsic)
 
 using namespace syncd;
 
+#ifdef MOCK_METHOD
 class MockSelectableChannel : public sairedis::SelectableChannel {
 public:
     MOCK_METHOD(bool, empty, (), (override));
@@ -258,3 +259,4 @@ TEST_F(SyncdTest, processNotifySyncd)
     }));
     syncd_object.processEvent(consumer);
 }
+#endif


### PR DESCRIPTION
There are two issues causing compilation failures of sairedis on Buster. Since the SONiC PTF container is still based on Buster, sairedis still needs to compile for Buster.

For the first issue, when generating Python bindings through SWIG on Buster, the `sai_struct_member_info_t` and `sai_object_type_info_t` struct cause issues during compilation on Buster. The errors stem from function pointers being used, but I'm not certain on the exact reason why these two specific structs have issues.

Instead of debugging further at this point, skip these two structs for now. We won't need it in the near future. Alternatively, once the Buster build is no longer needed, these lines can be removed.

For the second issue, the `TestSyncd.cpp` file uses the `MOCK_METHOD` macro. However, this macro is available only from version 1.10 of gmock, but Buster has version 1.8.1. As a simple fix, check to see if `MOCK_METHOD` is defined; if not, then don't compile this test.

ADO: 30055338