### PR TITLE
[azpipeline] Fix gcovr nested directory

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -193,7 +193,7 @@ jobs:
         gcov_dirs=$(find . -path "*.libs*gcda" | xargs dirname | sort -u |  cut -c"3-")
         for dir in ${gcov_dirs}; do
           source_dir=$(dirname $dir)
-          output_file="coverage-$source_dir.json"
+          output_file=$(echo "coverage-$source_dir.json"| tr '/' '-')
           gcovr --exclude-unreachable-branches --json-pretty -o $output_file --object-directory $source_dir $dir
         done
         gcovr -r ./ -e ".*/SAI/.*" -e ".+/json.hpp" -e "swss/.+" -e ".*/.libs/.*" -e ".*/debian/.*" --exclude-unreachable-branches --json-pretty -o coverage-all.json


### PR DESCRIPTION
sonic-swss-common introduced nested directory in common/c-api and it causes gcovr to write output file in non existing directory this fix replaces all / to - for all gcovr output files to be in the same directory