### PR TITLE
[vslib] SAI_KEY_VS_OPER_SPEED_IS_CONFIGURED_SPEED, SAI_PORT_ATTR_HOST_TX_READY_STATUS support

### DIFF
--- a/unittest/vslib/TestSwitchConfig.cpp
+++ b/unittest/vslib/TestSwitchConfig.cpp
@@ -67,13 +67,13 @@ TEST(SwitchConfig, parseBootType)
     EXPECT_EQ(type, SAI_VS_BOOT_TYPE_FAST);
 }
 
-TEST(SwitchConfig, parseUseTapDevice)
+TEST(SwitchConfig, parseBool)
 {
-    EXPECT_FALSE(SwitchConfig::parseUseTapDevice(nullptr));
+    EXPECT_FALSE(SwitchConfig::parseBool(nullptr));
 
-    EXPECT_FALSE(SwitchConfig::parseUseTapDevice("foo"));
+    EXPECT_FALSE(SwitchConfig::parseBool("foo"));
 
-    EXPECT_FALSE(SwitchConfig::parseUseTapDevice("false"));
+    EXPECT_FALSE(SwitchConfig::parseBool("false"));
 
-    EXPECT_TRUE(SwitchConfig::parseUseTapDevice("true"));
+    EXPECT_TRUE(SwitchConfig::parseBool("true"));
 }

--- a/vslib/Sai.cpp
+++ b/vslib/Sai.cpp
@@ -150,9 +150,15 @@ sai_status_t Sai::apiInitialize(
 
     const char *use_tap_dev = service_method_table->profile_get_value(0, SAI_KEY_VS_HOSTIF_USE_TAP_DEVICE);
 
-    auto useTapDevice = SwitchConfig::parseUseTapDevice(use_tap_dev);
+    auto useTapDevice = SwitchConfig::parseBool(use_tap_dev);
 
     SWSS_LOG_NOTICE("hostif use TAP device: %s", (useTapDevice ? "true" : "false"));
+
+    const char *use_configured_speed_as_oper_speed = service_method_table->profile_get_value(0, SAI_KEY_VS_USE_CONFIGURED_SPEED_AS_OPER_SPEED);
+
+    auto useConfiguredSpeedAsOperSpeed = SwitchConfig::parseBool(use_configured_speed_as_oper_speed);
+
+    SWSS_LOG_NOTICE("use configured speed as oper speed: %s", (useConfiguredSpeedAsOperSpeed ? "true" : "false"));
 
     auto cstrGlobalContext = service_method_table->profile_get_value(0, SAI_KEY_VS_GLOBAL_CONTEXT);
 
@@ -218,6 +224,7 @@ sai_status_t Sai::apiInitialize(
         sc->m_switchType = switchType;
         sc->m_bootType = bootType;
         sc->m_useTapDevice = useTapDevice;
+        sc->m_useConfiguredSpeedAsOperSpeed = useConfiguredSpeedAsOperSpeed;
         sc->m_laneMap = m_laneMapContainer->getLaneMap(sc->m_switchIndex);
 
         if (sc->m_laneMap == nullptr)

--- a/vslib/SwitchConfig.cpp
+++ b/vslib/SwitchConfig.cpp
@@ -17,7 +17,8 @@ SwitchConfig::SwitchConfig(
     m_bootType(SAI_VS_BOOT_TYPE_COLD),
     m_switchIndex(switchIndex),
     m_hardwareInfo(hwinfo),
-    m_useTapDevice(false)
+    m_useTapDevice(false),
+    m_useConfiguredSpeedAsOperSpeed(false)
 {
     SWSS_LOG_ENTER();
 

--- a/vslib/SwitchConfig.cpp
+++ b/vslib/SwitchConfig.cpp
@@ -141,14 +141,14 @@ bool SwitchConfig::parseBootType(
     return true;
 }
 
-bool SwitchConfig::parseUseTapDevice(
-        _In_ const char* useTapDeviceStr)
+bool SwitchConfig::parseBool(
+        _In_ const char* str)
 {
     SWSS_LOG_ENTER();
 
-    if (useTapDeviceStr)
+    if (str)
     {
-        return strcmp(useTapDeviceStr, "true") == 0;
+        return strcmp(str, "true") == 0;
     }
 
     return false;

--- a/vslib/SwitchConfig.h
+++ b/vslib/SwitchConfig.h
@@ -64,8 +64,8 @@ namespace saivs
                     _In_ const char* bootTypeStr,
                     _Out_ sai_vs_boot_type_t& bootType);
 
-            static bool parseUseTapDevice(
-                    _In_ const char* useTapDeviceStr);
+            static bool parseBool(
+                    _In_ const char* boolStr);
 
         public:
 
@@ -80,6 +80,8 @@ namespace saivs
             std::string m_hardwareInfo;
 
             bool m_useTapDevice;
+
+            bool m_useConfiguredSpeedAsOperSpeed;
 
             std::shared_ptr<LaneMap> m_laneMap;
 

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -1313,6 +1313,11 @@ sai_status_t SwitchStateBase::create_ports()
         attr.value.u32 = DEFAULT_VLAN_NUMBER;
 
         CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+        attr.id = SAI_PORT_ATTR_HOST_TX_READY_STATUS;
+        attr.value.u32 = SAI_PORT_HOST_TX_READY_STATUS_READY;
+
+        CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
     }
 
     return SAI_STATUS_SUCCESS;
@@ -1775,6 +1780,11 @@ sai_status_t SwitchStateBase::create_port_dependencies(
 
     attr.id = SAI_PORT_ATTR_ADMIN_STATE;
     attr.value.booldata = false;
+
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+
+    attr.id = SAI_PORT_ATTR_HOST_TX_READY_STATUS;
+    attr.value.u32 = SAI_PORT_HOST_TX_READY_STATUS_READY;
 
     CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
 
@@ -2504,6 +2514,7 @@ sai_status_t SwitchStateBase::refresh_read_only(
                  */
 
             case SAI_PORT_ATTR_OPER_STATUS:
+            case SAI_PORT_ATTR_HOST_TX_READY_STATUS:
                 return SAI_STATUS_SUCCESS;
 
             case SAI_PORT_ATTR_FABRIC_ATTACHED:

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -2339,7 +2339,12 @@ sai_status_t SwitchStateBase::refresh_port_oper_speed(
     }
     else
     {
-        if (!vs_get_oper_speed(port_id, attr.value.u32))
+        if (m_switchConfig->m_useConfiguredSpeedAsOperSpeed)
+        {
+            attr.id = SAI_PORT_ATTR_SPEED;
+            CHECK_STATUS(get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
+        }
+        else if (!vs_get_oper_speed(port_id, attr.value.u32))
         {
             return SAI_STATUS_FAILURE;
         }

--- a/vslib/saivs.h
+++ b/vslib/saivs.h
@@ -57,6 +57,16 @@ extern "C" {
 #define SAI_KEY_VS_HOSTIF_USE_TAP_DEVICE      "SAI_VS_HOSTIF_USE_TAP_DEVICE"
 
 /**
+ * @def SAI_KEY_VS_USE_CONFIGURED_SPEED_AS_OPER_SPEED
+ *
+ * Bool flag, (true/false). If set to true, SAI_PORT_ATTR_OPER_SPEED returns
+ * the SAI_PORT_ATTR_SPEED instead of querying the speed of veth
+ *
+ * By default this flag is set to false.
+ */
+#define SAI_KEY_VS_USE_CONFIGURED_SPEED_AS_OPER_SPEED "SAI_VS_USE_CONFIGURED_SPEED_AS_OPER_SPEED"
+
+/**
  * @def SAI_KEY_VS_CORE_PORT_INDEX_MAP_FILE
  *
  * For VOQ systems if specified in profile.ini it should point to eth interface to


### PR DESCRIPTION
This PR adds two features to `vslib`.

- `SAI_KEY_VS_OPER_SPEED_IS_CONFIGURED_SPEED`: when `true`, `SAI_PORT_ATTR_SPEED` returns the configured speed instead of the value retrieved via [`/sys/class/net/<name>/speed`](https://github.com/sonic-net/sonic-sairedis/blob/master/vslib/SwitchStateBaseHostif.cpp#L892-L893). 
  - fixes https://github.com/sonic-net/sonic-buildimage/issues/19735

- `SAI_PORT_ATTR_HOST_TX_READY_STATUS`: always returns `true`. Required to support running `xcvrd` in the VS env.
  - ref: https://github.com/sonic-net/SONiC/pull/1849/files#diff-6f3e95e6c57a3edc2e30e1f13edb9fd9a32a0db44e1035ac1f0b1b9a191762a5R46