### PR TITLE
[PATCH] [Marvell] Add Flag to identify SONiC related Init Handling

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -285,6 +285,8 @@ config_syncd_marvell()
 {
     CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
 
+    export MRVL_PSAI_SONIC=1
+
     [ -e /dev/net/tun ] || ( mkdir -p /dev/net && mknod /dev/net/tun c 10 200 )
 }
 


### PR DESCRIPTION
Backported PR #1420 from master to 202405.