### PR TITLE
[test] Add more testing for NotificationSwitchAsicSdkHealthEvent

### DIFF
--- a/unittest/meta/TestNotificationSwitchAsicSdkHealthEvent.cpp
+++ b/unittest/meta/TestNotificationSwitchAsicSdkHealthEvent.cpp
@@ -5,6 +5,8 @@
 #include "sairediscommon.h"
 #include "sai_serialize.h"
 
+#include <inttypes.h>
+
 #include <gtest/gtest.h>
 #include <memory>
 
@@ -65,12 +67,18 @@ static void on_switch_asic_sdk_health_event(
 {
     SWSS_LOG_ENTER();
 
-    printf("swtch: %lx %ld %d\n", switch_id, timestamp.tv_sec, timestamp.tv_nsec);
+    printf("swtch: %" PRIx64 " %" PRIu64 " %d\n", switch_id, timestamp.tv_sec, timestamp.tv_nsec);
 
     // this code is from swss and it crashes on put_time because of tv_sec == 172479515853275099
 
     // 67767710400000001
-    timestamp.tv_sec %= (1000L*365L*24L*60L*60L);
+    uint64_t y1000 = 1000;
+    y1000 *= 365;
+    y1000 *= 24;
+    y1000 *= 60;
+    y1000 *= 60;
+
+    timestamp.tv_sec %= y1000;
 
     std::stringstream ss;
     const std::time_t t = (std::time_t)timestamp.tv_sec;
@@ -126,7 +134,7 @@ static void on_switch_asic_sdk_health_event_v13(
 {
     SWSS_LOG_ENTER();
 
-    printf("swtch v13: %lx %ld %d, count = %d\n", switch_id, timestamp.tv_sec,timestamp.tv_nsec,
+    printf("switch v13: 0x%" PRIx64 " %" PRIu64 " %d, count = %d\n", switch_id, timestamp.tv_sec,timestamp.tv_nsec,
             description.count);
 
     EXPECT_TRUE(timestamp.tv_sec == 1731848814);
@@ -154,7 +162,7 @@ static void on_switch_asic_sdk_health_event_v14(
 {
     SWSS_LOG_ENTER();
 
-    printf("swtch v14: %lx %ld %d, count = %d\n", switch_id, timestamp.tv_sec,timestamp.tv_nsec,
+    printf("switch v14: 0x%" PRIx64 " %" PRIu64 " %d, count = %d\n", switch_id, timestamp.tv_sec, timestamp.tv_nsec,
             description.count);
 
     EXPECT_TRUE(timestamp.tv_sec == 1731848814);

--- a/unittest/meta/TestNotificationSwitchAsicSdkHealthEvent.cpp
+++ b/unittest/meta/TestNotificationSwitchAsicSdkHealthEvent.cpp
@@ -98,16 +98,13 @@ TEST(NotificationSwitchAsicSdkHealthEvent, executeCallback)
 
 typedef struct _sai_switch_health_data_t_v14
 {
-    /** Type of switch health data */
     sai_health_data_type_t data_type;
 
-    /** @passparam data_type */
     sai_health_data_t data;
 } sai_switch_health_data_t_v14;
 
 typedef struct _sai_switch_health_data_t_v13
 {
-    /** Type of switch health data */
     sai_health_data_type_t data_type;
 } sai_switch_health_data_t_v13;
 

--- a/unittest/meta/TestNotificationSwitchAsicSdkHealthEvent.cpp
+++ b/unittest/meta/TestNotificationSwitchAsicSdkHealthEvent.cpp
@@ -64,6 +64,17 @@ static void on_switch_asic_sdk_health_event(
         _In_ const sai_u8_list_t description)
 {
     SWSS_LOG_ENTER();
+
+    printf("swtch: %lx %ld %d\n", switch_id, timestamp.tv_sec, timestamp.tv_nsec);
+
+    // this code is from swss and it crashes on put_time because of tv_sec == 172479515853275099
+
+    // 67767710400000001
+    timestamp.tv_sec %= (1000L*365L*24L*60L*60L);
+
+    std::stringstream ss;
+    const std::time_t t = (std::time_t)timestamp.tv_sec;
+    ss << std::put_time(std::localtime(&t), "%Y-%m-%d %H:%M:%S");// THIS WILL THROW if seconds is too big
 }
 
 TEST(NotificationSwitchAsicSdkHealthEvent, executeCallback)
@@ -75,4 +86,120 @@ TEST(NotificationSwitchAsicSdkHealthEvent, executeCallback)
     ntfs.on_switch_asic_sdk_health_event = &on_switch_asic_sdk_health_event;
 
     n.executeCallback(ntfs);
+
+    auto str = "{\"category\":\"SAI_SWITCH_ASIC_SDK_HEALTH_CATEGORY_ASIC_HW\",\"data.data_type\":\"SAI_HEALTH_DATA_TYPE_GENERAL\",\"description\":\"16:123,10,9,34,100,97,116,97,34,58,32,34,48,34,10,125\",\"severity\":\"SAI_SWITCH_ASIC_SDK_HEALTH_SEVERITY_WARNING\",\"switch_id\":\"oid:0x21000000000000\",\"timestamp\":\"{\\\"tv_nsec\\\":\\\"12\\\",\\\"tv_sec\\\":\\\"172479515853275099\\\"}\"}";
+
+    NotificationSwitchAsicSdkHealthEvent nn(str);
+
+    ntfs.on_switch_asic_sdk_health_event = &on_switch_asic_sdk_health_event;
+
+    nn.executeCallback(ntfs);
+}
+
+typedef struct _sai_switch_health_data_t_v14
+{
+    /** Type of switch health data */
+    sai_health_data_type_t data_type;
+
+    /** @passparam data_type */
+    sai_health_data_t data;
+} sai_switch_health_data_t_v14;
+
+typedef struct _sai_switch_health_data_t_v13
+{
+    /** Type of switch health data */
+    sai_health_data_type_t data_type;
+} sai_switch_health_data_t_v13;
+
+typedef void (*on_switch_asic_sdk_health_event_v13_fn)(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t_v13 data,
+        _In_ const sai_u8_list_t description);
+
+static void on_switch_asic_sdk_health_event_v13(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t_v13 data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    printf("swtch v13: %lx %ld %d, count = %d\n", switch_id, timestamp.tv_sec,timestamp.tv_nsec,
+            description.count);
+
+    EXPECT_TRUE(timestamp.tv_sec == 1731848814);
+
+    const std::time_t &t = (std::time_t)timestamp.tv_sec;
+    std::stringstream time_ss;
+    time_ss << std::put_time(std::localtime(&t), "%Y-%m-%d %H:%M:%S");
+}
+
+typedef void (*on_switch_asic_sdk_health_event_v14_fn)(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t_v14 data,
+        _In_ const sai_u8_list_t description);
+
+static void on_switch_asic_sdk_health_event_v14(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t_v14 data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    printf("swtch v14: %lx %ld %d, count = %d\n", switch_id, timestamp.tv_sec,timestamp.tv_nsec,
+            description.count);
+
+    EXPECT_TRUE(timestamp.tv_sec == 1731848814);
+
+    const std::time_t &t = (std::time_t)timestamp.tv_sec;
+    std::stringstream time_ss;
+    time_ss << std::put_time(std::localtime(&t), "%Y-%m-%d %H:%M:%S");
+}
+
+TEST(NotificationSwitchAsicSdkHealthEvent, version)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t switchId = 0x21000000000000;
+    sai_switch_asic_sdk_health_severity_t severity = SAI_SWITCH_ASIC_SDK_HEALTH_SEVERITY_WARNING;
+    sai_switch_asic_sdk_health_category_t category = SAI_SWITCH_ASIC_SDK_HEALTH_CATEGORY_ASIC_HW;
+    sai_timespec_t timestamp = {1731848814, 123456};
+    sai_switch_health_data_t_v13 data13 = { };
+    sai_switch_health_data_t_v14 data14 = { };
+    data13.data_type = SAI_HEALTH_DATA_TYPE_GENERAL;
+    data14.data_type = SAI_HEALTH_DATA_TYPE_GENERAL;
+
+    uint8_t list[] = {123,10,9,34,100,97,116,97,34,58,32,34,48,34,10,125};
+    sai_u8_list_t desc;
+    desc.count = 16;
+    desc.list = list;
+
+    {
+        on_switch_asic_sdk_health_event_v13_fn v13 = &on_switch_asic_sdk_health_event_v13;
+        v13(switchId, severity, timestamp, category, data13, desc); // v13 call v13
+
+        on_switch_asic_sdk_health_event_v14_fn v14 = &on_switch_asic_sdk_health_event_v14;
+        v14(switchId, severity, timestamp, category, data14, desc); // v14 call v14
+    }
+
+    {
+        printf("call other\n");
+
+        on_switch_asic_sdk_health_event_v13_fn v13 = reinterpret_cast<on_switch_asic_sdk_health_event_v13_fn>((void*)&on_switch_asic_sdk_health_event_v14);
+        v13(switchId, severity, timestamp, category, data13, desc); // v13 call v14
+
+        on_switch_asic_sdk_health_event_v14_fn v14 = reinterpret_cast<on_switch_asic_sdk_health_event_v14_fn>((void*)&on_switch_asic_sdk_health_event_v13);
+        v14(switchId, severity, timestamp, category, data14, desc); // v14 call v13
+    }
 }


### PR DESCRIPTION
Related to https://github.com/sonic-net/sonic-buildimage/issues/19760.

Tests added to rule out v13 and v14 headers health_data stack shift influencing timestamp.