### PR TITLE
platform/marvell renaming to platform/marvell-prestera

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -284,7 +284,7 @@ config_syncd_cavium()
     done
 }
 
-config_syncd_marvell()
+config_syncd_marvell_prestera()
 {
     CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
 
@@ -484,8 +484,8 @@ config_syncd()
         config_syncd_cavium
     elif [ "$SONIC_ASIC_TYPE" == "centec" ]; then
         config_syncd_centec
-    elif [ "$SONIC_ASIC_TYPE" == "marvell" ]; then
-        config_syncd_marvell
+    elif [ "$SONIC_ASIC_TYPE" == "marvell-prestera" ]; then
+        config_syncd_marvell_prestera
      elif [ "$SONIC_ASIC_TYPE" == "barefoot" ]; then
          config_syncd_barefoot
     elif [ "$SONIC_ASIC_TYPE" == "nephos" ]; then


### PR DESCRIPTION

What i did
=======
this is one of the dependent set of PRs being raised for changing the marvell asic type to marvell-prestera

How i did
=======
syncd based logging enablement inside syncd docker and its related asic type checks are modified as per the renaming

How to verify
==========
Verfify syncd docker configs are applied properly in marvell-prestera platform
