### PR TITLE
VXLAN tunnel bogus error `unexpected type: SAI_OBJECT_TYPE_TUNNEL`

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -6702,6 +6702,7 @@ void Meta::meta_sai_on_port_state_change_single(
         case SAI_OBJECT_TYPE_PORT:
         case SAI_OBJECT_TYPE_BRIDGE_PORT:
         case SAI_OBJECT_TYPE_LAG:
+	case SAI_OBJECT_TYPE_TUNNEL:
 
             valid = true;
             break;


### PR DESCRIPTION
When trying to debug VXLAN tunnels it is bad to have errors output in the logs that are false positives.  This can lead users to go down a rabbit hole when the error has nothing to do with the issue at hand.

Here is the error sequence:
```
Aug 16 03:14:19.373668 Odin-ec58a ERR swss#orchagent: :- meta_sai_on_port_state_change_single: data.port_id oid:0x2a0000000009bf has unexpected type: SAI_OBJECT_TYPE_TUNNEL, expected PORT, BRIDGE_PORT or LAG
Aug 16 03:14:19.375495 Odin-ec58a NOTICE swss#orchagent: :- doTask: Get port state change notification id:2a0000000009bf status:1
Aug 16 03:14:19.375495 Odin-ec58a ERR swss#orchagent: :- doTask: Failed to get port object for port id 0x2a0000000009bf
```

In this case, as reported in https://github.com/sonic-net/sonic-buildimage/issues/10004 the fix is to simply add the `SAI_OBJECT_TYPE_TUNNEL` to the switch statement.

This is a trivial correction for an incorrect log entry.  It doesn't appear to alter behavior in any way.

It has been confirmed via my own Dell S5248F switches to resolve this false-positive error message.

Signed-off-by: Brad House (@bradh352)