### PR TITLE
[syncd] Add attribute version check feature

### DIFF
--- a/syncd/AttrVersionChecker.cpp
+++ b/syncd/AttrVersionChecker.cpp
@@ -1,0 +1,107 @@
+#include "AttrVersionChecker.h"
+
+#include "swss/logger.h"
+
+using namespace syncd;
+
+AttrVersionChecker::AttrVersionChecker():
+    m_enabled(false),
+    m_saiApiVersion(SAI_VERSION(0,0,0))
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+void AttrVersionChecker::enable(
+        _In_ bool enable)
+{
+    SWSS_LOG_ENTER();
+
+    m_enabled = enable;
+}
+
+void AttrVersionChecker::setSaiApiVersion(
+        _In_ sai_api_version_t version)
+{
+    SWSS_LOG_ENTER();
+
+    m_saiApiVersion = version;
+}
+
+void AttrVersionChecker::reset()
+{
+    SWSS_LOG_ENTER();
+
+    m_visitedAttributes.clear();
+}
+
+bool AttrVersionChecker::isSufficientVersion(
+        _In_ const sai_attr_metadata_t *md)
+{
+    SWSS_LOG_ENTER();
+
+    if (md == nullptr)
+    {
+        SWSS_LOG_ERROR("md is NULL");
+
+        return false;
+    }
+
+    if (!m_enabled)
+    {
+        return true;
+    }
+
+    if (SAI_METADATA_HAVE_ATTR_VERSION == 0)
+    {
+        // metadata does not contain attr versions, no check will be preformed
+        return true;
+    }
+
+    // check attr version if metadata have version defined
+
+    if (m_saiApiVersion > md->apiversion)
+    {
+        // ok, SAI version is bigger than attribute release version
+
+        return true;
+    }
+
+    if (m_saiApiVersion < md->apiversion)
+    {
+        // skip, SAI version is not sufficient
+
+        if (m_visitedAttributes.find(md->attridname) == m_visitedAttributes.end())
+        {
+            m_visitedAttributes.insert(md->attridname);
+
+            // log only once
+
+            SWSS_LOG_WARN("SAI version %lu, not sufficient to discover %s", m_saiApiVersion, md->attridname);
+        }
+
+        return false;
+    }
+
+    // m_saiApiVersion == md->apiversion
+
+    if (md->nextrelease == false)
+    {
+        // ok, SAI version is equal to attribute version
+        return true;
+    }
+
+    // next release == true
+
+    if (m_visitedAttributes.find(md->attridname) == m_visitedAttributes.end())
+    {
+        m_visitedAttributes.insert(md->attridname);
+
+        // warn only once
+
+        SWSS_LOG_WARN("%s is ment for next release after %lu, will not discover", md->attridname, m_saiApiVersion);
+    }
+
+    return false;
+}

--- a/syncd/AttrVersionChecker.h
+++ b/syncd/AttrVersionChecker.h
@@ -1,0 +1,40 @@
+#pragma once
+
+extern "C" {
+#include "sai.h"
+#include "saimetadata.h"
+}
+
+#include <set>
+#include <string>
+
+namespace syncd
+{
+    class AttrVersionChecker
+    {
+        public:
+
+            AttrVersionChecker();
+
+        public:
+
+            void enable(
+                    _In_ bool enable);
+
+            void setSaiApiVersion(
+                    _In_ sai_api_version_t version);
+
+            void reset();
+
+            bool isSufficientVersion(
+                    _In_ const sai_attr_metadata_t *md);
+
+        private:
+
+            bool m_enabled;
+
+            sai_api_version_t m_saiApiVersion;
+
+            std::set<std::string> m_visitedAttributes;
+    };
+}

--- a/syncd/CommandLineOptions.cpp
+++ b/syncd/CommandLineOptions.cpp
@@ -44,6 +44,9 @@ CommandLineOptions::CommandLineOptions()
 
 #endif // SAITHRIFT
 
+    m_supportingBulkCounterGroups = "";
+
+    m_enableAttrVersionCheck = false;
 }
 
 std::string CommandLineOptions::getCommandLineString() const
@@ -67,6 +70,7 @@ std::string CommandLineOptions::getCommandLineString() const
     ss << " BreakConfig=" << m_breakConfig;
     ss << " WatchdogWarnTimeSpan=" << m_watchdogWarnTimeSpan;
     ss << " SupportingBulkCounters=" << m_supportingBulkCounterGroups;
+    ss << " EnableAttrVersionCheck=" << (m_enableAttrVersionCheck ? "YES" : "NO");
 
 #ifdef SAITHRIFT
 

--- a/syncd/CommandLineOptions.h
+++ b/syncd/CommandLineOptions.h
@@ -100,5 +100,6 @@ namespace syncd
 
             std::string m_supportingBulkCounterGroups;
 
+            bool m_enableAttrVersionCheck;
     };
 }

--- a/syncd/CommandLineOptionsParser.cpp
+++ b/syncd/CommandLineOptionsParser.cpp
@@ -19,9 +19,9 @@ std::shared_ptr<CommandLineOptions> CommandLineOptionsParser::parseCommandLine(
     auto options = std::make_shared<CommandLineOptions>();
 
 #ifdef SAITHRIFT
-    const char* const optstring = "dp:t:g:x:b:B:w:uSUCsz:lrm:h";
+    const char* const optstring = "dp:t:g:x:b:B:aw:uSUCsz:lrm:h";
 #else
-    const char* const optstring = "dp:t:g:x:b:B:w:uSUCsz:lh";
+    const char* const optstring = "dp:t:g:x:b:B:aw:uSUCsz:lh";
 #endif // SAITHRIFT
 
     while (true)
@@ -43,6 +43,7 @@ std::shared_ptr<CommandLineOptions> CommandLineOptionsParser::parseCommandLine(
             { "breakConfig",             required_argument, 0, 'b' },
             { "watchdogWarnTimeSpan",    optional_argument, 0, 'w' },
             { "supportingBulkCounters",  required_argument, 0, 'B' },
+            { "enableAttrVersionCheck",  no_argument,       0, 'a' },
 #ifdef SAITHRIFT
             { "rpcserver",               no_argument,       0, 'r' },
             { "portmap",                 required_argument, 0, 'm' },
@@ -138,6 +139,10 @@ std::shared_ptr<CommandLineOptions> CommandLineOptionsParser::parseCommandLine(
                 options->m_supportingBulkCounterGroups = std::string(optarg);
                 break;
 
+            case 'a':
+                options->m_enableAttrVersionCheck = true;
+                break;
+
             case 'h':
                 printUsage();
                 exit(EXIT_SUCCESS);
@@ -196,6 +201,8 @@ void CommandLineOptionsParser::printUsage()
     std::cout << "        Watchdog time span (in microseconds) to watch for execution" << std::endl;
     std::cout << "    -B --supportingBulkCounters" << std::endl;
     std::cout << "        Counter groups those support bulk polling" << std::endl;
+    std::cout << "    -a --enableAttrVersionCheck" << std::endl;
+    std::cout << "        Enable attribute SAI version check when performing SAI discovery" << std::endl;
 
 #ifdef SAITHRIFT
 

--- a/syncd/HardReiniter.cpp
+++ b/syncd/HardReiniter.cpp
@@ -13,11 +13,13 @@ HardReiniter::HardReiniter(
         _In_ std::shared_ptr<RedisClient> client,
         _In_ std::shared_ptr<VirtualOidTranslator> translator,
         _In_ std::shared_ptr<sairedis::SaiInterface> sai,
-        _In_ std::shared_ptr<NotificationHandler> handler):
+        _In_ std::shared_ptr<NotificationHandler> handler,
+        _In_ bool checkAttrVersion):
     m_vendorSai(sai),
     m_translator(translator),
     m_client(client),
-    m_handler(handler)
+    m_handler(handler),
+    m_checkAttrVersion(checkAttrVersion)
 {
     SWSS_LOG_ENTER();
 
@@ -99,7 +101,8 @@ std::map<sai_object_id_t, std::shared_ptr<syncd::SaiSwitch>> HardReiniter::hardR
                 m_handler,
                 m_switchVidToRid.at(kvp.first),
                 m_switchRidToVid.at(kvp.first),
-                kvp.second);
+                kvp.second,
+                m_checkAttrVersion);
 
         sr->hardReinit();
 

--- a/syncd/HardReiniter.h
+++ b/syncd/HardReiniter.h
@@ -27,7 +27,8 @@ namespace syncd
                     _In_ std::shared_ptr<RedisClient> client,
                     _In_ std::shared_ptr<VirtualOidTranslator> translator,
                     _In_ std::shared_ptr<sairedis::SaiInterface> sai,
-                    _In_ std::shared_ptr<NotificationHandler> handler);
+                    _In_ std::shared_ptr<NotificationHandler> handler,
+                    _In_ bool checkAttrVersion);
 
             virtual ~HardReiniter();
 
@@ -59,5 +60,7 @@ namespace syncd
             std::shared_ptr<RedisClient> m_client;
 
             std::shared_ptr<NotificationHandler> m_handler;
+
+            bool m_checkAttrVersion;
     };
 }

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -17,6 +17,7 @@ noinst_LIBRARIES = libSyncd.a libSyncdRequestShutdown.a libMdioIpcClient.a
 libSyncd_a_SOURCES = \
 				AsicOperation.cpp \
 				AsicView.cpp \
+				AttrVersionChecker.cpp \
 				BestCandidateFinder.cpp \
 				BreakConfig.cpp \
 				BreakConfigParser.cpp \

--- a/syncd/SaiDiscovery.h
+++ b/syncd/SaiDiscovery.h
@@ -2,6 +2,8 @@
 
 #include "meta/SaiInterface.h"
 
+#include "AttrVersionChecker.h"
+
 #include <memory>
 #include <set>
 #include <map>
@@ -18,7 +20,8 @@ namespace syncd
         public:
 
             SaiDiscovery(
-                    _In_ std::shared_ptr<sairedis::SaiInterface> sai);
+                    _In_ std::shared_ptr<sairedis::SaiInterface> sai,
+                    _In_ bool checkAttrVersion);
 
             virtual ~SaiDiscovery();
 
@@ -61,5 +64,7 @@ namespace syncd
             std::shared_ptr<sairedis::SaiInterface> m_sai;
 
             DefaultOidMap m_defaultOidMap;
+
+            AttrVersionChecker m_attrVersionChecker;
     };
 }

--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -26,12 +26,14 @@ SaiSwitch::SaiSwitch(
         _In_ std::shared_ptr<RedisClient> client,
         _In_ std::shared_ptr<VirtualOidTranslator> translator,
         _In_ std::shared_ptr<sairedis::SaiInterface> vendorSai,
-        _In_ bool warmBoot):
+        _In_ bool warmBoot,
+        _In_ bool checkAttrVersion):
     SaiSwitchInterface(switch_vid, switch_rid),
     m_vendorSai(vendorSai),
     m_warmBoot(warmBoot),
     m_translator(translator),
-    m_client(client)
+    m_client(client),
+    m_checkAttrVersion(checkAttrVersion)
 {
     SWSS_LOG_ENTER();
 
@@ -661,7 +663,7 @@ void SaiSwitch::helperDiscover()
 {
     SWSS_LOG_ENTER();
 
-    SaiDiscovery sd(m_vendorSai);
+    SaiDiscovery sd(m_vendorSai, m_checkAttrVersion);
 
     m_discovered_rids = sd.discover(m_switch_rid);
 
@@ -952,7 +954,7 @@ void SaiSwitch::onPostPortCreate(
 {
     SWSS_LOG_ENTER();
 
-    SaiDiscovery sd(m_vendorSai);
+    SaiDiscovery sd(m_vendorSai, m_checkAttrVersion);
 
     auto discovered = sd.discover(port_rid);
 

--- a/syncd/SaiSwitch.h
+++ b/syncd/SaiSwitch.h
@@ -34,7 +34,8 @@ namespace syncd
                     _In_ std::shared_ptr<RedisClient> client,
                     _In_ std::shared_ptr<VirtualOidTranslator> translator,
                     _In_ std::shared_ptr<sairedis::SaiInterface> vendorSai,
-                    _In_ bool warmBoot = false);
+                    _In_ bool warmBoot,
+                    _In_ bool checkAttrVersion);
 
             virtual ~SaiSwitch() = default;
 
@@ -353,5 +354,7 @@ namespace syncd
             std::shared_ptr<VirtualOidTranslator> m_translator;
 
             std::shared_ptr<RedisClient> m_client;
+
+            bool m_checkAttrVersion;
     };
 }

--- a/syncd/SingleReiniter.cpp
+++ b/syncd/SingleReiniter.cpp
@@ -22,14 +22,16 @@ SingleReiniter::SingleReiniter(
         _In_ std::shared_ptr<NotificationHandler> handler,
         _In_ const ObjectIdMap& vidToRidMap,
         _In_ const ObjectIdMap& ridToVidMap,
-        _In_ const std::vector<std::string>& asicKeys):
+        _In_ const std::vector<std::string>& asicKeys,
+        _In_ bool checkAttrVersion):
     m_vendorSai(sai),
     m_vidToRidMap(vidToRidMap),
     m_ridToVidMap(ridToVidMap),
     m_asicKeys(asicKeys),
     m_translator(translator),
     m_client(client),
-    m_handler(handler)
+    m_handler(handler),
+    m_checkAttrVersion(checkAttrVersion)
 {
     SWSS_LOG_ENTER();
 
@@ -317,7 +319,7 @@ void SingleReiniter::processSwitches()
          * object, so when doing discover we will get full default ASIC view.
          */
 
-        m_sw = std::make_shared<SaiSwitch>(m_switch_vid, m_switch_rid, m_client, m_translator, m_vendorSai);
+        m_sw = std::make_shared<SaiSwitch>(m_switch_vid, m_switch_rid, m_client, m_translator, m_vendorSai, false, m_checkAttrVersion);
 
         /*
          * We processed switch. We have switch vid/rid so we can process all

--- a/syncd/SingleReiniter.h
+++ b/syncd/SingleReiniter.h
@@ -32,7 +32,8 @@ namespace syncd
                     _In_ std::shared_ptr<NotificationHandler> handler,
                     _In_ const ObjectIdMap& vidToRidMap,
                     _In_ const ObjectIdMap& ridToVidMap,
-                    _In_ const std::vector<std::string>& asicKeys);
+                    _In_ const std::vector<std::string>& asicKeys,
+                    _In_ bool checkAttrVersion);
 
             virtual ~SingleReiniter();
 
@@ -136,5 +137,7 @@ namespace syncd
             std::shared_ptr<RedisClient> m_client;
 
             std::shared_ptr<NotificationHandler> m_handler;
+
+            bool m_checkAttrVersion;
     };
 }

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -3136,7 +3136,7 @@ sai_status_t Syncd::processOidCreate(
              * constructor, like getting all queues, ports, etc.
              */
 
-            m_switches[switchVid] = std::make_shared<SaiSwitch>(switchVid, objectRid, m_client, m_translator, m_vendorSai);
+            m_switches[switchVid] = std::make_shared<SaiSwitch>(switchVid, objectRid, m_client, m_translator, m_vendorSai, false, m_commandLineOptions->m_enableAttrVersionCheck);
 
             m_mdioIpcServer->setSwitchId(objectRid);
 
@@ -4353,7 +4353,7 @@ void Syncd::onSyncdStart(
         SWSS_LOG_THROW("performing hard reinit, but there are %zu switches defined, bug!", m_switches.size());
     }
 
-    HardReiniter hr(m_client, m_translator, m_vendorSai, m_handler);
+    HardReiniter hr(m_client, m_translator, m_vendorSai, m_handler, m_commandLineOptions->m_enableAttrVersionCheck);
 
     m_switches = hr.hardReinit();
 
@@ -4455,7 +4455,7 @@ void Syncd::onSwitchCreateInInitViewMode(
 
         // make switch initialization and get all default data
 
-        m_switches[switchVid] = std::make_shared<SaiSwitch>(switchVid, switchRid, m_client, m_translator, m_vendorSai);
+        m_switches[switchVid] = std::make_shared<SaiSwitch>(switchVid, switchRid, m_client, m_translator, m_vendorSai, false, m_commandLineOptions->m_enableAttrVersionCheck);
 
         m_mdioIpcServer->setSwitchId(switchRid);
 
@@ -4639,7 +4639,7 @@ void Syncd::performWarmRestartSingleSwitch(
 
     // perform all get operations on existing switch
 
-    auto sw = m_switches[switchVid] = std::make_shared<SaiSwitch>(switchVid, switchRid, m_client, m_translator, m_vendorSai, true);
+    auto sw = m_switches[switchVid] = std::make_shared<SaiSwitch>(switchVid, switchRid, m_client, m_translator, m_vendorSai, true, m_commandLineOptions->m_enableAttrVersionCheck);
 
     startDiagShell(switchRid);
 }

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -478,3 +478,4 @@ saiproxy
 submodule
 Enqueue
 deque
+apiversion

--- a/tests/utils.pm
+++ b/tests/utils.pm
@@ -48,19 +48,19 @@ sub flush_redis
 sub start_syncd
 {
     print color('bright_blue') . "Starting syncd" . color('reset') . "\n";
-    `./vssyncd -SUu -p "$DIR/vsprofile.ini" @_ >/dev/null 2>/dev/null &`;
+    `./vssyncd -aSUu -p "$DIR/vsprofile.ini" @_ >/dev/null 2>/dev/null &`;
 }
 
 sub start_syncd_bulk
 {
     print color('bright_blue') . "Starting syncd bulk" . color('reset') . "\n";
-    `./vssyncd -SUul -p "$DIR/vsprofile.ini" @_ >/dev/null 2>/dev/null &`;
+    `./vssyncd -aSUul -p "$DIR/vsprofile.ini" @_ >/dev/null 2>/dev/null &`;
 }
 
 sub start_syncd_warm
 {
     print color('bright_blue') . "Starting syncd warm" . color('reset') . "\n";
-    `./vssyncd -SUu -t warm -p "$DIR/vsprofile.ini" >/dev/null 2>/dev/null &`;
+    `./vssyncd -aSUu -t warm -p "$DIR/vsprofile.ini" >/dev/null 2>/dev/null &`;
 
     sleep 1;
 }
@@ -68,13 +68,13 @@ sub start_syncd_warm
 sub sync_start_syncd
 {
     print color('bright_blue') . "Starting syncd" . color('reset') . "\n";
-    `./vssyncd -s -SUu -p "$DIR/vsprofile.ini" >/dev/null 2>/dev/null &`;
+    `./vssyncd -s -aSUu -p "$DIR/vsprofile.ini" >/dev/null 2>/dev/null &`;
 }
 
 sub sync_start_syncd_warm
 {
     print color('bright_blue') . "Starting syncd warm" . color('reset') . "\n";
-    `./vssyncd -s -SUu -t warm -p "$DIR/vsprofile.ini" >/dev/null 2>/dev/null &`;
+    `./vssyncd -s -aSUu -t warm -p "$DIR/vsprofile.ini" >/dev/null 2>/dev/null &`;
 
     sleep 1;
 }

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -7,6 +7,7 @@ LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main -lgmock
 tests_SOURCES = main.cpp \
                 MockableSaiInterface.cpp \
                 MockHelper.cpp \
+				TestAttrVersionChecker.cpp \
 				TestCommandLineOptions.cpp \
 				TestConcurrentQueue.cpp \
 				TestFlexCounter.cpp \

--- a/unittest/syncd/TestAttrVersionChecker.cpp
+++ b/unittest/syncd/TestAttrVersionChecker.cpp
@@ -1,0 +1,132 @@
+#include <cstdint>
+
+#include <memory>
+#include <vector>
+#include <array>
+
+#include <gtest/gtest.h>
+
+#include "AttrVersionChecker.h"
+#include "swss/logger.h"
+
+using namespace syncd;
+
+TEST(AttrVersionChecker, ctr)
+{
+    AttrVersionChecker avc;
+}
+
+TEST(AttrVersionChecker, enable)
+{
+    AttrVersionChecker avc;
+
+    avc.enable(true);
+
+    avc.enable(false);
+}
+
+TEST(AttrVersionChecker, setSaiApiVersion)
+{
+    AttrVersionChecker avc;
+
+    avc.setSaiApiVersion(SAI_VERSION(1,13,0));
+}
+
+TEST(AttrVersionChecker, reset)
+{
+    AttrVersionChecker avc;
+
+    avc.reset();
+}
+
+#define MD(x,v,n) \
+    const sai_attr_metadata_t x = {\
+        .objecttype                    = (sai_object_type_t)SAI_OBJECT_TYPE_BRIDGE,\
+        .attrid                        = SAI_BRIDGE_ATTR_PORT_LIST,\
+        .attridname                    = "SAI_BRIDGE_ATTR_PORT_LIST",\
+        .brief                         = "List of bridge ports associated to this bridge.",\
+        .attrvaluetype                 = SAI_ATTR_VALUE_TYPE_OBJECT_LIST,\
+        .flags                         = (sai_attr_flags_t)(SAI_ATTR_FLAGS_READ_ONLY),\
+        .allowedobjecttypes            = NULL,\
+        .allowedobjecttypeslength      = 0,\
+        .allowrepetitiononlist         = false,\
+        .allowmixedobjecttypes         = false,\
+        .allowemptylist                = false,\
+        .allownullobjectid             = false,\
+        .isoidattribute                = (1 > 0),\
+        .defaultvaluetype              = SAI_DEFAULT_VALUE_TYPE_NONE,\
+        .defaultvalue                  = NULL,\
+        .defaultvalueobjecttype        = SAI_OBJECT_TYPE_NULL,\
+        .defaultvalueattrid            = SAI_INVALID_ATTRIBUTE_ID,\
+        .storedefaultvalue             = false,\
+        .isenum                        = false,\
+        .isenumlist                    = false,\
+        .enummetadata                  = NULL,\
+        .conditiontype                 = SAI_ATTR_CONDITION_TYPE_NONE,\
+        .conditions                    = NULL,\
+        .conditionslength              = 0,\
+        .isconditional                 = (0 != 0),\
+        .validonlytype                 = SAI_ATTR_CONDITION_TYPE_NONE,\
+        .validonly                     = NULL,\
+        .validonlylength               = 0,\
+        .isvalidonly                   = (0 != 0),\
+        .getsave                       = false,\
+        .isvlan                        = false,\
+        .isaclfield                    = false,\
+        .isaclaction                   = false,\
+        .isaclmask                     = false,\
+        .ismandatoryoncreate           = false,\
+        .iscreateonly                  = false,\
+        .iscreateandset                = false,\
+        .isreadonly                    = true,\
+        .iskey                         = false,\
+        .isprimitive                   = false,\
+        .notificationtype              = -1,\
+        .iscallback                    = false,\
+        .pointertype                   = -1,\
+        .capability                    = NULL,\
+        .capabilitylength              = 0,\
+        .isextensionattr               = false,\
+        .isresourcetype                = false,\
+        .isdeprecated                  = false,\
+        .isconditionrelaxed            = false,\
+        .iscustom                      = false,\
+        .apiversion                    = (v),\
+        .nextrelease                   = (n),\
+    };\
+
+
+TEST(AttrVersionChecker, isSufficientVersion)
+{
+    AttrVersionChecker avc;
+
+    avc.enable(true);
+    EXPECT_EQ(avc.isSufficientVersion(nullptr), false);
+
+    avc.enable(false);
+    avc.setSaiApiVersion(SAI_VERSION(1,10,0));
+    avc.enable(true);
+
+    MD(md,SAI_VERSION(1,9,0),false);
+    EXPECT_EQ(avc.isSufficientVersion(&md), true);
+
+    MD(md1,SAI_VERSION(1,11,0),false);
+    EXPECT_EQ(avc.isSufficientVersion(&md1),false);
+
+    avc.enable(false);
+    EXPECT_EQ(avc.isSufficientVersion(&md1),true);
+
+    avc.enable(true);
+    avc.setSaiApiVersion(SAI_VERSION(1,10,0));
+    EXPECT_EQ(avc.isSufficientVersion(&md1),false);
+
+    avc.setSaiApiVersion(SAI_VERSION(1,12,0));
+    EXPECT_EQ(avc.isSufficientVersion(&md1),true);
+
+    avc.setSaiApiVersion(SAI_VERSION(1,11,0));
+    EXPECT_EQ(avc.isSufficientVersion(&md1),true);
+
+    MD(md2,SAI_VERSION(1,11,0),true);
+    avc.setSaiApiVersion(SAI_VERSION(1,11,0));
+    EXPECT_EQ(avc.isSufficientVersion(&md2),false);
+}

--- a/unittest/syncd/TestCommandLineOptions.cpp
+++ b/unittest/syncd/TestCommandLineOptions.cpp
@@ -38,6 +38,8 @@ R"(Usage: syncd [-d] [-p profile] [-t type] [-u] [-S] [-U] [-C] [-s] [-z mode] [
         Watchdog time span (in microseconds) to watch for execution
     -B --supportingBulkCounters
         Counter groups those support bulk polling
+    -a --enableAttrVersionCheck
+        Enable attribute SAI version check when performing SAI discovery
     -h --help
         Print out this message
 )";
@@ -51,7 +53,7 @@ TEST(CommandLineOptions, getCommandLineString)
     EXPECT_EQ(str, " EnableDiagShell=NO EnableTempView=NO DisableExitSleep=NO EnableUnittests=NO"
             " EnableConsistencyCheck=NO EnableSyncMode=NO RedisCommunicationMode=redis_async"
             " EnableSaiBulkSuport=NO StartType=cold ProfileMapFile= GlobalContext=0 ContextConfig= BreakConfig="
-            " WatchdogWarnTimeSpan=30000000 SupportingBulkCounters=");
+            " WatchdogWarnTimeSpan=30000000 SupportingBulkCounters= EnableAttrVersionCheck=NO");
 }
 
 TEST(CommandLineOptions, startTypeStringToStartType)


### PR DESCRIPTION
By default disabled. If enabled, it will use SAI metadata and libsai version returned by sai_api_version_query to verify if given attribute during SAI discovery process was introduced in the current libsai version or below that version.

This feature is partial solution to this problem:
https://github.com/sonic-net/sonic-buildimage/issues/20725, more here: https://github.com/opencomputeproject/SAI/issues/2099