### PR TITLE
Update pipeline to build for bookworm

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -207,7 +207,7 @@ jobs:
           set -ex
           # Install .NET CORE
           curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          sudo apt-add-repository https://packages.microsoft.com/debian/11/prod
+          sudo apt-add-repository https://packages.microsoft.com/debian/12/prod
           sudo apt-get update
           sudo apt-get install -y dotnet-sdk-7.0
         displayName: "Install .NET CORE"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ resources:
 parameters:
   - name: debian_version
     type: string
-    default: bullseye
+    default: bookworm
 variables:
   - name: BUILD_BRANCH
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
In order to update `docker-sonic-vs` to `bookworm` update pipeline to build for bookworm.