### PR TITLE
Turn on SAI attribute version validation

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -29,6 +29,10 @@ fi
 # Use temporary view between init view and apply view
 CMD_ARGS+=" -u"
 
+# Enable SAI attribute version checking, required currently for Broadcom
+# as per https://github.com/sonic-net/sonic-buildimage/issues/20725
+CMD_ARGS+=" -a"
+
 # Create a folder for SAI failure dump files
 mkdir -p /var/log/sai_failure_dump/
 


### PR DESCRIPTION
As per https://github.com/sonic-net/sonic-buildimage/issues/20725 attribute validation must be enabled otherwise failures will be observed.   This prevents the ASIC from coming online on broadcom and likely other vendors.

Signed-off-by: Brad House