### PR TITLE
[202405] Fix compilation error on Buster

### DIFF
--- a/unittest/syncd/TestSyncd.cpp
+++ b/unittest/syncd/TestSyncd.cpp
@@ -11,6 +11,7 @@
 
 using namespace syncd;
 
+#ifdef MOCK_METHOD
 class MockSelectableChannel : public sairedis::SelectableChannel {
 public:
     MOCK_METHOD(bool, empty, (), (override));
@@ -59,3 +60,5 @@ TEST_F(SyncdTest, processNotifySyncd)
     }));
     syncd_object.processEvent(consumer);
 }
+
+#endif


### PR DESCRIPTION
There is issue causing compilation failures of sairedis on Buster. Since the SONiC PTF container is still based on Buster, sairedis still needs to compile for Buster.

The TestSyncd.cpp file uses the MOCK_METHOD macro. However, this macro is available only from version 1.10 of gmock, but Buster has version 1.8.1. As a simple fix, check to see if MOCK_METHOD is defined; if not, then don't compile this test.