### PR TITLE
Revert "Do not enter vendor SAI critical section for counter polling/clearing operations (#1450)"

### DIFF
--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -313,6 +313,7 @@ sai_status_t VendorSai::getStats(
         _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
@@ -350,6 +351,7 @@ sai_status_t VendorSai::getStatsExt(
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
@@ -364,6 +366,7 @@ sai_status_t VendorSai::clearStats(
         _In_ uint32_t number_of_counters,
         _In_ const sai_stat_id_t *counter_ids)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
@@ -383,6 +386,7 @@ sai_status_t VendorSai::bulkGetStats(
         _Inout_ sai_status_t *object_statuses,
         _Out_ uint64_t *counters)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
@@ -410,6 +414,7 @@ sai_status_t VendorSai::bulkClearStats(
         _In_ sai_stats_mode_t mode,
         _Inout_ sai_status_t *object_statuses)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -156,6 +156,28 @@ TEST(VendorSai, bulkGetStats)
                                                              nullptr));
 }
 
+TEST(VendorSai, getStatsExt)
+{
+    VendorSai sai;
+    sai.apiInitialize(0, &test_services);
+    ASSERT_EQ(SAI_STATUS_NOT_SUPPORTED, sai.getStatsExt(SAI_OBJECT_TYPE_NULL,
+                                                          SAI_NULL_OBJECT_ID,
+                                                          0,
+                                                          nullptr,
+                                                          SAI_STATS_MODE_READ,
+                                                          nullptr));
+}
+
+TEST(VendorSai, clearStats)
+{
+    VendorSai sai;
+    sai.apiInitialize(0, &test_services);
+    ASSERT_EQ(SAI_STATUS_NOT_SUPPORTED, sai.clearStats(SAI_OBJECT_TYPE_NULL,
+                                                       SAI_NULL_OBJECT_ID,
+                                                       0,
+                                                       nullptr));
+}
+
 sai_object_id_t create_port(
         _In_ VendorSai& sai,
         _In_ sai_object_id_t switch_id)


### PR DESCRIPTION
Revert "Do not enter vendor SAI critical section for counter polling/clearing operations (#1450)"

This reverts commit 0317b16e4fdccf769c77a7b164ff90c1365c7d4e.