### PR TITLE
Fix for credo gbsyncd warm-reboot

### DIFF
--- a/syncd/ComparisonLogic.cpp
+++ b/syncd/ComparisonLogic.cpp
@@ -61,9 +61,26 @@ ComparisonLogic::ComparisonLogic(
 
     // TODO needs to be removed and done in generic
 
-    m_current->m_defaultTrapGroupRid     = m_switch->getSwitchDefaultAttrOid(SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP);
-    m_temp->m_defaultTrapGroupRid        = m_switch->getSwitchDefaultAttrOid(SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP);
+    try
+    {
+        m_current->m_defaultTrapGroupRid     = m_switch->getSwitchDefaultAttrOid(SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP);
+    }
+    catch(const std::exception &e)
+    {
+        SWSS_LOG_WARN("Failed to to obtain SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP in current view");
+        m_current->m_defaultTrapGroupRid = SAI_NULL_OBJECT_ID;
+    }
 
+    try
+    {
+        m_temp->m_defaultTrapGroupRid        = m_switch->getSwitchDefaultAttrOid(SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP);
+    }
+    catch(const std::exception &e)
+    {
+        SWSS_LOG_WARN("Failed to to obtain SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP in temp view");
+        m_temp->m_defaultTrapGroupRid = SAI_NULL_OBJECT_ID;
+
+    }
     auto seed = (unsigned int)std::time(0);
 
     SWSS_LOG_NOTICE("srand seed for switch %s: %u", sai_serialize_object_id(m_switch->getVid()).c_str(), seed);
@@ -2272,7 +2289,7 @@ void ComparisonLogic::bringDefaultTrapGroupToFinalState(
 
     sai_object_id_t rid = currentView.m_defaultTrapGroupRid;
 
-    if (temporaryView.hasRid(rid))
+    if (rid == SAI_NULL_OBJECT_ID || temporaryView.hasRid(rid))
     {
         /*
          * Default trap group is defined inside temporary view

--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -691,6 +691,15 @@ bool RedisClient::hasNoHiddenKeysDefined() const
     return keys.size() == 0;
 }
 
+bool RedisClient::hasNoSwitchDefined() const
+{
+    SWSS_LOG_ENTER();
+
+    auto keys = m_dbAsic->keys("ASIC_STATE:SAI_OBJECT_TYPE_SWITCH:*");
+
+    return keys.size() == 0;
+}
+
 void RedisClient::removeVidAndRid(
         _In_ sai_object_id_t vid,
         _In_ sai_object_id_t rid)

--- a/syncd/RedisClient.h
+++ b/syncd/RedisClient.h
@@ -119,6 +119,7 @@ namespace syncd
                     _In_ const std::string& key) const;
 
             bool hasNoHiddenKeysDefined() const;
+            bool hasNoSwitchDefined() const;
 
             void removeVidAndRid(
                     _In_ sai_object_id_t vid,

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -4645,7 +4645,16 @@ void Syncd::performWarmRestartSingleSwitch(
     sai_attribute_t *attrList = list.get_attr_list();
 
     uint32_t attrCount = list.get_attr_count();
-
+    bool isPhy = false;
+    for (uint32_t idx = 0; idx < attrCount; idx++)
+    {
+        auto id = attrList[idx].id;
+        if (id == SAI_SWITCH_ATTR_TYPE && attrList[idx].value.s32 == SAI_SWITCH_TYPE_PHY)
+        {
+            isPhy = true;
+            break;
+        }
+    }
     for (uint32_t idx = 0; idx < attrCount; idx++)
     {
         auto id = attrList[idx].id;
@@ -4662,7 +4671,7 @@ void Syncd::performWarmRestartSingleSwitch(
          * new process could be loaded at different address space.
          */
 
-        if (id == SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO || meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_POINTER)
+        if (isPhy || id == SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO || meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_POINTER)
         {
             attrs.push_back(attrList[idx]);
             continue;

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -5112,7 +5112,7 @@ bool Syncd::isVeryFirstRun()
      * this is first run, let's query HIDDEN ?
      */
 
-    bool firstRun = m_client->hasNoHiddenKeysDefined();
+    bool firstRun = m_client->hasNoHiddenKeysDefined() && m_client->hasNoSwitchDefined();
 
     SWSS_LOG_NOTICE("First Run: %s", firstRun ? "True" : "False");
 


### PR DESCRIPTION
To support credo gbsyncd warm-reboot, we found several issues to be fixed in sonic-sairedis as follows:
1) More attributes are needed for the create_switch of credo gbsyncd warm-boot. The fix here is to pass all the attributes when SAI_SWITCH_ATTR_TYPE is SAI_SWITCH_TYPE_PHY.
2) firstRun being true disallows the start of warm-reboot. It was set to true when no switch attributes is found under the key of HIDDEN* in ASIC_DB or GB_ASIC_DB. However, all such HIDDEN attributes are unrelated to the credo gbsyncd, so hasNoHiddenKeysDefined is always true for gbsyncd. The fix here is to determine the first run also based on no switch objects having been created in ASIC_DB or GB_ASIC_DB.
3) SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP is not supported by credo gbsyncd and unrelated to it. Skip the steps related to it when it is not available