### PR TITLE
[dash] Use CMD syncd_dash for kvm dpu

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -452,6 +452,11 @@ config_syncd_nephos()
 
 config_syncd_vs()
 {
+    if [[ $(sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' switch_type) == 'dpu' ]]; then
+        CMD_SYNCD=/usr/bin/syncd_dash
+        CMD=$CMD_SYNCD
+    fi
+
     CMD_ARGS+=" -l -p $HWSKU_DIR/sai.profile"
 }
 

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -453,8 +453,10 @@ config_syncd_nephos()
 config_syncd_vs()
 {
     if [[ $(sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' switch_type) == 'dpu' ]]; then
-        CMD_SYNCD=/usr/bin/syncd_dash
-        CMD=$CMD_SYNCD
+        if [[ -f /usr/bin/syncd_dash ]]; then
+            CMD_SYNCD=/usr/bin/syncd_dash
+            CMD=$CMD_SYNCD
+        fi
     fi
 
     CMD_ARGS+=" -l -p $HWSKU_DIR/sai.profile"


### PR DESCRIPTION
Use CMD `syncd_dash` in place of `syncd` while kvm sonic is running as kvm DPU