### PR TITLE
[Azure pipeline] Refresh configuration of rsyslogd using SIGHUP

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -165,7 +165,7 @@ jobs:
     displayName: "Compile sonic sairedis with coverage enabled"
   - script: |
       sudo cp azsyslog.conf /etc/rsyslog.conf
-      sudo pkill -F /run/rsyslogd.pid
+      sudo pkill --signal SIGHUP -F /run/rsyslogd.pid
       sudo rsyslogd
     displayName: "Update rsyslog.conf"
   - ${{ if eq(parameters.run_unit_test, true) }}:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -166,7 +166,6 @@ jobs:
   - script: |
       sudo cp azsyslog.conf /etc/rsyslog.conf
       sudo pkill --signal SIGHUP -F /run/rsyslogd.pid
-      sudo rsyslogd
     displayName: "Update rsyslog.conf"
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |


### PR DESCRIPTION
To overcome the rsyslog issue in azure pipeline test by refreshing rsyslogd configuration using SIGHUP instead of killing and restarting it.