### PR TITLE
[azue-pipeline] Use build agent pool sonic-ubuntu-1c

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -18,12 +18,16 @@ parameters:
   type: boolean
   default: false
 
+- name: pool
+  type: string
+  default: sonic-ubuntu-1c
+
 jobs:
 - job:
   displayName: vstest
   timeoutInMinutes: ${{ parameters.timeout }}
 
-  pool: sonic-common
+  pool: ${{ parameters.pool }}
 
   steps:
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,6 +146,7 @@ stages:
   jobs:
   - template: .azure-pipelines/test-docker-sonic-vs-template.yml
     parameters:
+      pool: sonic-ubuntu-1c
       log_artifact_name: log
 
 - stage: TestAsan
@@ -154,6 +155,7 @@ stages:
   jobs:
   - template: .azure-pipelines/test-docker-sonic-vs-template.yml
     parameters:
+      pool: sonic-ubuntu-1c
       docker_sonic_vs_name: docker-sonic-vs-asan
       log_artifact_name: log-asan
       asan: true


### PR DESCRIPTION
In azure-pipeline stage **Test**, build agent pool `sonic-common` has not been available .  Use pool `sonic-ubuntu-1c`.