### PR TITLE
Fix pipeline errors related to rsyslogd and libswsscommon installation

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -166,7 +166,10 @@ jobs:
   - script: |
       set -ex
       sudo cp azsyslog.conf /etc/rsyslog.conf
+      cat /run/rsyslogd.pid
       sudo pkill -F /run/rsyslogd.pid
+      ps -ef
+      sleep 5
       ps -ef
       sudo rsyslogd
     displayName: "Update rsyslog.conf"

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -164,8 +164,10 @@ jobs:
       mv ../*.deb .
     displayName: "Compile sonic sairedis with coverage enabled"
   - script: |
+      set -ex
       sudo cp azsyslog.conf /etc/rsyslog.conf
       sudo pkill -F /run/rsyslogd.pid
+      ps -ef
       sudo rsyslogd
     displayName: "Update rsyslog.conf"
   - ${{ if eq(parameters.run_unit_test, true) }}:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -168,8 +168,8 @@ jobs:
       sudo cp azsyslog.conf /etc/rsyslog.conf
       cat /run/rsyslogd.pid
       sudo pkill -F /run/rsyslogd.pid
-      ps -ef
-      sleep 5
+      # Looks like arm64 (and sometimes amd64) rsyslogd needs some time to exit
+      sleep 2
       ps -ef
       sudo rsyslogd
     displayName: "Update rsyslog.conf"

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -73,10 +73,8 @@ jobs:
 
       sudo apt-get update
       sudo apt-get install -y libhiredis0.14 libyang0.16
-      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
-      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb
-      sudo dpkg -i --force-confask,confnew $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb || apt-get install -f
-      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
+      sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
+      sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
 
       # install packages for vs test
       sudo apt-get install -y net-tools bridge-utils vlan

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -29,7 +29,7 @@ jobs:
   - script: |
       set -ex
       ls -A1 | xargs -I{} sudo rm -rf {}
-      sudo apt-get purge libswsscommon python3-swsscommon
+      sudo apt-get purge libswsscommon python3-swsscommon || true
     displayName: "Clean workspace"
   - checkout: self
     clean: true

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -27,7 +27,9 @@ jobs:
 
   steps:
   - script: |
+      set -ex
       ls -A1 | xargs -I{} sudo rm -rf {}
+      sudo apt-get purge libswsscommon python3-swsscommon
     displayName: "Clean workspace"
   - checkout: self
     clean: true


### PR DESCRIPTION
On arm64 (and maybe sometimes amd64), rsyslogd appears to need a second or two to actually fully exit. The current code expects it to exit practically instantly. Add a sleep of 2 seconds to give it some time. Also enable some logging so that the commands being run can be seen.

Also, fix an error related to libswsscommon not getting installed due to new dependencies being added. Solve this by using apt install to install the package, which brings in any necessary dependencies.