### PR TITLE
Define bulk chunk size and bulk chunk size per counter ID

### DIFF
--- a/lib/sairedis.h
+++ b/lib/sairedis.h
@@ -140,6 +140,20 @@ typedef struct _sai_redis_flex_counter_group_parameter_t
      */
     sai_s8_list_t plugins;
 
+    /**
+     * @brief The bulk chunk size of the counter group
+     *
+     * It should be a number representing the bulk chunk size.
+     */
+    sai_s8_list_t bulk_chunk_size;
+
+    /**
+     * @brief The bulk counter prefix map the counter group
+     *
+     * It should be a string representing bulk chunk size of each sub counter group.
+     */
+    sai_s8_list_t bulk_chunk_size_per_prefix;
+
 } sai_redis_flex_counter_group_parameter_t;
 
 typedef struct _sai_redis_flex_counter_parameter_t


### PR DESCRIPTION
Define bulk chunk size and bulk chunk size per counter ID.
This is to resolve the VS test failure in #1457, which is caused by loop dependency.
In PR #1457, new fields `bulk_chunk_size` and `bulk_chunk_size_per_prefix` have been introduced to `sai_redis_flex_counter_group_parameter_t` whose instances are initialized by orchagent.
However, the orchagent is still compiled with the old sairedis header, which prevents both new fields from being uninitialized which in turn fails vs test.

We have to split this PR into two:
1. #1519 which updates the header sairedis.h only. the motivation is to compile swss(orchagent) with both new fields initiated.
2. #1457 contains all the rest of code

The order to merge:
1. #1519
2. https://github.com/sonic-net/sonic-swss/pull/3391
3. #1457