### PR TITLE
[syncd] Move logSet logGet under mutex to prevent race condition

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -72,6 +72,7 @@ jobs:
       sudo sonic-sairedis/.azure-pipelines/build_and_install_module.sh
 
       sudo apt-get update
+      sudo apt --fix-broken install
       sudo apt-get install -y libhiredis0.14 libyang0.16
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb

--- a/lib/sai_redis_interfacequery.cpp
+++ b/lib/sai_redis_interfacequery.cpp
@@ -27,7 +27,7 @@ sai_status_t sai_log_set(
 {
     SWSS_LOG_ENTER();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return redis_sai->logSet(sai_api_id, log_level);
 }
 
 #define API(api) .api ## _api = const_cast<sai_ ## api ## _api_t*>(&redis_ ## api ## _api)

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -1679,6 +1679,7 @@ sai_status_t VendorSai::logSet(
         _In_ sai_api_t api,
         _In_ sai_log_level_t log_level)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
 
     m_logLevelMap[api] = log_level;
@@ -1689,6 +1690,7 @@ sai_status_t VendorSai::logSet(
 sai_log_level_t VendorSai::logGet(
         _In_ sai_api_t api)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
 
     auto it = m_logLevelMap.find(api);

--- a/unittest/lib/test_sai_redis_interfacequery.cpp
+++ b/unittest/lib/test_sai_redis_interfacequery.cpp
@@ -8,7 +8,7 @@ extern "C" {
 
 TEST(libsairedis, sai_log_set)
 {
-    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai_log_set(SAI_API_VLAN, SAI_LOG_LEVEL_NOTICE));
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai_log_set(SAI_API_VLAN, SAI_LOG_LEVEL_NOTICE));
 }
 
 TEST(libsairedis, sai_api_query)

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -1409,11 +1409,11 @@ TEST(VendorSai, bulk_dash_outbound_ca_to_pa_entry)
 TEST(VendorSai, logSet_logGet)
 {
     VendorSai sai;
-    sai.apiInitialize(0, &test_services);
+    sai.initialize(0, &test_services);
 
     EXPECT_EQ(SAI_STATUS_SUCCESS, sai.logSet(SAI_API_PORT, SAI_LOG_LEVEL_DEBUG));
 
-    EXPECT(SAI_LOG_LEVEL_DEBUG, sai.logGet(SAI_API_PORT));
-    EXPECT(SAI_LOG_LEVEL_NOTICE, sai.logGet(SAI_API_SWITCH));
+    EXPECT_EQ(SAI_LOG_LEVEL_DEBUG, sai.logGet(SAI_API_PORT));
+    EXPECT_EQ(SAI_LOG_LEVEL_NOTICE, sai.logGet(SAI_API_SWITCH));
 }
 

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -1405,3 +1405,15 @@ TEST(VendorSai, bulk_dash_outbound_ca_to_pa_entry)
     remove_counter(sai, counter0);
     remove_counter(sai, counter1);
 }
+
+TEST(VendorSai, logSet_logGet)
+{
+    VendorSai sai;
+    sai.apiInitialize(0, &test_services);
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.logSet(SAI_API_PORT, SAI_LOG_LEVEL_DEBUG));
+
+    EXPECT(SAI_LOG_LEVEL_DEBUG, sai.logGet(SAI_API_PORT));
+    EXPECT(SAI_LOG_LEVEL_NOTICE, sai.logGet(SAI_API_SWITCH));
+}
+

--- a/unittest/vslib/test_sai_vs_interfacequery.cpp
+++ b/unittest/vslib/test_sai_vs_interfacequery.cpp
@@ -8,7 +8,7 @@ extern "C" {
 
 TEST(libsaivs, sai_log_set)
 {
-    EXPECT_EQ(SAI_STATUS_NOT_IMPLEMENTED, sai_log_set(SAI_API_VLAN, SAI_LOG_LEVEL_NOTICE));
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai_log_set(SAI_API_VLAN, SAI_LOG_LEVEL_NOTICE));
 }
 
 TEST(libsaivs, sai_api_query)

--- a/vslib/sai_vs_interfacequery.cpp
+++ b/vslib/sai_vs_interfacequery.cpp
@@ -25,7 +25,7 @@ sai_status_t sai_log_set(
 {
     SWSS_LOG_ENTER();
 
-    return SAI_STATUS_NOT_IMPLEMENTED;
+    return vs_sai->logSet(sai_api_id, log_level);
 }
 
 #define API(api) .api ## _api = const_cast<sai_ ## api ## _api_t*>(&vs_ ## api ## _api)


### PR DESCRIPTION
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/21180