### PR TITLE
Update log level for bulk api

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -2109,7 +2109,7 @@ sai_status_t Syncd::processBulkOidCreate(
 
     if (status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_NOT_SUPPORTED)
     {
-        SWSS_LOG_ERROR("bulkCreate api is not implemented or not supported, object_type = %s",
+        SWSS_LOG_WARN("bulkCreate api is not implemented or not supported, object_type = %s",
                 sai_serialize_object_type(objectType).c_str());
         return status;
     }
@@ -2185,7 +2185,7 @@ sai_status_t Syncd::processBulkOidSet(
 
     if (status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_NOT_SUPPORTED)
     {
-        SWSS_LOG_ERROR("bulkSet api is not implemented or not supported, object_type = %s",
+        SWSS_LOG_WARN("bulkSet api is not implemented or not supported, object_type = %s",
                 sai_serialize_object_type(objectType).c_str());
     }
 
@@ -2233,7 +2233,7 @@ sai_status_t Syncd::processBulkOidRemove(
 
     if (status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_NOT_SUPPORTED)
     {
-        SWSS_LOG_ERROR("bulkRemove api is not implemented or not supported, object_type = %s",
+        SWSS_LOG_WARN("bulkRemove api is not implemented or not supported, object_type = %s",
                 sai_serialize_object_type(objectType).c_str());
         return status;
     }


### PR DESCRIPTION
Log level should be warning instead of error, because functionality is fine. Latter code will fall back to use single api instead of bulk api, when syncd support bulk but sai doesn't support it.

**Background**
When syncd added support for bulk APIs like bulk set, but sai didn't implement it, this error will be printed:
"processBulkOidSet: bulk set api is not implemented or not supported, object_type = SAI_OBJECT_TYPE_QUEUE", and it will fail the cases. Actually the print should be warning, as in current code, bulk set fall back to single set in latter code, so sai will still receive single set APIs, so functionality is actually OK.

**What I did**
Update log level from error to warning.

**How to verify it**
When bulk set api is added in syncd, but sai did not implement it, only warning logs will be printed, instead of error logs.