### PR TITLE
[syncd] Move logSet logGet under mutex to prevent race condition (#1520)

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -74,6 +74,7 @@ jobs:
       sudo sonic-sairedis/.azure-pipelines/build_and_install_module.sh
 
       sudo apt-get update
+      sudo apt --fix-broken install
       sudo apt-get install -y libhiredis0.14 libyang0.16
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -1885,6 +1885,7 @@ sai_status_t VendorSai::logSet(
         _In_ sai_api_t api,
         _In_ sai_log_level_t log_level)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
 
     m_logLevelMap[api] = log_level;
@@ -1903,6 +1904,7 @@ sai_status_t VendorSai::queryApiVersion(
 sai_log_level_t VendorSai::logGet(
         _In_ sai_api_t api)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
 
     auto it = m_logLevelMap.find(api);

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -1547,7 +1547,7 @@ TEST(VendorSai, bulk_meter_rules)
 TEST(VendorSai, logSet_logGet)
 {
     VendorSai sai;
-    sai.initialize(0, &test_services);
+    sai.apiInitialize(0, &test_services);
 
     EXPECT_EQ(SAI_STATUS_SUCCESS, sai.logSet(SAI_API_PORT, SAI_LOG_LEVEL_DEBUG));
 

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -1543,3 +1543,14 @@ TEST(VendorSai, bulk_meter_rules)
     EXPECT_EQ(SAI_STATUS_SUCCESS, sai.remove((sai_object_type_t)SAI_OBJECT_TYPE_METER_POLICY, meter_policy0));
     EXPECT_EQ(SAI_STATUS_SUCCESS, sai.remove((sai_object_type_t)SAI_OBJECT_TYPE_METER_POLICY, meter_policy1));
 }
+
+TEST(VendorSai, logSet_logGet)
+{
+    VendorSai sai;
+    sai.initialize(0, &test_services);
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.logSet(SAI_API_PORT, SAI_LOG_LEVEL_DEBUG));
+
+    EXPECT_EQ(SAI_LOG_LEVEL_DEBUG, sai.logGet(SAI_API_PORT));
+    EXPECT_EQ(SAI_LOG_LEVEL_NOTICE, sai.logGet(SAI_API_SWITCH));
+}


### PR DESCRIPTION
* [syncd] Move logSet logGet under mutex to prevent race condition

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/21180