### PR TITLE
Fix counter issues on VS platform

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -480,7 +480,7 @@ class CounterContext : public BaseCounterContext
     std::map<std::string, uint32_t> m_counterChunkSizeMapFromPrefix;
 
 protected:
-    sai_object_id_t m_switchId;
+    sai_object_id_t m_switchId = SAI_NULL_OBJECT_ID;
 
 public:
     typedef CounterIds<StatType> CounterIdsType;
@@ -1445,7 +1445,7 @@ private:
         stats_capability.count = 0;
         stats_capability.list = nullptr;
 
-        if (m_switchId == 0UL)
+        if (m_switchId == SAI_NULL_OBJECT_ID)
         {
             m_switchId = m_vendorSai->switchIdQuery(rid);
         }

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -914,6 +914,12 @@ public:
             }
         }
 
+        if (supportedIds.empty())
+        {
+            SWSS_LOG_NOTICE("%s %s does not have supported counters", m_name.c_str(), m_instanceId.c_str());
+            return;
+        }
+
         std::map<std::vector<StatType>, std::tuple<const std::string, uint32_t>> bulkUnsupportedCounters;
         auto statsMode = m_groupStatsMode == SAI_STATS_MODE_READ ? SAI_STATS_MODE_BULK_READ : SAI_STATS_MODE_BULK_READ_AND_CLEAR;
         auto checkAndUpdateBulkCapability = [&](const std::vector<StatType> &counter_ids, const std::string &prefix, uint32_t bulk_chunk_size)

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -479,6 +479,9 @@ class CounterContext : public BaseCounterContext
 {
     std::map<std::string, uint32_t> m_counterChunkSizeMapFromPrefix;
 
+protected:
+    sai_object_id_t m_switchId;
+
 public:
     typedef CounterIds<StatType> CounterIdsType;
     typedef BulkStatsContext<StatType> BulkContextType;
@@ -1442,9 +1445,14 @@ private:
         stats_capability.count = 0;
         stats_capability.list = nullptr;
 
+        if (m_switchId == 0UL)
+        {
+            m_switchId = m_vendorSai->switchIdQuery(rid);
+        }
+
         /* First call is to check the size needed to allocate */
         sai_status_t status = m_vendorSai->queryStatsCapability(
-            rid,
+            m_switchId,
             m_objectType,
             &stats_capability);
 
@@ -1454,7 +1462,7 @@ private:
             std::vector<sai_stat_capability_t> statCapabilityList(stats_capability.count);
             stats_capability.list = statCapabilityList.data();
             status = m_vendorSai->queryStatsCapability(
-                rid,
+                m_switchId,
                 m_objectType,
                 &stats_capability);
 

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -656,6 +656,10 @@ TEST(FlexCounter, noSupportedCounters)
     fc.addCounter(sai_object_id_t(0x1000000000000), sai_object_id_t(0x1000000000000), values);
     // No supported counter, this object shall not be queried
     EXPECT_EQ(fc.isEmpty(), true);
+
+    std::vector<sai_object_id_t> oids = {0x1000000000000};
+    fc.bulkAddCounter(SAI_OBJECT_TYPE_PORT, oids, oids, values);
+    EXPECT_EQ(fc.isEmpty(), true);
 }
 
 void testAddRemovePlugin(const std::string& pluginFieldName)

--- a/unittest/vslib/TestSwitchMLNX2700.cpp
+++ b/unittest/vslib/TestSwitchMLNX2700.cpp
@@ -600,7 +600,7 @@ TEST(SwitchMLNX2700, test_stats_query_capability)
             std::make_shared<RealObjectIdManager>(0, scc),
             sc);
 
-    sai_stat_capability_t capability_list[51];
+    sai_stat_capability_t capability_list[83];
     sai_stat_capability_list_t stats_capability;
     stats_capability.count = 1;
     stats_capability.list = capability_list;
@@ -623,7 +623,7 @@ TEST(SwitchMLNX2700, test_stats_query_capability)
                                           SAI_OBJECT_TYPE_PORT,
                                           &stats_capability),
                                           SAI_STATUS_BUFFER_OVERFLOW);
-    stats_capability.count = 51;
+    stats_capability.count = 83;
 
     EXPECT_EQ(sw.queryStatsCapability(0x2100000000,
                                           SAI_OBJECT_TYPE_PORT,

--- a/unittest/vslib/TestSwitchMLNX2700.cpp
+++ b/unittest/vslib/TestSwitchMLNX2700.cpp
@@ -600,7 +600,7 @@ TEST(SwitchMLNX2700, test_stats_query_capability)
             std::make_shared<RealObjectIdManager>(0, scc),
             sc);
 
-    sai_stat_capability_t capability_list[83];
+    sai_stat_capability_t capability_list[91];
     sai_stat_capability_list_t stats_capability;
     stats_capability.count = 1;
     stats_capability.list = capability_list;
@@ -623,7 +623,7 @@ TEST(SwitchMLNX2700, test_stats_query_capability)
                                           SAI_OBJECT_TYPE_PORT,
                                           &stats_capability),
                                           SAI_STATUS_BUFFER_OVERFLOW);
-    stats_capability.count = 83;
+    stats_capability.count = 91;
 
     EXPECT_EQ(sw.queryStatsCapability(0x2100000000,
                                           SAI_OBJECT_TYPE_PORT,

--- a/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
+++ b/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
@@ -142,7 +142,7 @@ TEST_F(VirtualSwitchSaiInterfaceTest, bulkGet)
 
 TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsCapability)
 {
-    sai_stat_capability_t capability_list[51];
+    sai_stat_capability_t capability_list[83];
     sai_stat_capability_list_t stats_capability;
     stats_capability.list = capability_list;
 
@@ -170,7 +170,7 @@ TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsCapability)
                 SAI_OBJECT_TYPE_PORT,
                 &stats_capability));
 
-    stats_capability.count = 51;
+    stats_capability.count = 83;
     EXPECT_EQ(SAI_STATUS_SUCCESS,
             m_vssai->queryStatsCapability(
                 m_swid,

--- a/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
+++ b/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
@@ -142,7 +142,7 @@ TEST_F(VirtualSwitchSaiInterfaceTest, bulkGet)
 
 TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsCapability)
 {
-    sai_stat_capability_t capability_list[83];
+    sai_stat_capability_t capability_list[91];
     sai_stat_capability_list_t stats_capability;
     stats_capability.list = capability_list;
 
@@ -170,7 +170,7 @@ TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsCapability)
                 SAI_OBJECT_TYPE_PORT,
                 &stats_capability));
 
-    stats_capability.count = 83;
+    stats_capability.count = 91;
     EXPECT_EQ(SAI_STATUS_SUCCESS,
             m_vssai->queryStatsCapability(
                 m_swid,

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3920,13 +3920,13 @@ sai_status_t SwitchStateBase::queryStatsCapability(
     }
     else if (objectType == SAI_OBJECT_TYPE_PORT)
     {
-        if (stats_capability->count < 51)
+        if (stats_capability->count < 83)
         {
-            stats_capability->count = 51;
+            stats_capability->count = 83;
             return SAI_STATUS_BUFFER_OVERFLOW;
         }
 
-        stats_capability->count = 51;
+        stats_capability->count = 83;
         stats_capability->list[0].stat_enum = SAI_PORT_STAT_IF_IN_OCTETS;
         stats_capability->list[1].stat_enum = SAI_PORT_STAT_IF_IN_UCAST_PKTS;
         stats_capability->list[2].stat_enum = SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS;
@@ -3978,6 +3978,38 @@ sai_status_t SwitchStateBase::queryStatsCapability(
         stats_capability->list[48].stat_enum = SAI_PORT_STAT_WRED_DROPPED_PACKETS;
         stats_capability->list[49].stat_enum = SAI_PORT_STAT_WRED_DROPPED_BYTES;
         stats_capability->list[50].stat_enum = SAI_PORT_STAT_ECN_MARKED_PACKETS;
+        stats_capability->list[51].stat_enum = SAI_PORT_STAT_PFC_0_RX_PKTS;
+        stats_capability->list[52].stat_enum = SAI_PORT_STAT_PFC_0_TX_PKTS;
+        stats_capability->list[53].stat_enum = SAI_PORT_STAT_PFC_1_RX_PKTS;
+        stats_capability->list[54].stat_enum = SAI_PORT_STAT_PFC_1_TX_PKTS;
+        stats_capability->list[55].stat_enum = SAI_PORT_STAT_PFC_2_RX_PKTS;
+        stats_capability->list[56].stat_enum = SAI_PORT_STAT_PFC_2_TX_PKTS;
+        stats_capability->list[57].stat_enum = SAI_PORT_STAT_PFC_3_RX_PKTS;
+        stats_capability->list[58].stat_enum = SAI_PORT_STAT_PFC_3_TX_PKTS;
+        stats_capability->list[59].stat_enum = SAI_PORT_STAT_PFC_4_RX_PKTS;
+        stats_capability->list[60].stat_enum = SAI_PORT_STAT_PFC_4_TX_PKTS;
+        stats_capability->list[61].stat_enum = SAI_PORT_STAT_PFC_5_RX_PKTS;
+        stats_capability->list[62].stat_enum = SAI_PORT_STAT_PFC_5_TX_PKTS;
+        stats_capability->list[63].stat_enum = SAI_PORT_STAT_PFC_6_RX_PKTS;
+        stats_capability->list[64].stat_enum = SAI_PORT_STAT_PFC_6_TX_PKTS;
+        stats_capability->list[65].stat_enum = SAI_PORT_STAT_PFC_7_RX_PKTS;
+        stats_capability->list[66].stat_enum = SAI_PORT_STAT_PFC_7_TX_PKTS;
+        stats_capability->list[67].stat_enum = SAI_PORT_STAT_PFC_0_RX_PAUSE_DURATION_US;
+        stats_capability->list[68].stat_enum = SAI_PORT_STAT_PFC_0_TX_PAUSE_DURATION_US;
+        stats_capability->list[69].stat_enum = SAI_PORT_STAT_PFC_1_RX_PAUSE_DURATION_US;
+        stats_capability->list[70].stat_enum = SAI_PORT_STAT_PFC_1_TX_PAUSE_DURATION_US;
+        stats_capability->list[71].stat_enum = SAI_PORT_STAT_PFC_2_RX_PAUSE_DURATION_US;
+        stats_capability->list[72].stat_enum = SAI_PORT_STAT_PFC_2_TX_PAUSE_DURATION_US;
+        stats_capability->list[73].stat_enum = SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US;
+        stats_capability->list[74].stat_enum = SAI_PORT_STAT_PFC_3_TX_PAUSE_DURATION_US;
+        stats_capability->list[75].stat_enum = SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US;
+        stats_capability->list[76].stat_enum = SAI_PORT_STAT_PFC_4_TX_PAUSE_DURATION_US;
+        stats_capability->list[77].stat_enum = SAI_PORT_STAT_PFC_5_RX_PAUSE_DURATION_US;
+        stats_capability->list[78].stat_enum = SAI_PORT_STAT_PFC_5_TX_PAUSE_DURATION_US;
+        stats_capability->list[79].stat_enum = SAI_PORT_STAT_PFC_6_RX_PAUSE_DURATION_US;
+        stats_capability->list[80].stat_enum = SAI_PORT_STAT_PFC_6_TX_PAUSE_DURATION_US;
+        stats_capability->list[81].stat_enum = SAI_PORT_STAT_PFC_7_RX_PAUSE_DURATION_US;
+        stats_capability->list[82].stat_enum = SAI_PORT_STAT_PFC_7_TX_PAUSE_DURATION_US;
 
         for(i = 0; i < stats_capability->count; i++)
         {

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3920,13 +3920,13 @@ sai_status_t SwitchStateBase::queryStatsCapability(
     }
     else if (objectType == SAI_OBJECT_TYPE_PORT)
     {
-        if (stats_capability->count < 83)
+        if (stats_capability->count < 91)
         {
-            stats_capability->count = 83;
+            stats_capability->count = 91;
             return SAI_STATUS_BUFFER_OVERFLOW;
         }
 
-        stats_capability->count = 83;
+        stats_capability->count = 91;
         stats_capability->list[0].stat_enum = SAI_PORT_STAT_IF_IN_OCTETS;
         stats_capability->list[1].stat_enum = SAI_PORT_STAT_IF_IN_UCAST_PKTS;
         stats_capability->list[2].stat_enum = SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS;
@@ -4010,6 +4010,14 @@ sai_status_t SwitchStateBase::queryStatsCapability(
         stats_capability->list[80].stat_enum = SAI_PORT_STAT_PFC_6_TX_PAUSE_DURATION_US;
         stats_capability->list[81].stat_enum = SAI_PORT_STAT_PFC_7_RX_PAUSE_DURATION_US;
         stats_capability->list[82].stat_enum = SAI_PORT_STAT_PFC_7_TX_PAUSE_DURATION_US;
+        stats_capability->list[83].stat_enum = SAI_PORT_STAT_PFC_0_ON2OFF_RX_PKTS;
+        stats_capability->list[84].stat_enum = SAI_PORT_STAT_PFC_1_ON2OFF_RX_PKTS;
+        stats_capability->list[85].stat_enum = SAI_PORT_STAT_PFC_2_ON2OFF_RX_PKTS;
+        stats_capability->list[86].stat_enum = SAI_PORT_STAT_PFC_3_ON2OFF_RX_PKTS;
+        stats_capability->list[87].stat_enum = SAI_PORT_STAT_PFC_4_ON2OFF_RX_PKTS;
+        stats_capability->list[88].stat_enum = SAI_PORT_STAT_PFC_5_ON2OFF_RX_PKTS;
+        stats_capability->list[89].stat_enum = SAI_PORT_STAT_PFC_6_ON2OFF_RX_PKTS;
+        stats_capability->list[90].stat_enum = SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS;
 
         for(i = 0; i < stats_capability->count; i++)
         {

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -1011,13 +1011,13 @@ sai_status_t VirtualSwitchSaiInterface::queryStatsCapability(
     }
     else if (objectType == SAI_OBJECT_TYPE_PORT)
     {
-        if (stats_capability->count < 51)
+        if (stats_capability->count < 83)
         {
-            stats_capability->count = 51;
+            stats_capability->count = 83;
             return SAI_STATUS_BUFFER_OVERFLOW;
         }
 
-        stats_capability->count = 51;
+        stats_capability->count = 83;
         stats_capability->list[0].stat_enum = SAI_PORT_STAT_IF_IN_OCTETS;
         stats_capability->list[1].stat_enum = SAI_PORT_STAT_IF_IN_UCAST_PKTS;
         stats_capability->list[2].stat_enum = SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS;
@@ -1069,7 +1069,38 @@ sai_status_t VirtualSwitchSaiInterface::queryStatsCapability(
         stats_capability->list[48].stat_enum = SAI_PORT_STAT_WRED_DROPPED_PACKETS;
         stats_capability->list[49].stat_enum = SAI_PORT_STAT_WRED_DROPPED_BYTES;
         stats_capability->list[50].stat_enum = SAI_PORT_STAT_ECN_MARKED_PACKETS;
-
+        stats_capability->list[51].stat_enum = SAI_PORT_STAT_PFC_0_RX_PKTS;
+        stats_capability->list[52].stat_enum = SAI_PORT_STAT_PFC_0_TX_PKTS;
+        stats_capability->list[53].stat_enum = SAI_PORT_STAT_PFC_1_RX_PKTS;
+        stats_capability->list[54].stat_enum = SAI_PORT_STAT_PFC_1_TX_PKTS;
+        stats_capability->list[55].stat_enum = SAI_PORT_STAT_PFC_2_RX_PKTS;
+        stats_capability->list[56].stat_enum = SAI_PORT_STAT_PFC_2_TX_PKTS;
+        stats_capability->list[57].stat_enum = SAI_PORT_STAT_PFC_3_RX_PKTS;
+        stats_capability->list[58].stat_enum = SAI_PORT_STAT_PFC_3_TX_PKTS;
+        stats_capability->list[59].stat_enum = SAI_PORT_STAT_PFC_4_RX_PKTS;
+        stats_capability->list[60].stat_enum = SAI_PORT_STAT_PFC_4_TX_PKTS;
+        stats_capability->list[61].stat_enum = SAI_PORT_STAT_PFC_5_RX_PKTS;
+        stats_capability->list[62].stat_enum = SAI_PORT_STAT_PFC_5_TX_PKTS;
+        stats_capability->list[63].stat_enum = SAI_PORT_STAT_PFC_6_RX_PKTS;
+        stats_capability->list[64].stat_enum = SAI_PORT_STAT_PFC_6_TX_PKTS;
+        stats_capability->list[65].stat_enum = SAI_PORT_STAT_PFC_7_RX_PKTS;
+        stats_capability->list[66].stat_enum = SAI_PORT_STAT_PFC_7_TX_PKTS;
+        stats_capability->list[67].stat_enum = SAI_PORT_STAT_PFC_0_RX_PAUSE_DURATION_US;
+        stats_capability->list[68].stat_enum = SAI_PORT_STAT_PFC_0_TX_PAUSE_DURATION_US;
+        stats_capability->list[69].stat_enum = SAI_PORT_STAT_PFC_1_RX_PAUSE_DURATION_US;
+        stats_capability->list[70].stat_enum = SAI_PORT_STAT_PFC_1_TX_PAUSE_DURATION_US;
+        stats_capability->list[71].stat_enum = SAI_PORT_STAT_PFC_2_RX_PAUSE_DURATION_US;
+        stats_capability->list[72].stat_enum = SAI_PORT_STAT_PFC_2_TX_PAUSE_DURATION_US;
+        stats_capability->list[73].stat_enum = SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US;
+        stats_capability->list[74].stat_enum = SAI_PORT_STAT_PFC_3_TX_PAUSE_DURATION_US;
+        stats_capability->list[75].stat_enum = SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US;
+        stats_capability->list[76].stat_enum = SAI_PORT_STAT_PFC_4_TX_PAUSE_DURATION_US;
+        stats_capability->list[77].stat_enum = SAI_PORT_STAT_PFC_5_RX_PAUSE_DURATION_US;
+        stats_capability->list[78].stat_enum = SAI_PORT_STAT_PFC_5_TX_PAUSE_DURATION_US;
+        stats_capability->list[79].stat_enum = SAI_PORT_STAT_PFC_6_RX_PAUSE_DURATION_US;
+        stats_capability->list[80].stat_enum = SAI_PORT_STAT_PFC_6_TX_PAUSE_DURATION_US;
+        stats_capability->list[81].stat_enum = SAI_PORT_STAT_PFC_7_RX_PAUSE_DURATION_US;
+        stats_capability->list[82].stat_enum = SAI_PORT_STAT_PFC_7_TX_PAUSE_DURATION_US;
         for(uint32_t i = 0; i < stats_capability->count; i++)
         {
             stats_capability->list[i].stat_modes = SAI_STATS_MODE_READ_AND_CLEAR | SAI_STATS_MODE_READ ;

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -1011,13 +1011,13 @@ sai_status_t VirtualSwitchSaiInterface::queryStatsCapability(
     }
     else if (objectType == SAI_OBJECT_TYPE_PORT)
     {
-        if (stats_capability->count < 83)
+        if (stats_capability->count < 91)
         {
-            stats_capability->count = 83;
+            stats_capability->count = 91;
             return SAI_STATUS_BUFFER_OVERFLOW;
         }
 
-        stats_capability->count = 83;
+        stats_capability->count = 91;
         stats_capability->list[0].stat_enum = SAI_PORT_STAT_IF_IN_OCTETS;
         stats_capability->list[1].stat_enum = SAI_PORT_STAT_IF_IN_UCAST_PKTS;
         stats_capability->list[2].stat_enum = SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS;
@@ -1101,6 +1101,14 @@ sai_status_t VirtualSwitchSaiInterface::queryStatsCapability(
         stats_capability->list[80].stat_enum = SAI_PORT_STAT_PFC_6_TX_PAUSE_DURATION_US;
         stats_capability->list[81].stat_enum = SAI_PORT_STAT_PFC_7_RX_PAUSE_DURATION_US;
         stats_capability->list[82].stat_enum = SAI_PORT_STAT_PFC_7_TX_PAUSE_DURATION_US;
+        stats_capability->list[83].stat_enum = SAI_PORT_STAT_PFC_0_ON2OFF_RX_PKTS;
+        stats_capability->list[84].stat_enum = SAI_PORT_STAT_PFC_1_ON2OFF_RX_PKTS;
+        stats_capability->list[85].stat_enum = SAI_PORT_STAT_PFC_2_ON2OFF_RX_PKTS;
+        stats_capability->list[86].stat_enum = SAI_PORT_STAT_PFC_3_ON2OFF_RX_PKTS;
+        stats_capability->list[87].stat_enum = SAI_PORT_STAT_PFC_4_ON2OFF_RX_PKTS;
+        stats_capability->list[88].stat_enum = SAI_PORT_STAT_PFC_5_ON2OFF_RX_PKTS;
+        stats_capability->list[89].stat_enum = SAI_PORT_STAT_PFC_6_ON2OFF_RX_PKTS;
+        stats_capability->list[90].stat_enum = SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS;
         for(uint32_t i = 0; i < stats_capability->count; i++)
         {
             stats_capability->list[i].stat_modes = SAI_STATS_MODE_READ_AND_CLEAR | SAI_STATS_MODE_READ ;


### PR DESCRIPTION
Fix two day 1 counter issues on VS platform which have been exposed recently.

1. Use switch object to detect counter capability in flex counter. This is to fix the following error message
    ```
    E               2025 Feb 20 15:43:21.906623 vlab-03 ERR syncd#syncd: :- queryStatsCapability: parameter switchId oid:0x100000001 object type is SAI_OBJECT_TYPE_PORT, but expected SAI_OBJECT_TYPE_SWITCH
    E               
    E               2025 Feb 20 15:43:21.910428 vlab-03 ERR syncd#syncd: :- queryStatsCapability: parameter switchId oid:0x1500000003 object type is SAI_OBJECT_TYPE_QUEUE, but expected SAI_OBJECT_TYPE_SWITCH
    ```

2. Support PFC counters on VS platform
    Previously it didn't check counter capability before polling PFC counters by mistake.

3. Do not poll counters for a group without any counter supported by the system in bulk creation