### PR TITLE
Update to support SAI BFD_SESSION_OFFLOAD_TYPE.

### DIFF
--- a/vslib/Sai.cpp
+++ b/vslib/Sai.cpp
@@ -152,6 +152,9 @@ sai_status_t Sai::apiInitialize(
 
     auto useTapDevice = SwitchConfig::parseUseTapDevice(use_tap_dev);
 
+    const char *bfd_offload_supported = service_method_table->profile_get_value(0, SAI_KEY_VS_BFD_OFFLOAD_SUPPORTED);
+    auto bfdOffloadSupported = SwitchConfig::parseBfdOffloadSupported(bfd_offload_supported);
+
     SWSS_LOG_NOTICE("hostif use TAP device: %s", (useTapDevice ? "true" : "false"));
 
     auto cstrGlobalContext = service_method_table->profile_get_value(0, SAI_KEY_VS_GLOBAL_CONTEXT);
@@ -219,6 +222,7 @@ sai_status_t Sai::apiInitialize(
         sc->m_bootType = bootType;
         sc->m_useTapDevice = useTapDevice;
         sc->m_laneMap = m_laneMapContainer->getLaneMap(sc->m_switchIndex);
+        sc->m_bfdOffload = bfdOffloadSupported;
 
         if (sc->m_laneMap == nullptr)
         {

--- a/vslib/SwitchConfig.cpp
+++ b/vslib/SwitchConfig.cpp
@@ -17,7 +17,8 @@ SwitchConfig::SwitchConfig(
     m_bootType(SAI_VS_BOOT_TYPE_COLD),
     m_switchIndex(switchIndex),
     m_hardwareInfo(hwinfo),
-    m_useTapDevice(false)
+    m_useTapDevice(false),
+    m_bfdOffload(true)
 {
     SWSS_LOG_ENTER();
 
@@ -152,4 +153,17 @@ bool SwitchConfig::parseUseTapDevice(
     }
 
     return false;
+}
+
+bool SwitchConfig::parseBfdOffloadSupported(
+    _In_ const char* bfdOffloadSupportedStr)
+{
+    SWSS_LOG_ENTER();
+
+    if (bfdOffloadSupportedStr)
+    {
+        return strcmp(bfdOffloadSupportedStr, "true") == 0;
+    }
+
+    return true;
 }

--- a/vslib/SwitchConfig.h
+++ b/vslib/SwitchConfig.h
@@ -67,6 +67,9 @@ namespace saivs
             static bool parseUseTapDevice(
                     _In_ const char* useTapDeviceStr);
 
+            static bool parseBfdOffloadSupported(
+                    _In_ const char* bfdOffloadSupportedStr);
+
         public:
 
             sai_switch_type_t m_saiSwitchType;
@@ -80,6 +83,8 @@ namespace saivs
             std::string m_hardwareInfo;
 
             bool m_useTapDevice;
+
+            bool m_bfdOffload;
 
             std::shared_ptr<LaneMap> m_laneMap;
 

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -1057,16 +1057,20 @@ sai_status_t SwitchStateBase::set_switch_default_attributes()
 
     attr.id = SAI_SWITCH_ATTR_SUPPORTED_IPV4_BFD_SESSION_OFFLOAD_TYPE;
     uint32_t list[1] = { SAI_BFD_SESSION_OFFLOAD_TYPE_FULL };
+
     if(!m_switchConfig->m_bfdOffload) {
         list[0] = SAI_BFD_SESSION_OFFLOAD_TYPE_NONE;
     }
+
     attr.value.u32list.count = 1;
     attr.value.u32list.list = list;
+
     CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
 
     attr.id = SAI_SWITCH_ATTR_SUPPORTED_IPV6_BFD_SESSION_OFFLOAD_TYPE;
     attr.value.u32list.count = 1;
     attr.value.u32list.list = list;
+
     CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
 
     return set_switch_supported_object_types();

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -1055,6 +1055,20 @@ sai_status_t SwitchStateBase::set_switch_default_attributes()
 
     CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
 
+    attr.id = SAI_SWITCH_ATTR_SUPPORTED_IPV4_BFD_SESSION_OFFLOAD_TYPE;
+    uint32_t list[1] = { SAI_BFD_SESSION_OFFLOAD_TYPE_FULL };
+    if(!m_switchConfig->m_bfdOffload) {
+        list[0] = SAI_BFD_SESSION_OFFLOAD_TYPE_NONE;
+    }
+    attr.value.u32list.count = 1;
+    attr.value.u32list.list = list;
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
+    attr.id = SAI_SWITCH_ATTR_SUPPORTED_IPV6_BFD_SESSION_OFFLOAD_TYPE;
+    attr.value.u32list.count = 1;
+    attr.value.u32list.list = list;
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
     return set_switch_supported_object_types();
 }
 
@@ -2463,6 +2477,10 @@ sai_status_t SwitchStateBase::refresh_read_only(
             case SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY:
             case SAI_SWITCH_ATTR_AVAILABLE_IPMC_ENTRY:
             case SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAT_ENTRY:
+                return SAI_STATUS_SUCCESS;
+
+            case SAI_SWITCH_ATTR_SUPPORTED_IPV4_BFD_SESSION_OFFLOAD_TYPE:
+            case SAI_SWITCH_ATTR_SUPPORTED_IPV6_BFD_SESSION_OFFLOAD_TYPE:
                 return SAI_STATUS_SUCCESS;
 
             case SAI_SWITCH_ATTR_NUMBER_OF_SYSTEM_PORTS:

--- a/vslib/saivs.h
+++ b/vslib/saivs.h
@@ -57,6 +57,19 @@ extern "C" {
 #define SAI_KEY_VS_HOSTIF_USE_TAP_DEVICE      "SAI_VS_HOSTIF_USE_TAP_DEVICE"
 
 /**
+ * @def SAI_KEY_VS_BFD_OFFLOAD_SUPPORTED
+ *
+ * Bool flag, (true/false). If set to false, then platform will be configured
+ * to return SAI_BFD_SESSION_OFFLOAD_TYPE_NONE for
+ * SAI_SWITCH_ATTR_SUPPORTED_IPV4_BFD_SESSION_OFFLOAD_TYPE and
+ * SAI_SWITCH_ATTR_SUPPORTED_IPV6_BFD_SESSION_OFFLOAD_TYPE calls; otherwise
+ * SAI_BFD_SESSION_OFFLOAD_TYPE_FULL will be set.
+ *
+ * By default this flag is set to true.
+ */
+ #define SAI_KEY_VS_BFD_OFFLOAD_SUPPORTED     "SAI_VS_BFD_OFFLOAD_SUPPORTED"
+
+/**
  * @def SAI_KEY_VS_CORE_PORT_INDEX_MAP_FILE
  *
  * For VOQ systems if specified in profile.ini it should point to eth interface to


### PR DESCRIPTION
Adding support for SAI_SWITCH_ATTR_SUPPORTED_IPV4_BFD_SESSION_OFFLOAD_TYPE and SAI_SWITCH_ATTR_SUPPORTED_IPV6_BFD_SESSION_OFFLOAD_TYPE in vslib. This is needed by BfdOrch in sonic-swss to choose between software BFD or regular (offloaded) BFD.

Default will be to return SAI_BFD_SESSION_OFFLOAD_TYPE_FULL, as this was the default behavior previously when this value was not checked. 

Added capability to return SAI_BFD_SESSION_OFFLOAD_TYPE_NONE by setting SAI_VS_BFD_OFFLOAD_SUPPORTED=false in sai.profile for testing and in cases where software BFD is desired.