### PR TITLE
Update build_and_install_module.sh to match newer Linux kernel version

### DIFF
--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -28,14 +28,24 @@ function build_and_install_kmodule()
     # Install the required debian packages to build the kernel modules
     apt-get update
     apt-get install -y build-essential linux-headers-${KERNEL_RELEASE} autoconf pkg-config fakeroot
-    apt-get install -y flex bison libssl-dev libelf-dev
+    apt-get install -y flex bison libssl-dev libelf-dev dwarves
     apt-get install -y libnl-route-3-200 libnl-route-3-dev libnl-cli-3-200 libnl-cli-3-dev libnl-3-dev
 
     # Add the apt source mirrors and download the linux image source code
     cp /etc/apt/sources.list /etc/apt/sources.list.bk
     sed -i "s/^# deb-src/deb-src/g" /etc/apt/sources.list
     apt-get update
-    apt-get source linux-image-unsigned-$(uname -r) > source.log
+    KERNEL_PACKAGE_SOURCE=$(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Source: | cut -d':' -f 2)
+    KERNEL_PACKAGE_VERSION=$(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Version: | cut -d':' -f 2)
+    SOURCE_PACKAGE_VERSION=$(apt-cache showsrc ${KERNEL_PACKAGE_SOURCE} | grep ^Version: | cut -d':' -f 2)
+    if [ ${KERNEL_PACKAGE_VERSION} != ${SOURCE_PACKAGE_VERSION} ]; then
+        echo "WARNING: the running kernel version (${KERNEL_PACKAGE_VERSION}) doesn't match the source package " \
+            "version (${SOURCE_PACKAGE_VERSION}) being downloaded. There's no guarantee the module being downloaded " \
+            "can be loaded into the kernel or function correctly. If possible, please update your kernel and reboot " \
+            "your system so that it's running the matching kernel version." >&2
+        echo "Continuing with the build anyways" >&2
+    fi
+    apt-get source linux-image-unsigned-${KERNEL_RELEASE} > source.log
 
     # Recover the original apt sources list
     cp /etc/apt/sources.list.bk /etc/apt/sources.list
@@ -43,46 +53,33 @@ function build_and_install_kmodule()
 
     # Build the Linux kernel module drivers/net/team and vrf
     cd $(find . -maxdepth 1 -type d | grep -v "^.$")
+    if [ -e debian/debian.env ]; then
+        source debian/debian.env
+        if [ -n "${DEBIAN}" -a -e ${DEBIAN}/reconstruct ]; then
+            bash ${DEBIAN}/reconstruct
+        fi
+    fi
     make  allmodconfig
     mv .config .config.bk
     cp /boot/config-$(uname -r) .config
     grep NET_TEAM .config.bk >> .config
-    echo CONFIG_NET_VRF=m >> .config
-    echo CONFIG_MACSEC=m >> .config
-    echo CONFIG_NET_VENDOR_MICROSOFT=y >> .config
-    echo CONFIG_MICROSOFT_MANA=m >> .config
-    echo CONFIG_SYSTEM_REVOCATION_LIST=n >> .config
     make VERSION=$VERSION PATCHLEVEL=$PATCHLEVEL SUBLEVEL=$SUBLEVEL EXTRAVERSION=-${EXTRAVERSION} LOCALVERSION=-${LOCALVERSION} modules_prepare
-    make M=drivers/net/team
+    cp /usr/src/linux-headers-$(uname -r)/Module.symvers .
+    make -j$(nproc) M=drivers/net/team
     mv drivers/net/Makefile drivers/net/Makefile.bak
     echo 'obj-$(CONFIG_NET_VRF) += vrf.o' > drivers/net/Makefile
     echo 'obj-$(CONFIG_MACSEC) += macsec.o' >> drivers/net/Makefile
-    make M=drivers/net
+    make -j$(nproc) M=drivers/net
 
     # Install the module
-    TEAM_DIR=$(echo /lib/modules/$(uname -r)/kernel/net/team)
-    NET_DIR=$(echo /lib/modules/$(uname -r)/kernel/net)
-    if [ ! -e "$TEAM_DIR/team.ko" ]; then
-        mkdir -p $TEAM_DIR
-        cp drivers/net/team/*.ko $TEAM_DIR/
-        modinfo $TEAM_DIR/team.ko
-        depmod
-        modprobe team
-    fi
-    if [ ! -e "$NET_DIR/vrf.ko" ]; then
-        mkdir -p $NET_DIR
-        cp drivers/net/vrf.ko $NET_DIR/
-        modinfo $NET_DIR/vrf.ko
-        depmod
-        modprobe vrf
-    fi
-    if [ ! -e "$NET_DIR/macsec.ko" ]; then
-        mkdir -p $NET_DIR
-        cp drivers/net/macsec.ko $NET_DIR/
-        modinfo $NET_DIR/macsec.ko
-        depmod
-        modprobe macsec
-    fi
+    SONIC_MODULES_DIR=/lib/modules/$(uname -r)/updates/sonic
+    mkdir -p $SONIC_MODULES_DIR
+    cp drivers/net/team/*.ko drivers/net/vrf.ko drivers/net/macsec.ko $SONIC_MODULES_DIR/
+    depmod
+    modinfo team vrf macsec
+    modprobe team
+    modprobe vrf
+    modprobe macsec
 
     cd /tmp
     rm -rf $WORKDIR


### PR DESCRIPTION
sonic-sairedis will checkout sonic-swss to do vstest but using local build_and_install_module.sh to setup test environment, which is out of date with newer Linux kernel version.
The build_and_install_module.sh in sonic-swss is up to date with latest Ubuntu 20.04, so we need to update the build sh file with the file in sonic-swss.
In a long term, we may need to do some automatically sync, but now we have some azure agent security issue need to fix immediately, so just update the build_and_install_module.sh manually.