### PR TITLE
Enhance the logic to check capability of bulk counter poll

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -922,7 +922,7 @@ public:
                 }
             }
 
-            if (supportedBulkIds.size() == 0)
+            if (supportedBulkIds.size() < counter_ids.size())
             {
                 // Bulk polling is unsupported for the whole group but single polling is supported
                 // Add all objects to m_objectIdsMap so that they will be polled using single API

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -947,7 +947,7 @@ public:
 
             ctx.counter_ids = counter_ids;
             addBulkStatsContext(vids, rids, counter_ids, ctx);
-            auto status = m_vendorSai->bulkGetStats(
+            status = m_vendorSai->bulkGetStats(
                 SAI_NULL_OBJECT_ID,
                 m_objectType,
                 static_cast<uint32_t>(ctx.object_keys.size()),

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -907,11 +907,12 @@ public:
             BulkContextType ctx;
             // Check bulk capabilities again
             std::vector<StatType> supportedBulkIds;
+            sai_status_t status = SAI_STATUS_SUCCESS;
             if (m_supportedBulkCounters.empty())
             {
-                querySupportedCounters(rids[0], statsMode, m_supportedBulkCounters);
+                status = querySupportedCounters(rids[0], statsMode, m_supportedBulkCounters);
             }
-            if (!m_supportedBulkCounters.empty())
+            if (status == SAI_STATUS_SUCCESS && !m_supportedBulkCounters.empty())
             {
                 for (auto stat : counter_ids)
                 {

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -858,7 +858,7 @@ public:
         if (HasStatsMode<CounterIdsType>::value)
         {
             // Bulk operation is not supported by the counter group.
-            SWSS_LOG_NOTICE("Counter group %s %s does not support bulk. Fallback to single call", m_name.c_str(), m_instanceId.c_str());
+            SWSS_LOG_INFO("Counter group %s %s does not support bulk. Fallback to single call", m_name.c_str(), m_instanceId.c_str());
 
             // Fall back to old way
             for (size_t i = 0; i < vids.size(); i++)

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -928,6 +928,13 @@ public:
                 // Add all objects to m_objectIdsMap so that they will be polled using single API
                 for (size_t i = 0; i < vids.size(); i++)
                 {
+                    auto it_vid = m_objectIdsMap.find(vids[i]);
+                    if (it_vid != m_objectIdsMap.end())
+                    {
+                        // Remove and re-add if vid already exists
+                        m_objectIdsMap.erase(it_vid);
+                    }
+
                     auto counter_data = std::make_shared<CounterIds<StatType>>(rids[i], counter_ids);
                     m_objectIdsMap.emplace(vids[i], counter_data);
                 }

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -95,6 +95,7 @@ void testAddRemoveCounter(
         bool forceSingleCreate = false)
 {
     SWSS_LOG_ENTER();
+
     FlexCounter fc("test", sai, "COUNTERS_DB");
 
     test_syncd::mockVidManagerObjectTypeQuery(object_type);
@@ -973,7 +974,7 @@ TEST(FlexCounter, bulkCounter)
         false);
 
     clearCalled = false;
-    capabilities = (SAI_STATS_MODE_READ|SAI_STATS_MODE_READ_AND_CLEAR);//|SAI_STATS_MODE_BULK_READ||SAI_STATS_MODE_BULK_READ_AND_CLEAR|SAI_STATS_MODE_BULK_CLEAR);
+    capabilities = (SAI_STATS_MODE_READ|SAI_STATS_MODE_READ_AND_CLEAR);
     testAddRemoveCounter(
         2,
         SAI_OBJECT_TYPE_BUFFER_POOL,
@@ -1368,7 +1369,6 @@ TEST(FlexCounter, bulkChunksize)
     forceSingleCall = true;
     noBulkCapabilityOnly = true;
     initialCheckCount = 0; // check bulk for all counter IDs altogether
-    //    initialCheckCount += 6; // for bulk unsupported counter prefix, check bulk again for each objects
     bulkUnsupportedCounters = {
 	SAI_PORT_STAT_IF_IN_OCTETS,
 	SAI_PORT_STAT_IF_IN_UCAST_PKTS,

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -787,7 +787,7 @@ TEST(FlexCounter, addRemoveCounterForPort)
     countersTable.getKeys(keys);
     ASSERT_TRUE(keys.empty());
 }
-
+#if 0
 TEST(FlexCounter, bulkCounter)
 {
     sai->mock_getStatsExt = [&](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, sai_stats_mode_t, uint64_t *counters) {
@@ -804,9 +804,24 @@ TEST(FlexCounter, bulkCounter)
         }
         return SAI_STATUS_SUCCESS;
     };
+    int counterOffset = 0;
     sai->mock_queryStatsCapability = [&](sai_object_id_t switch_id, sai_object_type_t object_type, sai_stat_capability_list_t *stats_capability) {
-        // For now, just return failure to make test simple, will write a singe test to cover querySupportedCounters
-        return SAI_STATUS_FAILURE;
+	      // Support all counters in bulk mode
+	  if (stats_capability->count == 0)//[0].stat_modes == 
+	    {
+	      stats_capability->count = 100;
+                return SAI_STATUS_BUFFER_OVERFLOW;
+	    }
+	  else
+	    {
+	      for (int i = 0; i < 100; i++)
+		{
+		  stats_capability->list[i].stat_enum = i + counterOffset;
+		  stats_capability->list[i].stat_modes = (SAI_STATS_MODE_READ|SAI_STATS_MODE_BULK_READ|SAI_STATS_MODE_READ_AND_CLEAR|SAI_STATS_MODE_BULK_READ_AND_CLEAR|SAI_STATS_MODE_BULK_CLEAR);
+		  i++;
+		}
+	      return SAI_STATUS_SUCCESS;
+	    }
     };
 
     bool clearCalled = false;
@@ -872,7 +887,7 @@ TEST(FlexCounter, bulkCounter)
         {"100", "200"},
         counterVerifyFunc,
         false);
-
+#if 0
     testAddRemoveCounter(
         2,
         SAI_OBJECT_TYPE_PORT,
@@ -882,6 +897,7 @@ TEST(FlexCounter, bulkCounter)
         counterVerifyFunc,
         false);
 
+    counterOffset = SAI_PORT_STAT_IN_DROP_REASON_RANGE_BASE;
     testAddRemoveCounter(
         2,
         SAI_OBJECT_TYPE_PORT,
@@ -890,6 +906,7 @@ TEST(FlexCounter, bulkCounter)
         {"100", "200"},
         counterVerifyFunc,
         false);
+    counterOffset = 0;
 
     testAddRemoveCounter(
         2,
@@ -920,6 +937,7 @@ TEST(FlexCounter, bulkCounter)
         counterVerifyFunc,
         false);
 
+    counterOffset = SAI_SWITCH_STAT_IN_DROP_REASON_RANGE_BASE;
     testAddRemoveCounter(
         2,
         SAI_OBJECT_TYPE_SWITCH,
@@ -928,7 +946,8 @@ TEST(FlexCounter, bulkCounter)
         {"100", "200"},
         counterVerifyFunc,
         false);
-
+    counterOffset = 0;
+#endif
     testAddRemoveCounter(
         2,
         SAI_OBJECT_TYPE_TUNNEL,
@@ -971,7 +990,7 @@ TEST(FlexCounter, bulkCounter)
     // buffer pool stats does not support bulk
     EXPECT_EQ(false, clearCalled);
 }
-
+#endif
 TEST(FlexCounter, bulkChunksize)
 {
     /*
@@ -1003,9 +1022,33 @@ TEST(FlexCounter, bulkChunksize)
      *
      * For the bulk-unsupported counters, getStatExt will be called to poll counters, and return counter_id * OID as the counter's value
      */
+    bool noBulkCapabilityOnly = false;
+    std::set<sai_stat_id_t> bulkUnsupportedCounters;
+    std::set<sai_stat_id_t> allCounters = {
+        SAI_PORT_STAT_IF_IN_OCTETS,
+        SAI_PORT_STAT_IF_IN_UCAST_PKTS,
+        SAI_PORT_STAT_IF_OUT_QLEN,
+        SAI_PORT_STAT_IF_IN_FEC_CORRECTABLE_FRAMES,
+        SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES
+	};
     sai->mock_queryStatsCapability = [&](sai_object_id_t switch_id, sai_object_type_t object_type, sai_stat_capability_list_t *stats_capability) {
-        // For now, just return failure to make test simple, will write a singe test to cover querySupportedCounters
-        return SAI_STATUS_FAILURE;
+        std::set<sai_stat_id_t> &counterCapabilities = noBulkCapabilityOnly ? bulkUnsupportedCounters : allCounters;
+        if (stats_capability->count == 0)
+        {
+            stats_capability->count = static_cast<uint32_t>(counterCapabilities.size());
+            return SAI_STATUS_BUFFER_OVERFLOW;
+        }
+        else
+        {
+            int i = 0;
+            for (auto stat: counterCapabilities)
+            {
+                stats_capability->list[i].stat_enum = stat;
+                stats_capability->list[i].stat_modes = noBulkCapabilityOnly ? SAI_STATS_MODE_READ : (SAI_STATS_MODE_READ|SAI_STATS_MODE_BULK_READ);
+                i++;
+            }
+            return SAI_STATUS_SUCCESS;
+        }
     };
 
     // Map of number from {oid: {counter_id: counter value}}
@@ -1048,7 +1091,6 @@ TEST(FlexCounter, bulkChunksize)
     };
 
     // Bulk-unsupported counter IDs should be polled using single call (getStatExt)
-    std::set<sai_stat_id_t> bulkUnsupportedCounters;
     std::set<sai_object_id_t> bulkUnsupportedObjectIds;
     bool forceSingleCall = false;
     // <oid, <counter id, counter value>>
@@ -1315,6 +1357,32 @@ TEST(FlexCounter, bulkChunksize)
     EXPECT_TRUE(allObjectIds.empty());
     forceSingleCall = false;
 
+    forceSingleCall = true;
+    noBulkCapabilityOnly = true;
+    initialCheckCount = 0; // check bulk for all counter IDs altogether
+    //    initialCheckCount += 6; // for bulk unsupported counter prefix, check bulk again for each objects
+    bulkUnsupportedCounters = {
+	SAI_PORT_STAT_IF_IN_OCTETS,
+	SAI_PORT_STAT_IF_IN_UCAST_PKTS,
+	SAI_PORT_STAT_IF_OUT_QLEN,
+        SAI_PORT_STAT_IF_IN_FEC_CORRECTABLE_FRAMES,
+        SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES
+	};
+    testAddRemoveCounter(
+        6,
+        SAI_OBJECT_TYPE_PORT,
+        PORT_COUNTER_ID_LIST,
+        {"SAI_PORT_STAT_IF_IN_OCTETS", "SAI_PORT_STAT_IF_IN_UCAST_PKTS", "SAI_PORT_STAT_IF_OUT_QLEN", "SAI_PORT_STAT_IF_IN_FEC_CORRECTABLE_FRAMES", "SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES"},
+        {},
+        counterVerifyFunc,
+        false,
+        STATS_MODE_READ,
+        true);
+    EXPECT_TRUE(allObjectIds.empty());
+    bulkUnsupportedCounters.clear();
+    noBulkCapabilityOnly = false;
+    forceSingleCall = false;
+
     // set bulk chunk size + per counter bulk chunk size first and then add ports counters in bulk mode with some bulk-unsupported counters
     // All bulk-unsupported counters are polled using single call and all the rest counters are polled using bulk call
     // For each OID, it will be in both m_bulkContexts and m_objectIdsMap
@@ -1361,6 +1429,9 @@ TEST(FlexCounter, bulkChunksize)
 
 TEST(FlexCounter, counterIdChange)
 {
+    sai->mock_queryStatsCapability = [](sai_object_id_t, sai_object_type_t, sai_stat_capability_list_t *capability) {
+        return SAI_STATUS_FAILURE;
+    };
     sai->mock_getStats = [&](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, uint64_t *counters) {
         for (uint32_t i = 0; i < number_of_counters; i++)
         {


### PR DESCRIPTION
Enhance the logic to check the capability of the bulk counter poll in `bulkAddObject`
1. Check bulk capability using m_vendorSai->queryStatsCapability before calling SAI API to check capability
2. Check single call capability before adding it to `m_objectIdsMap`
3. Reduce the log severity to `INFO` when a counter is not supported to be bulk-polled to avoid too many log messages
4. Remove redundant code for buffer pool counters

Details:
In `bulkAddObject` it enables counter polling for a set of objects. A brief flow is the following:
1. Check the object type's counter capability of single operation (`SAI_STATS_MODE_READ_AND_CLEAR` or `SAI_STATS_MODE_READ`) using `updateSupportedCounters` (which eventually calls `query_stats_capability`). All counters that do not support the capability will be removed.
2. Check the object type's counter capability of the corresponding bulk operation (`SAI_STATS_MODE_BULK_READ_AND_CLEAR` and `SAI_STATS_MODE_BULK_READ` respectively).
  Add the counters to `m_objectIdsMap` if they do not support bulk call.
3. Check the bulk operation capability on the group of objects (since some vendors support bulk operation only on a part of objects). Add the objects to bulk context if all objects support bulk operation. The objects will be polled using bulk operation.
4. Check the single call capability on each object (since some vendors support counters only on a part of objects). The objects that do not support single call will not be polled at all.

Possible error messages in vendor SAI:
An error message can be observed on some platforms if an unsupported counter-polling SAI API is called.
This could happen if the vendor SAI supports a counter polling operation only on part of objects. 
In this case, the function `query_stats_capability` returns that it supports the operation on the object type. FlexCounter needs to call the counter polling SAI API to check whether the operation is supported on each object. An error message could be seen if vendor SAI prints it.