### PR TITLE
Move time stamp to time stamp table in counter database to avoid frequently update the counter table

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1317,7 +1317,7 @@ private:
         }
 
         // First generate the key, then replace spaces with underscores to avoid issues when Lua plugins handle the timestamp
-        std::string timestamp_key = "PFC_WD_" + m_name + "_time_stamp";
+        std::string timestamp_key = m_instanceId + "_" + m_name + "_time_stamp";
         std::replace(timestamp_key.begin(), timestamp_key.end(), ' ', '_');
 
         values.emplace_back(timestamp_key, std::to_string(time_stamp));

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1311,10 +1311,17 @@ private:
             {
                 values.emplace_back(serializeStat(ctx.counter_ids[j]), std::to_string(ctx.counters[i * ctx.counter_ids.size() + j]));
             }
-            values.emplace_back(m_instanceId + "_time_stamp", std::to_string(time_stamp));
+
             countersTable.set(sai_serialize_object_id(vid), values, "");
             values.clear();
         }
+
+        // First generate the key, then replace spaces with underscores to avoid issues when Lua plugins handle the timestamp
+        std::string timestamp_key = "PFC_WD_" + m_name + "_time_stamp";
+        std::replace(timestamp_key.begin(), timestamp_key.end(), ' ', '_');
+
+        values.emplace_back(timestamp_key, std::to_string(time_stamp));
+        countersTable.set("TIME_STAMP", values, "");
 
         SWSS_LOG_DEBUG("After pushing db %s %s %s", m_instanceId.c_str(), m_name.c_str(), ctx.name.c_str());
     }

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -77,6 +77,16 @@ std::vector<sai_object_id_t> generateOids(
     return object_ids;
 }
 
+void removeTimeStamp(std::vector<std::string>& keys, swss::Table& countersTable)
+{
+    auto it = std::find(keys.begin(), keys.end(), "TIME_STAMP");
+    if (it != keys.end())
+    {
+        countersTable.del("TIME_STAMP");
+        keys.erase(it);
+    }
+}
+
 void testAddRemoveCounter(
         unsigned int numOid,
         sai_object_type_t object_type,
@@ -166,6 +176,8 @@ void testAddRemoveCounter(
 
     std::vector<std::string> keys;
     countersTable.getKeys(keys);
+    // We have a dedicated item for all timestamps for counters using bulk counter polling
+    removeTimeStamp(keys, countersTable);
     EXPECT_EQ(keys.size(), object_ids.size());
 
     for (size_t i = 0; i < object_ids.size(); i++)
@@ -185,6 +197,7 @@ void testAddRemoveCounter(
     EXPECT_EQ(fc.isEmpty(), true);
 
     countersTable.getKeys(keys);
+    removeTimeStamp(keys, countersTable);
     ASSERT_TRUE(keys.empty());
 }
 
@@ -1708,6 +1721,7 @@ void testDashMeterAddRemoveCounter(
 
     std::vector<std::string> keys;
     countersTable.getKeys(keys);
+    removeTimeStamp(keys, countersTable);
     ASSERT_TRUE(keys.empty());
 }
 

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -79,6 +79,8 @@ std::vector<sai_object_id_t> generateOids(
 
 void removeTimeStamp(std::vector<std::string>& keys, swss::Table& countersTable)
 {
+    SWSS_LOG_ENTER();
+
     auto it = std::find(keys.begin(), keys.end(), "TIME_STAMP");
     if (it != keys.end())
     {


### PR DESCRIPTION
Move the timestamp out of the COUNTER table to avoid updating the table too frequently and overwhelming the telemetry system.
Fixes https://github.com/sonic-net/sonic-buildimage/issues/22201