### PR TITLE
[syncd] Check whether stat_st and tam_telemetry is defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,7 @@ CXXFLAGS="$SAVED_FLAGS"
 AM_COND_IF([SYNCD], [
 SAVED_FLAGS="$CXXFLAGS"
 CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
-AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats)
+AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_query_stats_st_capability sai_tam_telemetry_get_data)
 CXXFLAGS="$SAVED_FLAGS"
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -272,11 +272,20 @@ AC_MSG_ERROR("SAI headers API version and library version mismatch")])],
 CXXFLAGS="$SAVED_FLAGS"
 ])])
 
-AM_COND_IF([SYNCD], [
-SAVED_FLAGS="$CXXFLAGS"
-CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
-AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_query_stats_st_capability sai_tam_telemetry_get_data)
-CXXFLAGS="$SAVED_FLAGS"
+AM_COND_IF([SAIVS],
+[
+    AC_DEFINE([HAVE_SAI_BULK_OBJECT_CLEAR_STATS], [1], [])
+    AC_DEFINE([HAVE_SAI_BULK_OBJECT_GET_STATS], [1], [])
+    AC_DEFINE([HAVE_SAI_QUERY_STATS_ST_CAPABILITY], [1], [])
+    AC_DEFINE([HAVE_SAI_TAM_TELEMETRY_GET_DATA], [1], [])
+],
+[
+    AM_COND_IF([SYNCD], [
+    SAVED_FLAGS="$CXXFLAGS"
+    CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
+    AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_query_stats_st_capability sai_tam_telemetry_get_data)
+    CXXFLAGS="$SAVED_FLAGS"
+    ])
 ])
 
 AC_DEFINE([SAIREDIS_GIT_REVISION],

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -53,9 +53,17 @@ VendorSai::VendorSai()
         .query_attribute_enum_values_capability = &sai_query_attribute_enum_values_capability,
         .query_object_stage = nullptr,
         .query_stats_capability = &sai_query_stats_capability,
+#ifdef HAVE_SAI_QUERY_STATS_ST_CAPABILITY
         .query_stats_st_capability = &sai_query_stats_st_capability,
+#else
+        .query_stats_st_capability = nullptr;
+#endif
         .switch_id_query = &sai_switch_id_query,
+#ifdef HAVE_SAI_TAM_TELEMETRY_GET_DATA
         .tam_telemetry_get_data = &sai_tam_telemetry_get_data,
+#else
+        .tam_telemetry_get_data = nullptr;
+#endif
     };
 
     m_globalApis = ga;
@@ -353,10 +361,12 @@ sai_status_t VendorSai::queryStatsStCapability(
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
-    return m_globalApis.query_stats_st_capability(
-        switchId,
-        objectType,
-        stats_capability);
+    return (m_globalApis.query_stats_st_capability == nullptr)
+        ? SAI_STATUS_NOT_IMPLEMENTED
+        : m_globalApis.query_stats_st_capability(
+                switchId,
+                objectType,
+                stats_capability);
 }
 
 sai_status_t VendorSai::getStatsExt(

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -56,13 +56,13 @@ VendorSai::VendorSai()
 #ifdef HAVE_SAI_QUERY_STATS_ST_CAPABILITY
         .query_stats_st_capability = &sai_query_stats_st_capability,
 #else
-        .query_stats_st_capability = nullptr;
+        .query_stats_st_capability = nullptr,
 #endif
         .switch_id_query = &sai_switch_id_query,
 #ifdef HAVE_SAI_TAM_TELEMETRY_GET_DATA
         .tam_telemetry_get_data = &sai_tam_telemetry_get_data,
 #else
-        .tam_telemetry_get_data = nullptr;
+        .tam_telemetry_get_data = nullptr,
 #endif
     };
 

--- a/tests/TestClient.cpp
+++ b/tests/TestClient.cpp
@@ -402,7 +402,7 @@ void TestClient::test_query_api()
         SAI_OBJECT_TYPE_QUEUE,
         &queue_stats_st_capability);
 
-    printf("rc: %s\n", sai_serialize_status(rc));
+    printf("rc: %s\n", sai_serialize_status(rc).c_str());
 
     ASSERT_TRUE(rc == SAI_STATUS_BUFFER_OVERFLOW);
 

--- a/tests/TestClient.cpp
+++ b/tests/TestClient.cpp
@@ -405,7 +405,8 @@ void TestClient::test_query_api()
 
     printf("rc: %s\n", sai_serialize_status(rc).c_str());
 
-    ASSERT_TRUE(rc == SAI_STATUS_BUFFER_OVERFLOW);
+    ASSERT_TRUE(rc == SAI_STATUS_BUFFER_OVERFLOW ||
+            rc == SAI_STATUS_NOT_IMPLEMENTED);
 
     sai_stat_st_capability_t stat_st_initializer;
     stat_st_initializer.capability.stat_enum = 0;
@@ -415,10 +416,13 @@ void TestClient::test_query_api()
 
     SWSS_LOG_NOTICE(" * sai_query_stats_st_capability");
 
-    ASSERT_SUCCESS(sai_query_stats_st_capability(
+    rc = sai_query_stats_st_capability(
         m_switch_id,
         SAI_OBJECT_TYPE_QUEUE,
-        &queue_stats_st_capability));
+        &queue_stats_st_capability);
+
+    ASSERT_TRUE(rc == SAI_STATUS_SUCCESS ||
+            rc == SAI_STATUS_NOT_IMPLEMENTED);
 
     teardown();
 }

--- a/tests/TestClient.cpp
+++ b/tests/TestClient.cpp
@@ -374,7 +374,8 @@ void TestClient::test_query_api()
                 m_switch_id,
                 SAI_OBJECT_TYPE_QUEUE,
                 &queue_stats_capability);
-    ASSERT_TRUE(rc == SAI_STATUS_BUFFER_OVERFLOW);
+    ASSERT_TRUE(rc == SAI_STATUS_BUFFER_OVERFLOW ||
+            rc == SAI_STATUS_NOT_IMPLEMENTED);
 
     sai_stat_capability_t stat_initializer;
     stat_initializer.stat_enum = 0;

--- a/tests/TestClient.cpp
+++ b/tests/TestClient.cpp
@@ -401,6 +401,9 @@ void TestClient::test_query_api()
         m_switch_id,
         SAI_OBJECT_TYPE_QUEUE,
         &queue_stats_st_capability);
+
+    printf("rc: %s\n", sai_serialize_status(rc));
+
     ASSERT_TRUE(rc == SAI_STATUS_BUFFER_OVERFLOW);
 
     sai_stat_st_capability_t stat_st_initializer;

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -1592,3 +1592,25 @@ TEST_F(VendorSaiTest, bulk_prefix_compression_entry)
     EXPECT_EQ(SAI_STATUS_NOT_SUPPORTED,
             m_vsai->bulkSet(0, e, nullptr, SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR, nullptr));
 }
+
+TEST(VendorSai, queryStatsStCapability)
+{
+    VendorSai sai;
+    sai.apiInitialize(0, &test_services);
+
+    sai_stat_st_capability_list_t st;
+
+    sai_stat_st_capability_t item;
+
+    st.count = 1;
+    st.list = &item;
+
+    sai_status_t status = sai.queryStatsStCapability(
+            SAI_NULL_OBJECT_ID, // switch id
+            SAI_OBJECT_TYPE_QUEUE,
+            &st);
+
+    // success expected, since always compiled against virtual switch
+
+    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, status); // switch is null
+}


### PR DESCRIPTION
Check if sai_query_stats_st_capability sai_tam_telemetry_get_data is defined whilie configure to make sure if vendor is not implementing those new APIs then it will still link syncd for VendorSai.cpp