### PR TITLE
Use sai_vpp.profile when starting vpp syncd

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -474,7 +474,7 @@ vpp_api_check()
 
 config_syncd_vpp()
 {
-    CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+    CMD_ARGS+=" -p $HWSKU_DIR/sai_vpp.profile"
     vpp_api_check "/run/vpp/api.sock"
     source /etc/sonic/vpp/syncd_vpp_env
     export NO_LINUX_NL


### PR DESCRIPTION
To use the vs/vpp combined libsai, a new switch type SAI_VS_SWITCH_TYPE_VPP is introduced, which is set through sai profile. Therefore, we need to choose the right sai profile when starting vpp syncd.