### PR TITLE
[nvidia-bluefield] Remove switchdev configuration from syncd init.

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -514,25 +514,7 @@ config_syncd_nvidia_bluefield()
     mkdir -p /mnt/huge
     mount -t hugetlbfs pagesize=1GB /mnt/huge
 
-    devlink dev eswitch set pci/0000:03:00.0 mode legacy
-    devlink dev eswitch set pci/0000:03:00.0 mode switchdev
-
-    if [[ $hwsku != *"-C1" ]] && [[ $single_port == false ]]; then
-        devlink dev param set pci/0000:03:00.0 name esw_multiport value 1 cmode runtime
-        devlink dev param set pci/0000:03:00.1 name esw_multiport value 1 cmode runtime
-    fi
-
     ethtool -A Ethernet0 rx off tx off
-
-    if [[ $single_port == false ]]; then
-        eth4_mac=$(cat /sys/class/net/Ethernet4/address)
-        echo "PORT_2_MAC_ADDRESS=$eth4_mac" >> /tmp/sai.profile
-
-        devlink dev eswitch set pci/0000:03:00.1 mode legacy
-        devlink dev eswitch set pci/0000:03:00.1 mode switchdev
-
-        ethtool -A Ethernet4 rx off tx off
-    fi
 }
 
 config_syncd_xsight()


### PR DESCRIPTION
This configuration will be applied by a separate systemd service on system start.