### PR TITLE
Add support for IPMC and L2MC Entry

### DIFF
--- a/meta/SaiInterface.cpp
+++ b/meta/SaiInterface.cpp
@@ -76,6 +76,12 @@ sai_status_t SaiInterface::create(
         case SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY:
             return create(&metaKey.objectkey.key.eni_trusted_vni_entry, attr_count, attr_list);
 
+        case SAI_OBJECT_TYPE_IPMC_ENTRY:
+            return create(&metaKey.objectkey.key.ipmc_entry, attr_count, attr_list);
+
+        case SAI_OBJECT_TYPE_L2MC_ENTRY:
+            return create(&metaKey.objectkey.key.l2mc_entry, attr_count, attr_list);
+
         default:
 
             SWSS_LOG_ERROR("object type %s not implemented, FIXME", info->objecttypename);
@@ -152,6 +158,12 @@ sai_status_t SaiInterface::remove(
 
         case SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY:
             return remove(&metaKey.objectkey.key.eni_trusted_vni_entry);
+
+        case SAI_OBJECT_TYPE_IPMC_ENTRY:
+            return remove(&metaKey.objectkey.key.ipmc_entry);
+
+        case SAI_OBJECT_TYPE_L2MC_ENTRY:
+            return remove(&metaKey.objectkey.key.l2mc_entry);
 
         default:
 
@@ -231,6 +243,12 @@ sai_status_t SaiInterface::set(
         case SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY:
             return set(&metaKey.objectkey.key.eni_trusted_vni_entry, attr);
 
+        case SAI_OBJECT_TYPE_IPMC_ENTRY:
+            return set(&metaKey.objectkey.key.ipmc_entry, attr);
+
+        case SAI_OBJECT_TYPE_L2MC_ENTRY:
+            return set(&metaKey.objectkey.key.l2mc_entry, attr);
+
         default:
 
             SWSS_LOG_ERROR("object type %s not implemented, FIXME", info->objecttypename);
@@ -309,6 +327,12 @@ sai_status_t SaiInterface::get(
 
         case SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY:
             return get(&metaKey.objectkey.key.eni_trusted_vni_entry, attr_count, attr_list);
+
+        case SAI_OBJECT_TYPE_IPMC_ENTRY:
+            return get(&metaKey.objectkey.key.ipmc_entry, attr_count, attr_list);
+
+        case SAI_OBJECT_TYPE_L2MC_ENTRY:
+            return get(&metaKey.objectkey.key.l2mc_entry, attr_count, attr_list);
 
         default:
 

--- a/unittest/meta/TestSaiInterface.cpp
+++ b/unittest/meta/TestSaiInterface.cpp
@@ -18,6 +18,8 @@ static sai_object_type_t objects_types_to_verify[] {
     SAI_OBJECT_TYPE_NAT_ENTRY,
     SAI_OBJECT_TYPE_INSEG_ENTRY,
     SAI_OBJECT_TYPE_MY_SID_ENTRY,
+    SAI_OBJECT_TYPE_L2MC_ENTRY,
+    SAI_OBJECT_TYPE_IPMC_ENTRY,
     (sai_object_type_t)SAI_OBJECT_TYPE_DIRECTION_LOOKUP_ENTRY,
     (sai_object_type_t)SAI_OBJECT_TYPE_ENI_ETHER_ADDRESS_MAP_ENTRY,
     (sai_object_type_t)SAI_OBJECT_TYPE_VIP_ENTRY,
@@ -40,9 +42,6 @@ TEST(SaiInterface, create)
         mk.objecttype = ot;
         EXPECT_EQ(SAI_STATUS_SUCCESS, sai->create(mk, 0, 0, nullptr));
     }
-
-    mk.objecttype = SAI_OBJECT_TYPE_L2MC_ENTRY;
-    EXPECT_EQ(SAI_STATUS_FAILURE, sai->create(mk, 0, 0, nullptr));
 }
 
 TEST(SaiInterface, remove)
@@ -61,8 +60,6 @@ TEST(SaiInterface, remove)
         EXPECT_EQ(SAI_STATUS_SUCCESS, sai->remove(mk));
     }
 
-    mk.objecttype = SAI_OBJECT_TYPE_L2MC_ENTRY;
-    EXPECT_EQ(SAI_STATUS_FAILURE, sai->remove(mk));
 }
 
 TEST(SaiInterface, set)
@@ -80,9 +77,6 @@ TEST(SaiInterface, set)
         mk.objecttype = ot;
         EXPECT_EQ(SAI_STATUS_SUCCESS, sai->set(mk, nullptr));
     }
-
-    mk.objecttype = SAI_OBJECT_TYPE_L2MC_ENTRY;
-    EXPECT_EQ(SAI_STATUS_FAILURE, sai->set(mk, nullptr));
 }
 
 TEST(SaiInterface, get)
@@ -100,9 +94,6 @@ TEST(SaiInterface, get)
         mk.objecttype = ot;
         EXPECT_EQ(SAI_STATUS_SUCCESS, sai->get(mk, 0, nullptr));
     }
-
-    mk.objecttype = SAI_OBJECT_TYPE_L2MC_ENTRY;
-    EXPECT_EQ(SAI_STATUS_FAILURE, sai->get(mk, 0, nullptr));
 }
 
 TEST(SaiInterface, stats_meter_bucket_entry)


### PR DESCRIPTION
Adding support for create, remove, get, and set of SAI_OBJECT_TYPE_L2MC_ENTRY and SAI_OBJECT_TYPE_IPMC_ENTRY.  This is verified by the unit tests in TestSaiInterface.cpp. 