### PR TITLE
Exclude sonic-vpp sai code from code coverage check

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -245,7 +245,7 @@ jobs:
           output_file=$(echo "coverage-$source_dir.json"| tr '/' '-')
           gcovr --exclude-unreachable-branches --json-pretty -o $output_file --object-directory $source_dir $dir
         done
-        gcovr -r ./ -e ".*/SAI/.*" -e ".+/json.hpp" -e "swss/.+" -e ".*/.libs/.*" -e ".*/debian/.*" --exclude-unreachable-branches --json-pretty -o coverage-all.json
+        gcovr -r ./ -e ".*/SAI/.*" -e ".+/json.hpp" -e "swss/.+" -e ".*/.libs/.*" -e ".*/debian/.*" -e ".*/vslib/vpp/.*" --exclude-unreachable-branches --json-pretty -o coverage-all.json
         gcovr -a "coverage-*.json" -x --xml-pretty -o coverage.xml
       displayName: "Run sonic sairedis unit tests"
   - publish: $(System.DefaultWorkingDirectory)/


### PR DESCRIPTION
### why
sonic-vpp sai code doesn't have unit test at the moment. It has been worked on but not ready yet. In the meantime, code coverage check failed for vpp related PRs. This is blocking merging vpp code.

### what this PR does
exclude vpp code from code coverage check