### PR TITLE
[Mellanox] Update syncd_init_common.sh to include SAI parameters from per-asic sai profile

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -349,6 +349,17 @@ config_syncd_mlnx()
 
     echo >> /tmp/sai-temp.profile
 
+    DEVICE_TYPE="$(mlxfwmanager |  awk -F'Device Type: *' '/Device Type/ {print $2}')"
+    if [ -n "$DEVICE_TYPE" ]; then
+        ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+
+        ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
+        if [ -f "$ASIC_PROFILE_PATH" ]; then
+            cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+            echo >> /tmp/sai-temp.profile
+        fi
+    fi
+
     if [[ -f $SAI_COMMON_FILE_PATH ]]; then
         cat $SAI_COMMON_FILE_PATH >> /tmp/sai-temp.profile
     fi

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -329,6 +329,16 @@ config_syncd_mlnx()
 {
     CMD_ARGS+=" -l -p /tmp/sai.profile"
 
+    declare -A DEVICE_DICT=(
+    ["cb84"]="spc1"
+    ["cf6c"]="spc2"
+    ["cf70"]="spc3"
+    ["cf80"]="spc4"
+    ["cf82"]="spc5"
+    ["a2dc"]="bf3"
+    )
+    VENDOR_ID="15b3"
+
     [ -e /dev/sxdevs/sxcdev ] || ( mkdir -p /dev/sxdevs && mknod /dev/sxdevs/sxcdev c 231 193 )
 
     # Read MAC address
@@ -349,8 +359,11 @@ config_syncd_mlnx()
 
     echo >> /tmp/sai-temp.profile
 
-    DEVICE_TYPE="$(mlxfwmanager |  awk -F'Device Type: *' '/Device Type/ {print $2}')"
-    if [ -n "$DEVICE_TYPE" ]; then
+    DEVICE_TYPE=""
+    DEVICE_ID=$(lspci -n | awk -v vid="$VENDOR_ID" '$0 ~ vid {print $NF}' | cut -d: -f2)
+    # Check if DEVICE_ID exists in the DEVICE_DICT
+    if [[ -n "${DEVICE_DICT[$DEVICE_ID]}" ]]; then
+        DEVICE_TYPE="${DEVICE_DICT[$DEVICE_ID]}"
         ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
 
         ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"


### PR DESCRIPTION
Changed config_mlnx_syncd() functionality to use per-asic sai.profile for all Spectrum{x} SKUs.
The function will apply specific SKU sai.profile, then per-asic sai.profile and lastly - sai-common.profile (which is for all Mellanox SKUs).

Why I did it
To have the ability to add common parameters to only 1 file instead of all SKUs - but per asic. 

depends on https://github.com/sonic-net/sonic-buildimage/pull/23255 that installs pciutils to Mellanox syncd docker - so we could execute lspci command inside syncd docker.