### PR TITLE
[broadcom platforms] Temporary workaround for undefined symbol: sai_query_stats_st_capability error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -283,7 +283,8 @@ AM_COND_IF([SAIVS],
     AM_COND_IF([SYNCD], [
     SAVED_FLAGS="$CXXFLAGS"
     CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
-    AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_query_stats_st_capability sai_tam_telemetry_get_data)
+    AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_tam_telemetry_get_data)
+    AH_TEMPLATE([HAVE_SAI_QUERY_STATS_ST_CAPABILITY], [Force it disabled for SAIs without implementation - REMOVE WHEN NOT NEEDED])
     CXXFLAGS="$SAVED_FLAGS"
     ])
 ])


### PR DESCRIPTION
Temporary workaround we are using internally for 720DT and DNX devices which are hitting:
`INFO gbsyncd#supervisord: syncd /usr/bin/syncd: symbol lookup error: /usr/bin/syncd: undefined symbol: sai_query_stats_st_capability#015`
as described in https://github.com/sonic-net/sonic-buildimage/issues/23387