### PR TITLE
Add missing <array> include to TestSyncdBrcm.cpp

### DIFF
--- a/syncd/tests/TestSyncdBrcm.cpp
+++ b/syncd/tests/TestSyncdBrcm.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <array>
 #include <thread>
 
 #include <arpa/inet.h>


### PR DESCRIPTION
With the future base image upgrade to Trixie and changes to the Bookworm build, the <array> header is not indirectly included anymore. Explicitly add it here, since std:array is used in this file.