### PR TITLE
[Mellanox] Add logic to use common sai.profile per asic for mlnx and nv bluefield

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -349,6 +349,14 @@ config_syncd_mlnx()
 
     echo >> /tmp/sai-temp.profile
 
+    DEVICE_TYPE=$(/usr/bin/asic_detect/asic_detect.sh)
+    ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+    ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
+    if [ -f "$ASIC_PROFILE_PATH" ]; then
+        cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+        echo >> /tmp/sai-temp.profile
+    fi
+
     if [[ -f $SAI_COMMON_FILE_PATH ]]; then
         cat $SAI_COMMON_FILE_PATH >> /tmp/sai-temp.profile
     fi
@@ -509,7 +517,21 @@ config_syncd_nvidia_bluefield()
 
     eth0_mac=$(cat /sys/class/net/Ethernet0/address)
 
-    cp $HWSKU_DIR/sai.profile /tmp/sai.profile
+    cp $HWSKU_DIR/sai.profile /tmp/sai-temp.profile
+
+    echo >> /tmp/sai-temp.profile
+
+    DEVICE_TYPE=$(/usr/bin/asic_detect/asic_detect.sh)
+    ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+    ASIC_PROFILE_PATH="/etc/nv-bf/${ASIC_PROFILE_FILE}"
+    if [ -f "$ASIC_PROFILE_PATH" ]; then
+        cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+        echo >> /tmp/sai-temp.profile
+    fi
+
+    # keep only the first occurence of each prefix with '=' sign, and remove the others.
+    awk -F= '!seen[$1]++' /tmp/sai-temp.profile > /tmp/sai.profile
+    rm -f /tmp/sai-temp.profile
 
     # Update sai.profile with MAC_ADDRESS
     echo "DEVICE_MAC_ADDRESS=$base_mac" >> /tmp/sai.profile

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -350,11 +350,15 @@ config_syncd_mlnx()
     echo >> /tmp/sai-temp.profile
 
     DEVICE_TYPE=$(/usr/bin/asic_detect/asic_detect.sh)
-    ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
-    ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
-    if [ -f "$ASIC_PROFILE_PATH" ]; then
-        cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
-        echo >> /tmp/sai-temp.profile
+    if [[ $? -eq 0 ]]; then
+        ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+        ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
+        if [ -f "$ASIC_PROFILE_PATH" ]; then
+            cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+            echo >> /tmp/sai-temp.profile
+        fi
+    else
+        echo "Warning: ASIC is not detected..."
     fi
 
     if [[ -f $SAI_COMMON_FILE_PATH ]]; then
@@ -522,11 +526,15 @@ config_syncd_nvidia_bluefield()
     echo >> /tmp/sai-temp.profile
 
     DEVICE_TYPE=$(/usr/bin/asic_detect/asic_detect.sh)
-    ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
-    ASIC_PROFILE_PATH="/etc/nv-bf/${ASIC_PROFILE_FILE}"
-    if [ -f "$ASIC_PROFILE_PATH" ]; then
-        cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
-        echo >> /tmp/sai-temp.profile
+    if [[ $? -eq 0 ]]; then
+        ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+        ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
+        if [ -f "$ASIC_PROFILE_PATH" ]; then
+            cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+            echo >> /tmp/sai-temp.profile
+        fi
+    else
+        echo "Warning: ASIC is not detected..."
     fi
 
     # keep only the first occurence of each prefix with '=' sign, and remove the others.


### PR DESCRIPTION
Changed config_mlnx_syncd() and config_syncd_nvidia_bluefield() functionality to use per-asic sai.profile for all Spectrum{x} SKUs.
The function will apply specific SKU sai.profile, then per-asic sai.profile and lastly - sai-common.profile (which is for all Mellanox SKUs).

Why I did it
To have the ability to add common parameters to only 1 file instead of all SKUs - but per asic.

depends on sonic-buildimage that created asic_detect.sh.