### PR TITLE
Use container registry when running tests

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -108,7 +108,7 @@ jobs:
       all_tests="${all_tests} p4rt dash"
       RETRY=3
       IMAGE_NAME=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }}
-      echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo ./run-tests.sh "$IMAGE_NAME" "$params" "TEST_MODULE" "$RETRY"
+      echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io/ ./run-tests.sh "$IMAGE_NAME" "$params" "TEST_MODULE" "$RETRY"
 
       rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"


### PR DESCRIPTION
When running the docker-sonic-vs tests, specify a container registry to pull containers from.