### PR TITLE
[202411]: Update upstream pipeline name to fix VS test issue.

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -33,7 +33,7 @@ jobs:
   timeoutInMinutes: ${{ parameters.timeout }}
 
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
 
   steps:
   - checkout: self

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -45,7 +45,7 @@ jobs:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
     ${{ else }}:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -59,7 +59,7 @@ jobs:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
     ${{ else }}:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -10,10 +10,6 @@ parameters:
   type: string
   default: docker-sonic-vs
 
-- name: sonic_buildimage_ubuntu20_04
-  type: string
-  default: '$(BUILD_BRANCH)'
-
 - name: asan
   type: boolean
   default: false
@@ -52,7 +48,7 @@ jobs:
       source: specific
       project: build
       pipeline: Azure.sonic-swss-common
-      artifact: sonic-swss-common.amd64.ubuntu20_04
+      artifact: sonic-swss-common.amd64.ubuntu22_04
       path: $(Build.ArtifactStagingDirectory)/download
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
@@ -62,27 +58,42 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: sonic-net.sonic-buildimage-ubuntu20.04
-      artifact: sonic-buildimage.amd64.ubuntu20_04
+      pipeline: sonic-net.sonic-buildimage-ubuntu22.04
+      artifact: sonic-buildimage.amd64.ubuntu22_04
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.sonic_buildimage_ubuntu20_04 }}'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
-    displayName: "Download sonic buildimage ubuntu20.04 deb packages"
+    displayName: "Download sonic buildimage ubuntu deb packages"
 
   - script: |
       set -ex
-      sudo sonic-sairedis/.azure-pipelines/build_and_install_module.sh
+      # install packages for vs test
+      sudo pip3 install pytest flaky exabgp docker redis
 
+      # install packages for kvm test
       sudo apt-get update
       sudo apt --fix-broken install
-      sudo apt-get install -y libhiredis0.14 libyang0.16
+      sudo apt-get -o DPkg::Lock::Timeout=600 install -y libvirt-clients \
+          qemu \
+          openvswitch-switch \
+          net-tools \
+          bridge-utils \
+          vlan \
+          python3-libvirt \
+          libzmq3-dev \
+          libzmq5 \
+          libboost-serialization1.74.0 \
+          libboost1.74-dev \
+          libboost-dev \
+          libhiredis0.14 \
+          libyang-dev \
+          uuid-dev
+
+      sudo sonic-sairedis/.azure-pipelines/build_and_install_module.sh
+
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
 
-      # install packages for vs test
-      sudo apt-get install -y net-tools bridge-utils vlan
-      sudo apt-get install -y python3-pip
-      sudo pip3 install pytest==4.6.2 attrs==19.1.0 exabgp==4.0.10 distro==1.5.0 docker>=4.4.1 redis==3.3.4 flaky==3.7.0 requests==2.31.0
     displayName: "Install dependencies"
 
   - script: |


### PR DESCRIPTION
Cherry-pick #1605 to 202411.

The VS test stage of PR tests pipeline has been failing. The reason is that one of the VS test step is to download ubuntu deb packages built from an upstream pipeline. The upstream pipeline has been renamed from sonic-net.sonic-buildimage-ubuntu20.04 to sonic-net.sonic-buildimage-ubuntu22.04 because of the deprecation of Ubuntu 20.04.

This pipeline needs to be updated according to use the new upstream pipeline name for artifacts downloading.

This change also deprecated a parameter `sonic_buildimage_ubuntu20_04 which is not really necessary.

 * Fixed conflicts in .azure-pipelines/test-docker-sonic-vs-template.yml