### PR TITLE
[sai] Install yang related debto align with latest libswsscommon requirement

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -58,6 +58,21 @@ jobs:
     inputs:
       source: specific
       project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib
+      patterns: |
+        target/debs/bookworm/libyang-*_1.0*.deb
+        target/debs/bookworm/libyang_1.0*.deb
+        target/debs/bookworm/libyang-cpp_*.deb
+        target/debs/bookworm/python3-yang_*.deb
+    displayName: "Download libyang from common lib"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
       pipeline: sonic-net.sonic-buildimage-ubuntu22.04
       artifact: sonic-buildimage.amd64.ubuntu22_04
       runVersion: 'latestFromBranch'
@@ -85,10 +100,16 @@ jobs:
           libboost1.74-dev \
           libboost-dev \
           libhiredis0.14 \
-          libyang-dev \
+          libpcre3-dev \
           uuid-dev
 
       sudo sonic-sairedis/.azure-pipelines/build_and_install_module.sh
+
+      # Install libyang packages from downloaded artifacts
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang-*_1.0*.deb \
+                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang_1.0*.deb \
+                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang-cpp_*.deb \
+                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/python3-yang_*.deb
 
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb


### PR DESCRIPTION
**What I did**
Install the yang related deb to make it align with the latest libswsscommon deb file.
**Why I did it**
The vstest will fail if not update with requirement yang file
**How I verified it**
Verify with vs test