### PR TITLE
vpp: fix bogus errors

### DIFF
--- a/vslib/vpp/SaiObjectDB.cpp
+++ b/vslib/vpp/SaiObjectDB.cpp
@@ -282,7 +282,7 @@ SaiObjectDB::get(
     // check if the object exists
     status = m_switch_db->get(object_type, id, 0, &attr);
     if (status != SAI_STATUS_SUCCESS) {
-        SWSS_LOG_WARN("Object is not found in SwitchVpp %s:%s", sai_serialize_object_type(object_type).c_str(), id.c_str());
+        SWSS_LOG_NOTICE("Object is not found in SwitchVpp %s:%s", sai_serialize_object_type(object_type).c_str(), id.c_str());
         return std::shared_ptr<SaiDBObject>();
     }
     /*
@@ -309,6 +309,13 @@ SaiObject::get_linked_object(
         SWSS_LOG_ERROR("Failed to get attribute %d from object %s", link_attr_id, m_id.c_str());
         return std::shared_ptr<SaiDBObject>();
     }
+
+    if (RealObjectIdManager::objectTypeQuery(attr.value.oid) != linked_object_type) {
+        SWSS_LOG_INFO("Linked object type mismatch: expected %d, got %d. Will return empty object.",
+                       linked_object_type, RealObjectIdManager::objectTypeQuery(attr.value.oid));
+        return std::shared_ptr<SaiDBObject>();
+    }
+
     linked_obj_id = sai_serialize_object_id(attr.value.oid);
 
     return m_switch_db->get_sai_object(linked_object_type, linked_obj_id);

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1341,7 +1341,7 @@ sai_status_t SwitchVpp::get(
 
     if (it == objectHash.end())
     {
-        SWSS_LOG_ERROR("not found %s:%s",
+        SWSS_LOG_INFO("not found %s:%s",
                 sai_serialize_object_type(objectType).c_str(),
                 serializedObjectId.c_str());
 

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -154,11 +154,11 @@ std::string get_intf_name_for_prefix (
     is_v6 = (route_entry.destination.addr_family == SAI_IP_ADDR_FAMILY_IPV6) ? true : false;
 
     std::string full_if_name = "";
-        bool found = vpp_get_intf_name_for_prefix(route_entry.destination, is_v6, full_if_name);
-        if (found == false)
-        {
+    bool found = vpp_get_intf_name_for_prefix(route_entry.destination, is_v6, full_if_name);
+    if (found == false)
+    {
         auto prefix_str = sai_serialize_ip_prefix(route_entry.destination);
-            SWSS_LOG_ERROR("host interface for prefix not found: %s", prefix_str.c_str());
+        SWSS_LOG_INFO("host interface for prefix not found: %s", prefix_str.c_str());
     }
     return full_if_name;
 


### PR DESCRIPTION
### why
vpp incorrectly logs messages in error level and causes log analyzer failed.

### what this PR does

1. Changes the few places from ERROR to INFO level 
2. in SaiObject::get_linked_object, if object-type is not the expected type, return nullptr.