### PR TITLE
[sairedis] Fix hardcoded object type in DECLARE_BULK_SET_ENTRY macro

### DIFF
--- a/lib/ClientSai.cpp
+++ b/lib/ClientSai.cpp
@@ -428,7 +428,7 @@ sai_status_t ClientSai::bulkSet(                                                
     {                                                                                                     \
         serializedObjectIds.emplace_back(sai_serialize_ ##ot (ot[idx]));                                  \
     }                                                                                                     \
-    return bulkSet(SAI_OBJECT_TYPE_ROUTE_ENTRY, serializedObjectIds, attr_list, mode, object_statuses);   \
+    return bulkSet((sai_object_type_t)SAI_OBJECT_TYPE_ ## OT, serializedObjectIds, attr_list, mode, object_statuses);   \
 }
 
 SAIREDIS_DECLARE_EVERY_BULK_ENTRY(DECLARE_BULK_SET_ENTRY)


### PR DESCRIPTION
The DECLARE_BULK_SET_ENTRY macro in ClientSai.cpp incorrectly hardcoded SAI_OBJECT_TYPE_ROUTE_ENTRY instead of using the parameterized object type.

This caused all bulk set operations for non-route entries to fail, including:
- sai_neighbor_entry_t (neighbor entries)
- sai_fdb_entry_t (FDB entries)
- sai_nat_entry_t (NAT entries)
- sai_inseg_entry_t (MPLS in-segment entries)
- Various DASH entries

The fix changes:
  return bulkSet(SAI_OBJECT_TYPE_ROUTE_ENTRY, ...) to:
  return bulkSet((sai_object_type_t)SAI_OBJECT_TYPE_ ## OT, ...)

This aligns with the correct pattern used in DECLARE_BULK_REMOVE_ENTRY and other implementations (RedisRemoteSaiInterface.cpp, Meta.cpp).

Signed-off-by: Selvamani Ramasamy <selva@nexthop.ai>