### PR TITLE
Fix syncd crash due to attr obj list not initialized

### DIFF
--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -2185,6 +2185,13 @@ sai_status_t SwitchStateBase::warm_update_switch()
     }
 
     attr.id = SAI_SWITCH_ATTR_TAM_OBJECT_ID;
+
+    std::vector<sai_object_id_t> objlist;
+    objlist.resize(MAX_OBJLIST_LEN);
+
+    attr.value.objlist.count = MAX_OBJLIST_LEN;
+    attr.value.objlist.list = objlist.data();
+
     if (get(SAI_OBJECT_TYPE_SWITCH, m_switch_id, 1, &attr) != SAI_STATUS_SUCCESS)
     {
         CHECK_STATUS(set_initial_tam_objects());


### PR DESCRIPTION
## Issue description
SYNCD crash is observed in warm-reboot in swss-update PR build, the crash is due to the `SAI_SWITCH_ATTR_TAM_OBJECT_ID` attribute object list is not properly initialized in `warm_update_switch`.

## Root cause
The swss update includes PR [[orchagent]: HFTOrch init](https://github.com/sonic-net/sonic-swss/pull/3759/files#top), which creates the SAI TAM object.

## Fix
Let's initialize the object list explicitly.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>
