### PR TITLE
Fix the incorrect size limitation for string attribute in meta_generic_validation_create

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -3520,18 +3520,21 @@ sai_status_t Meta::meta_generic_validation_create(
                 {
                     const char* chardata = value.chardata;
 
-                    size_t len = strnlen(chardata, SAI_HOSTIF_NAME_SIZE);
+                    size_t limit_len = attr->id == SAI_HOSTIF_ATTR_NAME ? SAI_HOSTIF_NAME_SIZE :
+                            (attr->id == SAI_HOSTIF_ATTR_GENETLINK_MCGRP_NAME ? SAI_HOSTIF_GENETLINK_MCGRP_NAME_SIZE :
+                            sizeof(sai_attribute_value_t::chardata));
+                    size_t len = strnlen(chardata, limit_len);
 
-                    if (len == SAI_HOSTIF_NAME_SIZE)
+                    if (len == limit_len)
                     {
-                        META_LOG_ERROR(md, "host interface name is too long");
+                        META_LOG_ERROR(md, "char data is too long");
 
                         return SAI_STATUS_INVALID_PARAMETER;
                     }
 
                     if (len == 0)
                     {
-                        META_LOG_ERROR(md, "host interface name is zero");
+                        META_LOG_ERROR(md, "char data is zero");
 
                         return SAI_STATUS_INVALID_PARAMETER;
                     }
@@ -3542,7 +3545,7 @@ sai_status_t Meta::meta_generic_validation_create(
 
                         if (c < 0x20 || c > 0x7e)
                         {
-                            META_LOG_ERROR(md, "interface name contains invalid character 0x%02x", c);
+                            META_LOG_ERROR(md, "char data contains invalid character 0x%02x", c);
 
                             return SAI_STATUS_INVALID_PARAMETER;
                         }


### PR DESCRIPTION
Fix the incorrect size limitation for string attribute in meta_generic_validation_create (#1663)

1. SAI_HOSTIF_NAME_SIZE only applies to SAI_HOSTIF_ATTR_NAME
2. SAI_HOSTIF_GENETLINK_MCGRP_NAME_SIZE applies to SAI_HOSTIF_ATTR_GENETLINK_MCGRP_NAME
3. Others apply to chardata size.