### PR TITLE
[202411][meta] do not fail bulk operations if MODE_IGNORE_ERROR

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -16,6 +16,11 @@
 
 #define CHECK_STATUS_SUCCESS(s) { if ((s) != SAI_STATUS_SUCCESS) return (s); }
 
+#define CHECK_STATUS_SUCCESS_MODE(s,m)                                                          \
+{                                                                                               \
+    if ((s) != SAI_STATUS_SUCCESS && m != SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR) return (s);      \
+}                                                                                               \
+
 #define VALIDATION_LIST(md,vlist)                                               \
 {                                                                               \
     auto _status = meta_genetic_validation_list(md,vlist.count,vlist.list);     \
@@ -613,14 +618,14 @@ sai_status_t Meta::bulkCreate(                                                  
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], true);                                                 \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
              };                                                                                                         \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_create(meta_key, ot[idx].switch_id, attr_count[idx], attr_list[idx]);          \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
     }                                                                                                                   \
     auto status = m_implementation->bulkCreate(object_count, ot, attr_count, attr_list, mode, object_statuses);         \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
@@ -657,14 +662,14 @@ sai_status_t Meta::bulkRemove(                                                  
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], false);                                                \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
             };                                                                                                          \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_remove(meta_key);                                                              \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
     }                                                                                                                   \
     auto status = m_implementation->bulkRemove(object_count, ot, mode, object_statuses);                                \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
@@ -703,14 +708,14 @@ sai_status_t Meta::bulkSet(                                                     
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], false);                                                \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
              };                                                                                                         \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_set(meta_key, &attr_list[idx]);                                                \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
     }                                                                                                                   \
     auto status = m_implementation->bulkSet(object_count, ot, attr_list, mode, object_statuses);                        \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
@@ -1183,7 +1188,7 @@ sai_status_t Meta::bulkRemove(
     {
         sai_status_t status = meta_sai_validate_oid(object_type, &object_id[idx], SAI_NULL_OBJECT_ID, false);
 
-        CHECK_STATUS_SUCCESS(status);
+        CHECK_STATUS_SUCCESS_MODE(status, mode);
 
         sai_object_meta_key_t meta_key = { .objecttype = object_type, .objectkey = { .key = { .object_id  = object_id[idx] } } };
 
@@ -1191,7 +1196,7 @@ sai_status_t Meta::bulkRemove(
 
         status = meta_generic_validation_remove(meta_key);
 
-        CHECK_STATUS_SUCCESS(status);
+        CHECK_STATUS_SUCCESS_MODE(status, mode);
     }
 
     auto status = m_implementation->bulkRemove(object_type, object_count, object_id, mode, object_statuses);
@@ -1245,7 +1250,7 @@ sai_status_t Meta::bulkSet(
     {
         sai_status_t status = meta_sai_validate_oid(object_type, &object_id[idx], SAI_NULL_OBJECT_ID, false);
 
-        CHECK_STATUS_SUCCESS(status);
+        CHECK_STATUS_SUCCESS_MODE(status, mode);
 
         sai_object_meta_key_t meta_key = { .objecttype = object_type, .objectkey = { .key = { .object_id  = object_id[idx] } } };
 
@@ -1253,7 +1258,7 @@ sai_status_t Meta::bulkSet(
 
         status = meta_generic_validation_set(meta_key, &attr_list[idx]);
 
-        CHECK_STATUS_SUCCESS(status);
+        CHECK_STATUS_SUCCESS_MODE(status, mode);
     }
 
     auto status = m_implementation->bulkSet(object_type, object_count, object_id, attr_list, mode, object_statuses);
@@ -1343,7 +1348,7 @@ sai_status_t Meta::bulkCreate(
     {
         sai_status_t status = meta_sai_validate_oid(object_type, &object_id[idx], switchId, true);
 
-        CHECK_STATUS_SUCCESS(status);
+        CHECK_STATUS_SUCCESS_MODE(status, mode);
 
         // this is create, oid's don't exist yet
 
@@ -1353,7 +1358,7 @@ sai_status_t Meta::bulkCreate(
 
         status = meta_generic_validation_create(meta_key, switchId, attr_count[idx], attr_list[idx]);
 
-        CHECK_STATUS_SUCCESS(status);
+        CHECK_STATUS_SUCCESS_MODE(status, mode);
     }
 
     auto status = m_implementation->bulkCreate(object_type, switchId, object_count, attr_count, attr_list, mode, object_id, object_statuses);


### PR DESCRIPTION
bulk operations do not continue when SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR is set and an error occurs. Create new check that considers the mode when validating bulk operations.

fixes a crash in https://github.com/sonic-net/sonic-buildimage/issues/21243 because route entries that are not removed in syncd by bulker are assumed to be removed in orchagent. Then when the nexthops are attempting to be removed, orchagent crashes due to OBJECT_IN_USE.

cherry-pick of https://github.com/sonic-net/sonic-sairedis/pull/1613