### PR TITLE
Add PORT_PHY_ATTR flex counter support

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -2009,6 +2009,11 @@ void Meta::meta_generic_validation_post_remove(
                 // no special action required
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
+            case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+                // no special action required
+                break;
+
             default:
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
         }
@@ -3759,6 +3764,14 @@ sai_status_t Meta::meta_generic_validation_create(
                 VALIDATION_LIST(md, value.ipprefixlist);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
+                VALIDATION_LIST(md, value.portlanelatchstatuslist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+                VALIDATION_LIST(md, value.portsnrlist);
+                break;
+
             default:
 
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -4377,6 +4390,14 @@ sai_status_t Meta::meta_generic_validation_set(
             VALIDATION_LIST(md, value.ipprefixlist);
             break;
 
+        case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
+            VALIDATION_LIST(md, value.portlanelatchstatuslist);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+            VALIDATION_LIST(md, value.portsnrlist);
+            break;
+
         default:
 
             META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -4765,6 +4786,14 @@ sai_status_t Meta::meta_generic_validation_get(
                 VALIDATION_LIST(md, value.ipprefixlist);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
+                VALIDATION_LIST(md, value.portlanelatchstatuslist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+                VALIDATION_LIST(md, value.portsnrlist);
+                break;
+
             default:
 
                 // acl capability will is more complex since is in/out we need to check stage
@@ -5045,6 +5074,14 @@ void Meta::meta_generic_validation_post_get(
 
             case SAI_ATTR_VALUE_TYPE_IP_PREFIX_LIST:
                 VALIDATION_LIST_GET(md, value.ipprefixlist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
+                VALIDATION_LIST_GET(md, value.portlanelatchstatuslist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+                VALIDATION_LIST_GET(md, value.portsnrlist);
                 break;
 
             default:

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -1052,6 +1052,13 @@ std::string sai_serialize_ipmc_entry_type(
     return sai_serialize_enum(type, &sai_metadata_enum_sai_ipmc_entry_type_t);
 }
 
+std::string sai_serialize_port_attr(_In_ const sai_port_attr_t port_attr)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_enum(port_attr, &sai_metadata_enum_sai_port_attr_t);
+}
+
 std::string sai_serialize_port_stat(
         _In_ const sai_port_stat_t counter)
 {
@@ -1621,45 +1628,56 @@ std::string sai_serialize_latch_status(
     return changed + ":" + current_status;
 }
 
-json sai_serialize_port_lane_latch_status_item(
-        _In_ const sai_port_lane_latch_status_t& lane_latch_status)
-{
-    SWSS_LOG_ENTER();
-    json j;
-
-    j["lane"] = lane_latch_status.lane;
-    j["value"] = sai_serialize_latch_status(lane_latch_status.value);
-
-    return j;
-}
-
 std::string sai_serialize_port_lane_latch_status_list(
         _In_ const sai_port_lane_latch_status_list_t& status_list,
         _In_ bool countOnly)
 {
     SWSS_LOG_ENTER();
 
-    json j;
-
-    j["count"] = status_list.count;
+    json j = json::object();
 
     if (status_list.list == NULL || countOnly)
     {
-        j["list"] = nullptr;
-
         return j.dump();
     }
 
-    json arr = json::array();
-
+    // Create dictionary format: {"0": "T*", "1": "F", ...}
+    // T/F = current_status, * = changed indicator
     for (uint32_t i = 0; i < status_list.count; ++i)
     {
-        json item = sai_serialize_port_lane_latch_status_item(status_list.list[i]);
+        std::string lane_key = std::to_string(status_list.list[i].lane);
+        std::string value = status_list.list[i].value.current_status ? "T" : "F";
 
-        arr.push_back(item);
+        if (status_list.list[i].value.changed)
+        {
+            value += "*";
+        }
+
+        j[lane_key] = value;
     }
 
-    j["list"] = arr;
+    return j.dump();
+}
+
+std::string sai_serialize_port_snr_list(
+        _In_ const sai_port_snr_list_t& snr_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::object();
+
+    if (snr_list.list == NULL || countOnly)
+    {
+        return j.dump();
+    }
+
+    // Create dictionary format: {"0": 3712, "1": 3840, ...}
+    for (uint32_t i = 0; i < snr_list.count; ++i)
+    {
+        std::string lane_key = std::to_string(snr_list.list[i].lane);
+        j[lane_key] = snr_list.list[i].snr;
+    }
 
     return j.dump();
 }
@@ -2171,6 +2189,9 @@ std::string sai_serialize_attr_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             return sai_serialize_port_lane_latch_status_list(attr.value.portlanelatchstatuslist, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+            return sai_serialize_port_snr_list(attr.value.portsnrlist, countOnly);
 
 //        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
 //            return sai_serialize_number_list(attr.value.u16list, countOnly);
@@ -4294,35 +4315,134 @@ void sai_deserialize_port_lane_latch_status_list(
 {
     SWSS_LOG_ENTER();
 
-    json j = json::parse(s);
-
-    status_list.count = j["count"];
-
-    if (countOnly)
+    try
     {
-        return;
+        json j = json::parse(s);
+
+        if (j.empty() || !j.is_object())
+        {
+            status_list.count = 0;
+            status_list.list = NULL;
+            return;
+        }
+
+        status_list.count = static_cast<uint32_t>(j.size());
+
+        if (countOnly)
+        {
+            return;
+        }
+
+        status_list.list = sai_alloc_n_of_ptr_type(status_list.count, status_list.list);
+
+        uint32_t idx = 0;
+        for (auto it = j.begin(); it != j.end(); ++it, ++idx)
+        {
+            if (!it.value().is_string())
+            {
+                SWSS_LOG_ERROR("Invalid latch status value type for lane %s", it.key().c_str());
+                continue;
+            }
+
+            std::string value_str = it.value().get<std::string>();
+
+            if (value_str.empty() || (value_str[0] != 'T' && value_str[0] != 'F'))
+            {
+                SWSS_LOG_ERROR("Invalid latch status value '%s' for lane %s",
+                              value_str.c_str(), it.key().c_str());
+                continue;
+            }
+
+            status_list.list[idx].lane = static_cast<uint32_t>(std::stoul(it.key()));
+
+            if (value_str.back() == '*')
+            {
+                status_list.list[idx].value.changed = true;
+                status_list.list[idx].value.current_status = (value_str[0] == 'T');
+            }
+            else
+            {
+                status_list.list[idx].value.changed = false;
+                status_list.list[idx].value.current_status = (value_str[0] == 'T');
+            }
+        }
     }
-
-    if (j["list"] == nullptr)
+    catch (const json::parse_error& e)
     {
+        SWSS_LOG_ERROR("JSON parse error in sai_deserialize_port_lane_latch_status_list: %s", e.what());
+        status_list.count = 0;
         status_list.list = NULL;
-        return;
     }
-
-    json arr = j["list"];
-
-    if (arr.size() != (size_t)status_list.count)
+    catch (const std::exception& e)
     {
-        SWSS_LOG_THROW("port lane latch status count mismatch %lu vs %u", arr.size(),status_list.count);
+        SWSS_LOG_ERROR("Error in sai_deserialize_port_lane_latch_status_list: %s", e.what());
+        status_list.count = 0;
+        status_list.list = NULL;
     }
+}
 
-    status_list.list = sai_alloc_n_of_ptr_type(status_list.count, status_list.list);
+void sai_deserialize_port_snr_values_item(
+        _In_ const json& j,
+        _Out_ sai_port_snr_values_t& snr_values)
+{
+    SWSS_LOG_ENTER();
 
-    for (uint32_t i = 0; i < status_list.count; ++i)
+    // Parse quoted string values
+    sai_deserialize_number(j["lane"], snr_values.lane, false);
+    sai_deserialize_number(j["snr"], snr_values.snr, false);
+}
+
+void sai_deserialize_port_snr_list(
+        _In_ const std::string& s,
+        _Out_ sai_port_snr_list_t& snr_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    try
     {
-        const json &item = arr[i];
+        json j = json::parse(s);
 
-        sai_deserialize_port_lane_latch_status(item, status_list.list[i]);
+        if (j.empty() || !j.is_object())
+        {
+            snr_list.count = 0;
+            snr_list.list = NULL;
+            return;
+        }
+
+        snr_list.count = static_cast<uint32_t>(j.size());
+
+        if (countOnly)
+        {
+            return;
+        }
+
+        snr_list.list = sai_alloc_n_of_ptr_type(snr_list.count, snr_list.list);
+
+        uint32_t idx = 0;
+        for (auto it = j.begin(); it != j.end(); ++it, ++idx)
+        {
+            if (!it.value().is_number_unsigned())
+            {
+                SWSS_LOG_ERROR("Invalid SNR value type for lane %s", it.key().c_str());
+                continue;
+            }
+
+            snr_list.list[idx].lane = static_cast<uint32_t>(std::stoul(it.key()));
+            snr_list.list[idx].snr = it.value().get<sai_uint16_t>();
+        }
+    }
+    catch (const json::parse_error& e)
+    {
+        SWSS_LOG_ERROR("JSON parse error in sai_deserialize_port_snr_list: %s", e.what());
+        snr_list.count = 0;
+        snr_list.list = NULL;
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Error in sai_deserialize_port_snr_list: %s", e.what());
+        snr_list.count = 0;
+        snr_list.list = NULL;
     }
 }
 
@@ -4459,6 +4579,9 @@ void sai_deserialize_attr_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             return sai_deserialize_port_lane_latch_status_list(s, attr.value.portlanelatchstatuslist, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+            return sai_deserialize_port_snr_list(s, attr.value.portsnrlist, countOnly);
 
 //        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
 //            return sai_deserialize_number_list(s, attr.value.u16list, countOnly);
@@ -4625,6 +4748,15 @@ void sai_deserialize_ipmc_entry_type(
     SWSS_LOG_ENTER();
 
     return sai_deserialize_enum(s, &sai_metadata_enum_sai_ipmc_entry_type_t, (int32_t&)type);
+}
+
+void sai_deserialize_port_attr(
+    _In_ const std::string& s,
+    _Out_ sai_port_attr_t& port_attr)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_enum(s, &sai_metadata_enum_sai_port_attr_t, (int32_t&)port_attr);
 }
 
 void sai_deserialize_l2mc_entry_type(
@@ -5843,6 +5975,10 @@ void sai_deserialize_free_attribute_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             sai_free_list(attr.value.portlanelatchstatuslist);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+            sai_free_list(attr.value.portsnrlist);
             break;
 
             /* ACL FIELD DATA */

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -4326,7 +4326,7 @@ void sai_deserialize_port_lane_latch_status_list(
             return;
         }
 
-        status_list.count = j["count"];
+        status_list.count = static_cast<uint32_t>(j.size());
 
         if (countOnly)
         {

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -4326,7 +4326,7 @@ void sai_deserialize_port_lane_latch_status_list(
             return;
         }
 
-        status_list.count = static_cast<uint32_t>(j.size());
+        status_list.count = j["count"];
 
         if (countOnly)
         {
@@ -4354,17 +4354,8 @@ void sai_deserialize_port_lane_latch_status_list(
             }
 
             status_list.list[idx].lane = static_cast<uint32_t>(std::stoul(it.key()));
-
-            if (value_str.back() == '*')
-            {
-                status_list.list[idx].value.changed = true;
-                status_list.list[idx].value.current_status = (value_str[0] == 'T');
-            }
-            else
-            {
-                status_list.list[idx].value.changed = false;
-                status_list.list[idx].value.current_status = (value_str[0] == 'T');
-            }
+            status_list.list[idx].value.changed = (value_str.back() == '*');
+            status_list.list[idx].value.current_status = (value_str[0] == 'T');
         }
     }
     catch (const json::parse_error& e)

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -30,6 +30,8 @@ sai_status_t transfer_attributes(
 
 // serialize
 
+std::string sai_serialize_port_attr(_In_ const sai_port_attr_t port_attr);
+
 std::string sai_serialize_fdb_event(
         _In_ sai_fdb_event_t event);
 
@@ -316,6 +318,10 @@ std::string sai_serialize_stats_st_capability_list(
         _In_ const sai_enum_metadata_t *meta,
         _In_ bool countOnly);
 
+std::string sai_serialize_port_snr_list(
+        _In_ const sai_port_snr_list_t& snr_list,
+        _In_ bool countOnly);
+
 // serialize notifications
 
 std::string sai_serialize_fdb_event_ntf(
@@ -449,6 +455,10 @@ void sai_deserialize_api(
 void sai_deserialize_ipmc_entry_type(
         _In_ const std::string& s,
         _Out_ sai_ipmc_entry_type_t& type);
+
+void sai_deserialize_port_attr(
+      _In_ const std::string& s,
+      _Out_ sai_port_attr_t& port_attr);
 
 void sai_deserialize_l2mc_entry_type(
         _In_ const std::string& s,
@@ -751,6 +761,11 @@ void sai_deserialize_stats_st_capability_list(
         _In_ const std::string &stat_enum_str,
         _In_ const std::string &stat_modes_str,
         _In_ const std::string &minimal_polling_interval_str);
+
+void sai_deserialize_port_snr_list(
+        _In_ const std::string& s,
+        _Out_ sai_port_snr_list_t& snr_list,
+        _In_ bool countOnly);
 
 void sai_deserialize_switch_macsec_post_status(
         _In_ const std::string& s,

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2047,9 +2047,10 @@ public:
 
 private:
     /**
-     * @brief Compare current lane values with previous and update metadata
+     * @brief Update metadata when SAI reports lane latch status change
      *
-     * Updates timestamp and count when lane latch status changes.
+     * Updates timestamp and count when SAI indicates the latch status changed
+     * via the 'changed' flag in sai_latch_status_t.
      * Only applicable for discrete latch attributes (signal detect, FEC lock).
      *
      * @param vid Virtual object ID
@@ -2078,14 +2079,10 @@ private:
             // Get or initialize metadata for this lane
             auto& metadata = m_laneMetadata[vid][attr_id][lane];
 
-            // Check if latch status changed
-            bool status_changed = (metadata.latch_value.current_status != current_latch.current_status) ||
-                                 (metadata.latch_value.changed != current_latch.changed);
-
-            if (status_changed)
+            // Check if SAI reports status changed
+            if (current_latch.changed)
             {
-                // Value changed - update all fields
-                metadata.latch_value = current_latch;
+                // SAI reported change - update timestamp and counter
                 metadata.timestamp_ms = timestamp_ms;
                 metadata.count++;
 
@@ -2149,15 +2146,10 @@ private:
 
     struct LaneMetadata
     {
-        sai_latch_status_t latch_value;
         uint64_t timestamp_ms;
         uint64_t count;
 
-        LaneMetadata() : timestamp_ms(0), count(0)
-        {
-            latch_value.current_status = false;
-            latch_value.changed = false;
-        }
+        LaneMetadata() : timestamp_ms(0), count(0) {}
     };
 
     std::string m_dbCounters;

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -22,7 +22,7 @@ using namespace std;
 #define MUTEX_UNLOCK _lock.unlock();
 
 static const std::string COUNTER_TYPE_PORT = "Port Counter";
-static const std::string ATTR_TYPE_PORT_ATTR = "Port Attributes";
+static const std::string ATTR_TYPE_PORT_PHY_ATTR = "Port Phy Attributes";
 static const std::string COUNTER_TYPE_PORT_DEBUG = "Port Debug Counter";
 static const std::string COUNTER_TYPE_QUEUE = "Queue Counter";
 static const std::string COUNTER_TYPE_PG = "Priority Group Counter";
@@ -70,7 +70,7 @@ const std::map<std::string, std::string> FlexCounter::m_plugIn2CounterType = {
 
 const std::map<std::tuple<sai_object_type_t, std::string>, std::string> FlexCounter::m_objectTypeField2CounterType = {
     {{SAI_OBJECT_TYPE_PORT, PORT_COUNTER_ID_LIST}, COUNTER_TYPE_PORT},
-    {{SAI_OBJECT_TYPE_PORT, PORT_ATTR_ID_LIST}, ATTR_TYPE_PORT_ATTR},
+    {{SAI_OBJECT_TYPE_PORT, PORT_PHY_ATTR_ID_LIST}, ATTR_TYPE_PORT_PHY_ATTR},
     {{SAI_OBJECT_TYPE_PORT, PORT_DEBUG_COUNTER_ID_LIST}, COUNTER_TYPE_PORT_DEBUG},
     {{SAI_OBJECT_TYPE_QUEUE, QUEUE_COUNTER_ID_LIST}, COUNTER_TYPE_QUEUE},
     {{SAI_OBJECT_TYPE_QUEUE, QUEUE_ATTR_ID_LIST}, ATTR_TYPE_QUEUE},
@@ -1742,7 +1742,7 @@ public:
     }
 };
 
-// Specialized context for PORT_ATTR that writes to dedicated table with port name as key
+// Specialized context for PORT_PHY_ATTR that writes to dedicated table with port name as key
 class PortAttrContext : public AttrContext<sai_port_attr_t, PortAttributeData>
 {
 public:
@@ -1811,7 +1811,7 @@ public:
 
             if (!initAttrForLaneCountQuery(attr))
             {
-                SWSS_LOG_DEBUG("PORT_ATTR: initAttrForLaneCountQuery failed for attribute %d", attr.id);
+                SWSS_LOG_DEBUG("PORT_PHY_ATTR: initAttrForLaneCountQuery failed for attribute %d", attr.id);
                 continue;
             }
 
@@ -1823,14 +1823,14 @@ public:
                     &attr);
             if (status != SAI_STATUS_BUFFER_OVERFLOW)
             {
-                SWSS_LOG_ERROR("PORT_ATTR: Failed to get supported lane count for attr_id=%d Rid:0x%" PRIx64 ", status=%d",
+                SWSS_LOG_ERROR("PORT_PHY_ATTR: Failed to get supported lane count for attr_id=%d Rid:0x%" PRIx64 ", status=%d",
                         attr.id, rid, status);
                 continue;
             }
 
             uint32_t laneCount = extractLaneCount(attr);
             m_portLaneCountMap[rid][static_cast<sai_port_attr_t>(attr.id)] = laneCount;
-            SWSS_LOG_DEBUG("PORT_ATTR: m_portLaneCountMap[rid:0x%" PRIx64 "][%d] = %u", rid, attr.id, laneCount);
+            SWSS_LOG_DEBUG("PORT_PHY_ATTR: m_portLaneCountMap[rid:0x%" PRIx64 "][%d] = %u", rid, attr.id, laneCount);
         }
     }
 
@@ -1841,14 +1841,14 @@ public:
     {
         if (!attr || !data)
         {
-            SWSS_LOG_ERROR("PORT_ATTR: Invalid input params : attr : %p, data : %p", attr, data);
+            SWSS_LOG_ERROR("PORT_PHY_ATTR: Invalid input params : attr : %p, data : %p", attr, data);
             return;
         }
 
         auto outer_it = m_portLaneCountMap.find(rid);
         if (outer_it == m_portLaneCountMap.end())
         {
-          SWSS_LOG_ERROR("PORT_ATTR: Rid:0x%" PRIx64 " not found in m_portLaneCountMap, attr->id : %d",
+          SWSS_LOG_ERROR("PORT_PHY_ATTR: Rid:0x%" PRIx64 " not found in m_portLaneCountMap, attr->id : %d",
                          rid, attr->id);
           return;
         }
@@ -1857,13 +1857,13 @@ public:
         auto inner_it = attrLaneCountMap.find(static_cast<sai_port_attr_t>(attr->id));
         if (inner_it == attrLaneCountMap.end())
         {
-          SWSS_LOG_ERROR("PORT_ATTR: Attr Id(%d) not found in m_portLaneCountMap[Rid:0x%" PRIx64 "]",
+          SWSS_LOG_ERROR("PORT_PHY_ATTR: Attr Id(%d) not found in m_portLaneCountMap[Rid:0x%" PRIx64 "]",
                          attr->id, rid);
           return;
         }
 
         auto portLaneCount = inner_it->second;
-        SWSS_LOG_DEBUG("PORT_ATTR: Found m_portLaneCountMap[Rid:0x%" PRIx64 "][attr->id:%d] = %d",
+        SWSS_LOG_DEBUG("PORT_PHY_ATTR: Found m_portLaneCountMap[Rid:0x%" PRIx64 "][attr->id:%d] = %d",
                      rid, attr->id, portLaneCount);
 
         switch (attr->id) {
@@ -1886,7 +1886,7 @@ public:
                 break;
 
             default:
-                SWSS_LOG_ERROR("PORT_ATTR: initAttrData: Unsupported attr-id : %d", attr->id);
+                SWSS_LOG_ERROR("PORT_PHY_ATTR: initAttrData: Unsupported attr-id : %d", attr->id);
                 break;
         }
     }
@@ -1931,7 +1931,7 @@ public:
             auto lane_it = m_portLaneCountMap.find(it->second->rid);
             if (lane_it != m_portLaneCountMap.end())
             {
-                SWSS_LOG_DEBUG("PORT_ATTR: Removing RID 0x%" PRIx64 " from m_portLaneCountMap", it->second->rid);
+                SWSS_LOG_DEBUG("PORT_PHY_ATTR: Removing RID 0x%" PRIx64 " from m_portLaneCountMap", it->second->rid);
                 m_portLaneCountMap.erase(lane_it);
             }
         }
@@ -1944,7 +1944,7 @@ public:
     {
         SWSS_LOG_ENTER();
 
-        // Create dedicated PORT_ATTR table
+        // Create dedicated PORT_PHY_ATTR table
         swss::DBConnector db(m_dbCounters, 0);
         swss::RedisPipeline pipeline(&db);
         swss::Table portAttrTable(&pipeline, PORT_PHY_ATTR_TABLE, true);
@@ -1998,14 +1998,14 @@ public:
                 auto it = m_attrAliases.find(attrIds[i]);
                 if (it == m_attrAliases.end())
                 {
-                    SWSS_LOG_ERROR("Unsupported PORT_ATTR: %d", attrIds[i]);
+                    SWSS_LOG_ERROR("Unsupported PORT_PHY_ATTR: %d", attrIds[i]);
                     continue;
                 }
 
                 values.emplace_back(it->second, attr_value);
             }
 
-            // Store in PORT_ATTR table using VID as key
+            // Store in PORT_PHY_ATTR table using VID as key
             std::string vid_str = sai_serialize_object_id(vid);
             portAttrTable.set(vid_str, values, "");
         }
@@ -2771,7 +2771,7 @@ std::shared_ptr<BaseCounterContext> FlexCounter::createCounterContext(
     {
         return std::make_shared<DashMeterCounterContext>(context_name, instance, m_vendorSai.get(), m_dbCounters);
     }
-    else if (context_name == ATTR_TYPE_PORT_ATTR)
+    else if (context_name == ATTR_TYPE_PORT_PHY_ATTR)
     {
         return std::make_shared<PortAttrContext>(context_name, instance, SAI_OBJECT_TYPE_PORT, m_vendorSai.get(), m_statsMode, m_dbCounters);
     }
@@ -2999,9 +2999,9 @@ void FlexCounter::removeCounter(
         {
             getCounterContext(COUNTER_TYPE_WRED_ECN_PORT)->removeObject(vid);
         }
-        if (hasCounterContext(ATTR_TYPE_PORT_ATTR))
+        if (hasCounterContext(ATTR_TYPE_PORT_PHY_ATTR))
         {
-            getCounterContext(ATTR_TYPE_PORT_ATTR)->removeObject(vid);
+            getCounterContext(ATTR_TYPE_PORT_PHY_ATTR)->removeObject(vid);
         }
     }
     else if (objectType == SAI_OBJECT_TYPE_QUEUE)

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1965,7 +1965,7 @@ public:
         // Create dedicated PORT_PHY_ATTR table
         swss::DBConnector db(m_dbCounters, 0);
         swss::RedisPipeline pipeline(&db);
-        swss::Table portAttrTable(&pipeline, PORT_PHY_ATTR_TABLE, true);
+        swss::Table portPhyAttrTable(&pipeline, PORT_PHY_ATTR_TABLE, true);
 
         for (const auto &kv : Base::m_objectIdsMap)
         {
@@ -2039,10 +2039,10 @@ public:
 
             // Store in PORT_PHY_ATTR table using VID as key
             std::string vid_str = sai_serialize_object_id(vid);
-            portAttrTable.set(vid_str, values, "");
+            portPhyAttrTable.set(vid_str, values, "");
         }
 
-        portAttrTable.flush();
+        portPhyAttrTable.flush();
     }
 
 private:

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1769,6 +1769,8 @@ public:
 
     bool initAttrForLaneCountQuery(sai_attribute_t& attr)
     {
+        SWSS_LOG_ENTER();
+
         switch (attr.id) {
             case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
             case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
@@ -1788,6 +1790,8 @@ public:
 
     uint32_t extractLaneCount(const sai_attribute_t& attr)
     {
+        SWSS_LOG_ENTER();
+
         switch (attr.id) {
             case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
             case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
@@ -1803,6 +1807,8 @@ public:
 
     void updatePortLaneCountMap(const std::shared_ptr<AttrIdsType>& attrIdsPtr)
     {
+        SWSS_LOG_ENTER();
+
         auto counter_ids = attrIdsPtr->counter_ids;
         auto rid = attrIdsPtr->rid;
 
@@ -1841,6 +1847,8 @@ public:
         sai_attribute_t *attr,
         PortPhyAttributeData* data)
     {
+        SWSS_LOG_ENTER();
+
         if (!attr || !data)
         {
             SWSS_LOG_ERROR("PORT_PHY_ATTR: Invalid input params : attr : %p, data : %p", attr, data);
@@ -2013,11 +2021,10 @@ public:
                 std::string attr_value;
 
                 // Latch attributes: Track changes, add timestamp/count per lane
-                if (attrIds[i] == SAI_PORT_ATTR_RX_SIGNAL_DETECT ||
-                    attrIds[i] == SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK)
+                if (meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST)
                 {
                     // Compare current lane values with previous and update metadata
-                    updateLaneMetadata(vid, attrIds[i], attrs[i]);
+                    updateLatchedLaneMetadata(vid, attrIds[i], attrs[i]);
 
                     // Serialize with timestamp and count per lane
                     attr_value = buildLatchStatusWithMetadata(vid, attrIds[i], attrs[i]);
@@ -2049,7 +2056,7 @@ private:
      * @param attr_id Attribute ID (must be latch type)
      * @param attr Current attribute containing lane latch status list
      */
-    void updateLaneMetadata(
+    void updateLatchedLaneMetadata(
         _In_ sai_object_id_t vid,
         _In_ sai_port_attr_t attr_id,
         _In_ const sai_attribute_t& attr)

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -15,6 +15,19 @@ extern "C" {
 #include <memory>
 #include <type_traits>
 
+// Placeholder type for attributes not requiring data allocation
+// Used as default template parameter for simple attributes
+struct NoAttrData {
+    // Empty struct - minimal footprint, compiler optimizes away
+};
+
+// Holds data storage for SAI PORT attribute API calls
+struct PortAttributeData {
+    std::vector<sai_port_lane_latch_status_t> rxSignalDetectData;
+    std::vector<sai_port_lane_latch_status_t> fecAlignmentLockData;
+    std::vector<sai_port_snr_values_t> rxSnrData;
+};
+
 namespace syncd
 {
     class BaseCounterContext

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -22,7 +22,7 @@ struct NoAttrData {
 };
 
 // Holds data storage for SAI PORT attribute API calls
-struct PortAttributeData {
+struct PortPhyAttributeData {
     std::vector<sai_port_lane_latch_status_t> rxSignalDetectData;
     std::vector<sai_port_lane_latch_status_t> fecAlignmentLockData;
     std::vector<sai_port_snr_values_t> rxSnrData;

--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -13,8 +13,6 @@ using namespace syncd;
 
 #define MAX_OBJLIST_LEN 128
 
-#define MAX_LANES_PER_PORT 8
-
 /*
  * NOTE: If real ID will change during hard restarts, then we need to remap all
  * VID/RID, but we can only do that if we will save entire tree with all

--- a/syncd/SaiSwitch.h
+++ b/syncd/SaiSwitch.h
@@ -16,6 +16,8 @@ extern "C" {
 #include <map>
 #include <memory>
 
+#define MAX_LANES_PER_PORT 8
+
 namespace syncd
 {
     class SaiSwitch:

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -488,3 +488,5 @@ VxLAN
 IPFIX
 IPFix
 ipfix
+SNR
+tparam

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -13,6 +13,7 @@ tests_SOURCES = main.cpp \
 				TestCommandLineOptions.cpp \
 				TestConcurrentQueue.cpp \
 				TestFlexCounter.cpp \
+				TestPortAttr.cpp \
 				TestVirtualOidTranslator.cpp \
 				TestNotificationQueue.cpp \
 				TestNotificationProcessor.cpp \

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -13,7 +13,7 @@ tests_SOURCES = main.cpp \
 				TestCommandLineOptions.cpp \
 				TestConcurrentQueue.cpp \
 				TestFlexCounter.cpp \
-				TestPortAttr.cpp \
+				TestPortPhyAttr.cpp \
 				TestVirtualOidTranslator.cpp \
 				TestNotificationQueue.cpp \
 				TestNotificationProcessor.cpp \

--- a/unittest/syncd/TestPortAttr.cpp
+++ b/unittest/syncd/TestPortAttr.cpp
@@ -1,0 +1,265 @@
+/**
+ * @file TestPortAttr.cpp
+ * @brief Unit tests for PORT_ATTR flex counter functionality
+ *
+ * Tests implementation according to UT Plan:
+ * 1. sai_serialize_port_attr() function
+ * 2. sai_deserialize_port_attr() function
+ * 3. collectData() with mocked SAI and counters DB validation
+ */
+
+#include "FlexCounter.h"
+#include "sai_serialize.h"
+#include "MockableSaiInterface.h"
+#include "MockHelper.h"
+#include "swss/table.h"
+#include "swss/schema.h"
+#include "syncd/SaiSwitch.h"
+#include <string>
+#include <gtest/gtest.h>
+#include <memory>
+
+using namespace saimeta;
+using namespace sairedis;
+using namespace syncd;
+using namespace std;
+
+static const std::string ATTR_TYPE_PORT_ATTR = "Port Physical Link Attributes";
+
+template <typename T>
+std::string toOid(T value)
+{
+    SWSS_LOG_ENTER();
+    std::ostringstream ostream;
+    ostream << "oid:0x" << std::hex << value;
+    return ostream.str();
+}
+
+
+class TestPortAttr : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        sai = std::make_shared<MockableSaiInterface>();
+
+        sai->mock_switchIdQuery = [](sai_object_id_t) {
+            return 0x21000000000000;
+        };
+
+        flexCounter = std::make_shared<FlexCounter>("TEST_PORT_ATTR", sai, "COUNTERS_DB");
+
+        // Setup test port OID
+        testPortOid = 0x1000000000001;
+        testPortRid = 0x1000000000001;
+    }
+
+    void TearDown() override
+    {
+        flexCounter.reset();
+        sai.reset();
+    }
+
+    std::shared_ptr<MockableSaiInterface> sai;
+    std::shared_ptr<FlexCounter> flexCounter;
+    sai_object_id_t testPortOid;
+    sai_object_id_t testPortRid;
+};
+
+TEST_F(TestPortAttr, SerializePortAttr)
+{
+    sai_port_attr_t attr = SAI_PORT_ATTR_RX_SIGNAL_DETECT;
+    std::string result = sai_serialize_port_attr(attr);
+    EXPECT_EQ(result, "SAI_PORT_ATTR_RX_SIGNAL_DETECT");
+
+    attr = SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK;
+    result = sai_serialize_port_attr(attr);
+    EXPECT_EQ(result, "SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK");
+
+    attr = SAI_PORT_ATTR_RX_SNR;
+    result = sai_serialize_port_attr(attr);
+    EXPECT_EQ(result, "SAI_PORT_ATTR_RX_SNR");
+}
+
+TEST_F(TestPortAttr, DeserializePortAttr)
+{
+    sai_port_attr_t attr_out;
+
+    std::string input = "SAI_PORT_ATTR_RX_SIGNAL_DETECT";
+    sai_deserialize_port_attr(input, attr_out);
+    EXPECT_EQ(attr_out, SAI_PORT_ATTR_RX_SIGNAL_DETECT);
+
+    input = "SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK";
+    sai_deserialize_port_attr(input, attr_out);
+    EXPECT_EQ(attr_out, SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK);
+
+    input = "SAI_PORT_ATTR_RX_SNR";
+    sai_deserialize_port_attr(input, attr_out);
+    EXPECT_EQ(attr_out, SAI_PORT_ATTR_RX_SNR);
+}
+
+/**
+ * Test collectData() with mocked SAI and COUNTERS_DB validation
+ * This test verifies the complete data collection workflow:
+ * 1. Mock SAI interface returns realistic PORT attribute data
+ * 2. FlexCounter collects the data via collectData()
+ * 3. Verify collected data is properly written to COUNTERS_DB
+ *
+ * This test validates the complete PORT_ATTR collection workflow
+ * including RX_SIGNAL_DETECT, FEC_ALIGNMENT_LOCK, and RX_SNR attributes.
+ */
+TEST_F(TestPortAttr, CollectDataAndValidateCountersDB)
+{
+    // Setup mock for PORT attributes with realistic data
+    sai->mock_get = [](sai_object_type_t object_type,
+                      sai_object_id_t object_id,
+                      uint32_t attr_count,
+                      sai_attribute_t *attr_list) -> sai_status_t
+    {
+        if (object_type != SAI_OBJECT_TYPE_PORT) {
+            return SAI_STATUS_INVALID_PARAMETER;
+        }
+
+        for (uint32_t i = 0; i < attr_count; i++) {
+            switch (attr_list[i].id) {
+                case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
+                    if (attr_list[i].value.portlanelatchstatuslist.list == nullptr) {
+                        // First call: return count needed
+                        attr_list[i].value.portlanelatchstatuslist.count = MAX_LANES_PER_PORT;
+                        return SAI_STATUS_BUFFER_OVERFLOW;
+                    } else {
+                        // Second call: fill actual data
+                        uint32_t count = attr_list[i].value.portlanelatchstatuslist.count;
+                        for (uint32_t lane = 0; lane < count && lane < MAX_LANES_PER_PORT; lane++) {
+                            attr_list[i].value.portlanelatchstatuslist.list[lane].lane = lane;
+                            attr_list[i].value.portlanelatchstatuslist.list[lane].value.changed = true;
+                            attr_list[i].value.portlanelatchstatuslist.list[lane].value.current_status = (lane % 2 == 0);
+                        }
+                        attr_list[i].value.portlanelatchstatuslist.count = std::min(count, static_cast<uint32_t>(MAX_LANES_PER_PORT));
+                    }
+                    break;
+                case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
+                    if (attr_list[i].value.portlanelatchstatuslist.list == nullptr) {
+                        // First call: return count needed
+                        attr_list[i].value.portlanelatchstatuslist.count = MAX_LANES_PER_PORT;
+                        return SAI_STATUS_BUFFER_OVERFLOW;
+                    } else {
+                        // Second call: fill actual data
+                        uint32_t count = attr_list[i].value.portlanelatchstatuslist.count;
+                        for (uint32_t lane = 0; lane < count && lane < MAX_LANES_PER_PORT; lane++) {
+                            attr_list[i].value.portlanelatchstatuslist.list[lane].lane = lane;
+                            attr_list[i].value.portlanelatchstatuslist.list[lane].value.changed = (lane % 2 == 0);
+                            attr_list[i].value.portlanelatchstatuslist.list[lane].value.current_status = false;
+                        }
+                        attr_list[i].value.portlanelatchstatuslist.count = std::min(count, static_cast<uint32_t>(MAX_LANES_PER_PORT));
+                    }
+                    break;
+                case SAI_PORT_ATTR_RX_SNR:
+                    if (attr_list[i].value.portsnrlist.list == nullptr) {
+                        // First call: return count needed
+                        attr_list[i].value.portsnrlist.count = MAX_LANES_PER_PORT;
+                        return SAI_STATUS_BUFFER_OVERFLOW;
+                    } else {
+                        // Second call: fill actual data
+                        uint32_t count = attr_list[i].value.portsnrlist.count;
+                        for (uint32_t lane = 0; lane < count && lane < MAX_LANES_PER_PORT; lane++) {
+                            attr_list[i].value.portsnrlist.list[lane].lane = lane;
+                            attr_list[i].value.portsnrlist.list[lane].snr = static_cast<sai_uint16_t>(145 + (lane * 5));
+                        }
+                        attr_list[i].value.portsnrlist.count = std::min(count, static_cast<uint32_t>(MAX_LANES_PER_PORT));
+                    }
+                    break;
+                default:
+                    return SAI_STATUS_NOT_SUPPORTED;
+            }
+        }
+        return SAI_STATUS_SUCCESS;
+    };
+
+    vector<swss::FieldValueTuple> portAttrValues;
+
+    std::string attrIds = "SAI_PORT_ATTR_RX_SIGNAL_DETECT,SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK,SAI_PORT_ATTR_RX_SNR";
+
+    portAttrValues.emplace_back(PORT_ATTR_ID_LIST, attrIds);
+
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT);
+
+    flexCounter->addCounter(testPortOid, testPortRid, portAttrValues);
+
+    vector<swss::FieldValueTuple> pluginValues;
+    pluginValues.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    pluginValues.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    pluginValues.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    flexCounter->addCounterPlugin(pluginValues);
+
+    usleep(1000 * 1050); // 1.05 seconds to ensure at least one poll cycle
+
+    // Connect to COUNTERS_DB and verify entries in PORT_PHY_ATTR_TABLE
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::RedisPipeline pipeline(&db);
+    swss::Table countersTable(&pipeline, PORT_PHY_ATTR_TABLE, false);
+
+    std::string expectedKey = toOid(testPortOid);
+
+    // Validate actual values against mocked data
+    std::string rxSignalDetectValue;
+    bool found = countersTable.hget(expectedKey, "phy_rx_signal_detect", rxSignalDetectValue);
+    EXPECT_TRUE(found) << "phy_rx_signal_detect not found in COUNTERS_DB";
+
+    std::cout << "Actual phy_rx_signal_detect value: " << rxSignalDetectValue << std::endl;
+
+    // T/F = current_status (true/false), * = changed indicator
+    for (uint32_t lane = 0; lane < MAX_LANES_PER_PORT; lane++) {
+        // Mock data: changed=true for all lanes, current_status=true for even lanes
+        std::string expected_value = (lane % 2 == 0) ? "T*" : "F*";
+        std::ostringstream expected_entry;
+        expected_entry << "\"" << lane << "\":\"" << expected_value << "\"";
+
+        EXPECT_TRUE(rxSignalDetectValue.find(expected_entry.str()) != std::string::npos)
+            << "Lane " << lane << " should have value=" << expected_value
+            << " (changed=true, current_status=" << ((lane % 2 == 0) ? "true" : "false") << ")"
+            << "\nActual full value: " << rxSignalDetectValue
+            << "\nLooking for: " << expected_entry.str();
+    }
+
+    std::string fecAlignmentValue;
+    found = countersTable.hget(expectedKey, "pcs_fec_lane_alignment_lock", fecAlignmentValue);
+    EXPECT_TRUE(found) << "pcs_fec_lane_alignment_lock not found in COUNTERS_DB";
+
+    std::cout << "Actual pcs_fec_lane_alignment_lock value: " << fecAlignmentValue << std::endl;
+
+    // Mock data: changed=true for even lanes, changed=false for odd lanes, current_status=false for all
+    for (uint32_t lane = 0; lane < MAX_LANES_PER_PORT; lane++) {
+        std::string expected_value = (lane % 2 == 0) ? "F*" : "F";
+        std::ostringstream expected_entry;
+        expected_entry << "\"" << lane << "\":\"" << expected_value << "\"";
+
+        EXPECT_TRUE(fecAlignmentValue.find(expected_entry.str()) != std::string::npos)
+            << "FEC Lane " << lane << " should have value=" << expected_value
+            << " (changed=" << ((lane % 2 == 0) ? "true" : "false") << ", current_status=false)"
+            << "\nActual full value: " << fecAlignmentValue
+            << "\nLooking for: " << expected_entry.str();
+    }
+
+    std::string rxSnrValue;
+    found = countersTable.hget(expectedKey, "rx_snr", rxSnrValue);
+    EXPECT_TRUE(found) << "rx_snr not found in COUNTERS_DB";
+
+    std::cout << "Actual rx_snr value: " << rxSnrValue << std::endl;
+
+    // Lane key is string, SNR value is number (no quotes around value)
+    // Validate all lanes (0-7) with SNR values: 145, 150, 155, 160, 165, 170, 175, 180
+    for (uint32_t lane = 0; lane < MAX_LANES_PER_PORT; lane++) {
+        uint32_t expected_snr = 145 + (lane * 5);
+        std::ostringstream expected_entry;
+        expected_entry << "\"" << lane << "\":" << expected_snr;
+
+        EXPECT_TRUE(rxSnrValue.find(expected_entry.str()) != std::string::npos)
+            << "Lane " << lane << " SNR should be " << expected_snr
+            << " in format \"" << lane << "\":" << expected_snr
+            << "\nActual full value: " << rxSnrValue
+            << "\nLooking for: " << expected_entry.str();
+    }
+
+    flexCounter->removeCounter(testPortOid);
+}

--- a/unittest/syncd/TestPortAttr.cpp
+++ b/unittest/syncd/TestPortAttr.cpp
@@ -1,6 +1,6 @@
 /**
  * @file TestPortAttr.cpp
- * @brief Unit tests for PORT_ATTR flex counter functionality
+ * @brief Unit tests for PORT_PHY_ATTR flex counter functionality
  *
  * Tests implementation according to UT Plan:
  * 1. sai_serialize_port_attr() function
@@ -24,7 +24,7 @@ using namespace sairedis;
 using namespace syncd;
 using namespace std;
 
-static const std::string ATTR_TYPE_PORT_ATTR = "Port Physical Link Attributes";
+static const std::string ATTR_TYPE_PORT_PHY_ATTR = "Port Physical Link Attributes";
 
 template <typename T>
 std::string toOid(T value)
@@ -47,7 +47,7 @@ protected:
             return 0x21000000000000;
         };
 
-        flexCounter = std::make_shared<FlexCounter>("TEST_PORT_ATTR", sai, "COUNTERS_DB");
+        flexCounter = std::make_shared<FlexCounter>("TEST_PORT_PHY_ATTR", sai, "COUNTERS_DB");
 
         // Setup test port OID
         testPortOid = 0x1000000000001;
@@ -105,7 +105,7 @@ TEST_F(TestPortAttr, DeserializePortAttr)
  * 2. FlexCounter collects the data via collectData()
  * 3. Verify collected data is properly written to COUNTERS_DB
  *
- * This test validates the complete PORT_ATTR collection workflow
+ * This test validates the complete PORT_PHY_ATTR collection workflow
  * including RX_SIGNAL_DETECT, FEC_ALIGNMENT_LOCK, and RX_SNR attributes.
  */
 TEST_F(TestPortAttr, CollectDataAndValidateCountersDB)
@@ -180,7 +180,7 @@ TEST_F(TestPortAttr, CollectDataAndValidateCountersDB)
 
     std::string attrIds = "SAI_PORT_ATTR_RX_SIGNAL_DETECT,SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK,SAI_PORT_ATTR_RX_SNR";
 
-    portAttrValues.emplace_back(PORT_ATTR_ID_LIST, attrIds);
+    portAttrValues.emplace_back(PORT_PHY_ATTR_ID_LIST, attrIds);
 
     test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT);
 

--- a/unittest/syncd/TestPortAttr.cpp
+++ b/unittest/syncd/TestPortAttr.cpp
@@ -211,12 +211,12 @@ TEST_F(TestPortAttr, CollectDataAndValidateCountersDB)
     // T/F = current_status (true/false), * = changed indicator
     for (uint32_t lane = 0; lane < MAX_LANES_PER_PORT; lane++) {
         // Mock data: changed=true for all lanes, current_status=true for even lanes
-        std::string expected_value = (lane % 2 == 0) ? "T*" : "F*";
+        std::string expected_status = (lane % 2 == 0) ? "T*" : "F*";
         std::ostringstream expected_entry;
-        expected_entry << "\"" << lane << "\":\"" << expected_value << "\"";
+        expected_entry << "\"" << lane << "\":[\"" << expected_status << "\"";
 
         EXPECT_TRUE(rxSignalDetectValue.find(expected_entry.str()) != std::string::npos)
-            << "Lane " << lane << " should have value=" << expected_value
+            << "Lane " << lane << " should have status=" << expected_status
             << " (changed=true, current_status=" << ((lane % 2 == 0) ? "true" : "false") << ")"
             << "\nActual full value: " << rxSignalDetectValue
             << "\nLooking for: " << expected_entry.str();
@@ -230,12 +230,12 @@ TEST_F(TestPortAttr, CollectDataAndValidateCountersDB)
 
     // Mock data: changed=true for even lanes, changed=false for odd lanes, current_status=false for all
     for (uint32_t lane = 0; lane < MAX_LANES_PER_PORT; lane++) {
-        std::string expected_value = (lane % 2 == 0) ? "F*" : "F";
+        std::string expected_status = (lane % 2 == 0) ? "F*" : "F";
         std::ostringstream expected_entry;
-        expected_entry << "\"" << lane << "\":\"" << expected_value << "\"";
+        expected_entry << "\"" << lane << "\":[\"" << expected_status << "\"";
 
         EXPECT_TRUE(fecAlignmentValue.find(expected_entry.str()) != std::string::npos)
-            << "FEC Lane " << lane << " should have value=" << expected_value
+            << "FEC Lane " << lane << " should have status=" << expected_status
             << " (changed=" << ((lane % 2 == 0) ? "true" : "false") << ", current_status=false)"
             << "\nActual full value: " << fecAlignmentValue
             << "\nLooking for: " << expected_entry.str();

--- a/unittest/syncd/TestPortPhyAttr.cpp
+++ b/unittest/syncd/TestPortPhyAttr.cpp
@@ -1,5 +1,5 @@
 /**
- * @file TestPortAttr.cpp
+ * @file TestPortPhyAttr.cpp
  * @brief Unit tests for PORT_PHY_ATTR flex counter functionality
  *
  * Tests implementation according to UT Plan:
@@ -36,7 +36,7 @@ std::string toOid(T value)
 }
 
 
-class TestPortAttr : public ::testing::Test
+class TestPortPhyAttr : public ::testing::Test
 {
 protected:
     void SetUp() override
@@ -66,7 +66,7 @@ protected:
     sai_object_id_t testPortRid;
 };
 
-TEST_F(TestPortAttr, SerializePortAttr)
+TEST_F(TestPortPhyAttr, SerializePortAttr)
 {
     sai_port_attr_t attr = SAI_PORT_ATTR_RX_SIGNAL_DETECT;
     std::string result = sai_serialize_port_attr(attr);
@@ -81,7 +81,7 @@ TEST_F(TestPortAttr, SerializePortAttr)
     EXPECT_EQ(result, "SAI_PORT_ATTR_RX_SNR");
 }
 
-TEST_F(TestPortAttr, DeserializePortAttr)
+TEST_F(TestPortPhyAttr, DeserializePortAttr)
 {
     sai_port_attr_t attr_out;
 
@@ -108,7 +108,7 @@ TEST_F(TestPortAttr, DeserializePortAttr)
  * This test validates the complete PORT_PHY_ATTR collection workflow
  * including RX_SIGNAL_DETECT, FEC_ALIGNMENT_LOCK, and RX_SNR attributes.
  */
-TEST_F(TestPortAttr, CollectDataAndValidateCountersDB)
+TEST_F(TestPortPhyAttr, CollectDataAndValidateCountersDB)
 {
     // Setup mock for PORT attributes with realistic data
     sai->mock_get = [](sai_object_type_t object_type,
@@ -176,15 +176,15 @@ TEST_F(TestPortAttr, CollectDataAndValidateCountersDB)
         return SAI_STATUS_SUCCESS;
     };
 
-    vector<swss::FieldValueTuple> portAttrValues;
+    vector<swss::FieldValueTuple> portPhyAttrValues;
 
     std::string attrIds = "SAI_PORT_ATTR_RX_SIGNAL_DETECT,SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK,SAI_PORT_ATTR_RX_SNR";
 
-    portAttrValues.emplace_back(PORT_PHY_ATTR_ID_LIST, attrIds);
+    portPhyAttrValues.emplace_back(PORT_PHY_ATTR_ID_LIST, attrIds);
 
     test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT);
 
-    flexCounter->addCounter(testPortOid, testPortRid, portAttrValues);
+    flexCounter->addCounter(testPortOid, testPortRid, portPhyAttrValues);
 
     vector<swss::FieldValueTuple> pluginValues;
     pluginValues.emplace_back(POLL_INTERVAL_FIELD, "1000");


### PR DESCRIPTION
Implement PORT_PHY_ATTR flex counter support for monitoring the port attributes (RX_SIGNAL_DETECT, FEC_ALIGNMENT_LOCK, RX_SNR).

### Changes
**meta/:** Add serialization support for PORT_SNR_LIST and PORT_LANE_LATCH_STATUS_LIST
**syncd/:** Introduce PortAttrContext extending AttrContext with specialized data handling for lane-based attribute types
**unittest/:** Add unit tests for serialization and collectData APIs.

### Implementation
Queries SAI for per-port lane count using BUFFER_OVERFLOW pattern
Maintains lane count cache for efficient memory allocation
Writes collected data to dedicated PORT_PHY_ATTR table in COUNTERS_DB