### PR TITLE
Reduce severity of log for unallowed enum value

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -938,7 +938,7 @@ sai_status_t Meta::queryAttributeEnumValuesCapability(
 
                 if (!sai_metadata_is_allowed_enum_value(mdp, val))
                 {
-                    SWSS_LOG_ERROR("returned value %d is not allowed on %s", val, mdp->attridname);
+                    SWSS_LOG_WARN("returned value %d is not allowed on %s", val, mdp->attridname);
                 }
             }
         }


### PR DESCRIPTION
Reduces the warning for !sai_metadata_is_allowed_enum_value from ERR to WARN to support SAI custom header extensions.

Addresses https://github.com/sonic-net/sonic-buildimage/issues/23467