### PR TITLE
Fix issues to support custom SAI header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,12 +228,12 @@ AC_ARG_WITH(extra-libsai-ldflags,
                           extra libsai.so flags for vendor library],
 [AC_SUBST(EXTRA_LIBSAI_LDFLAGS, "${withval}")])
 
-AC_SUBST(SAIINC, "-I\$(top_srcdir)/SAI/inc -I\$(top_srcdir)/SAI/experimental -I\$(top_srcdir)/SAI/meta")
+AC_SUBST(SAIINC, "-I\$(top_srcdir)/SAI/inc -I\$(top_srcdir)/SAI/experimental -I\$(top_srcdir)/SAI/meta -I\$(top_srcdir)/SAI/custom")
 
 AM_COND_IF([SYNCD], [
 AM_COND_IF([SAIVS], [], [
 SAVED_FLAGS="$CXXFLAGS"
-CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta $EXTRA_LIBSAI_LDFLAGS"
+CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta -I$srcdir/SAI/custom $EXTRA_LIBSAI_LDFLAGS"
 AC_CHECK_FUNCS(sai_query_api_version, [
 AC_MSG_CHECKING([SAI headers API version and library version check])
 AC_TRY_RUN([
@@ -283,7 +283,7 @@ AM_COND_IF([SAIVS],
 [
     AM_COND_IF([SYNCD], [
     SAVED_FLAGS="$CXXFLAGS"
-    CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
+    CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta -I$srcdir/SAI/custom"
     AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_query_stats_st_capability sai_tam_telemetry_get_data)
     CXXFLAGS="$SAVED_FLAGS"
     ])

--- a/debian/libsaivs-dev.install
+++ b/debian/libsaivs-dev.install
@@ -1,3 +1,4 @@
 SAI/inc/sai*.h usr/include/sai/
 SAI/experimental/sai*.h usr/include/sai/
+SAI/custom/sai*.h usr/include/sai/
 vslib/saivs.h

--- a/debian/rules
+++ b/debian/rules
@@ -58,6 +58,10 @@ override_dh_auto_configure:
 	dh_auto_configure -- ${SWSS_COMMON_CONFIG} $(configure_opts) $(DEB_CONFIGURE_EXTRA_FLAGS)
 
 override_dh_install:
+	# Conditionally comment out SAI/custom/*.h if no files exist
+	if ! ls SAI/custom/sai*.h 1> /dev/null 2>&1; then \
+		sed -i.bak 's|^\(SAI/custom/sai\*\.h.*\)|#\1|' debian/libsaivs-dev.install; \
+	fi
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	dh_install -N syncd-rpc
 	# This is to build a RPC-enabled version, and package that version into syncd-rpc
@@ -72,6 +76,10 @@ endif
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 endif
+	# Restore original .install file if backup exists
+	if [ -f debian/libsaivs-dev.install.bak ]; then \
+		mv debian/libsaivs-dev.install.bak debian/libsaivs-dev.install; \
+	fi
 
 override_dh_installinit:
 	dh_installinit --init-script=syncd

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -223,9 +223,9 @@ sai_status_t transfer_attribute(
             RETURN_ON_ERROR(transfer_list(src_attr.value.s8list, dst_attr.value.s8list, countOnly));
             break;
 
-//        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
-//            RETURN_ON_ERROR(transfer_list(src_attr.value.u16list, dst_attr.value.u16list, countOnly));
-//            break;
+        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
+            RETURN_ON_ERROR(transfer_list(src_attr.value.u16list, dst_attr.value.u16list, countOnly));
+            break;
 //
 //        case SAI_ATTR_VALUE_TYPE_INT16_LIST:
 //            RETURN_ON_ERROR(transfer_list(src_attr.value.s16list, dst_attr.value.s16list, countOnly));
@@ -2172,8 +2172,8 @@ std::string sai_serialize_attr_value(
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             return sai_serialize_port_lane_latch_status_list(attr.value.portlanelatchstatuslist, countOnly);
 
-//        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
-//            return sai_serialize_number_list(attr.value.u16list, countOnly);
+        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
+            return sai_serialize_number_list(attr.value.u16list, countOnly);
 //
 //        case SAI_ATTR_VALUE_TYPE_INT16_LIST:
 //            return sai_serialize_number_list(attr.value.s16list, countOnly);
@@ -4460,8 +4460,8 @@ void sai_deserialize_attr_value(
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             return sai_deserialize_port_lane_latch_status_list(s, attr.value.portlanelatchstatuslist, countOnly);
 
-//        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
-//            return sai_deserialize_number_list(s, attr.value.u16list, countOnly);
+        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
+            return sai_deserialize_number_list(s, attr.value.u16list, countOnly);
 //
 //        case SAI_ATTR_VALUE_TYPE_INT16_LIST:
 //            return sai_deserialize_number_list(s, attr.value.s16list, countOnly);
@@ -5792,9 +5792,9 @@ void sai_deserialize_free_attribute_value(
             sai_free_list(attr.value.s8list);
             break;
 
-//        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
-//            sai_free_list(attr.value.u16list);
-//            break;
+        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
+            sai_free_list(attr.value.u16list);
+            break;
 //
 //        case SAI_ATTR_VALUE_TYPE_INT16_LIST:
 //            sai_free_list(attr.value.s16list);

--- a/stub.pl
+++ b/stub.pl
@@ -99,7 +99,7 @@ sub GetFunctionCamelCaseName
 
 sub GetData
 {
-    $DATA = `cat $optionSaiDir/inc/sai*.h $optionSaiDir/experimental/sai*.h`;
+    $DATA = `cat $optionSaiDir/inc/sai*.h $optionSaiDir/experimental/sai*.h $optionSaiDir/custom/sai*.h`;
 }
 
 sub SanitizeData


### PR DESCRIPTION
**Why I did this**

SAI starts to support customer SAI header a few months ago. During integration with custom SAI header, I found some issues. This PR is to fix them. The PR also add a custom flag to VID and RID.

**How I did this**

1. sonic-sairedis should compile with custom headers
2. sonic vs sai should install custom headers to /usr/bin/sai
3. add a custom flag in VID and RID