### PR TITLE
Add secondary poll factor to flex counter infra

### DIFF
--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -692,6 +692,7 @@ sai_status_t RedisRemoteSaiInterface::notifyCounterGroupOperations(
     std::string key((const char*)flexCounterGroupParam->counter_group_name.list, flexCounterGroupParam->counter_group_name.count);
 
     emplaceStrings(POLL_INTERVAL_FIELD, flexCounterGroupParam->poll_interval, entries);
+    emplaceStrings(SECONDARY_POLL_FACTOR_FIELD, flexCounterGroupParam->secondary_poll_factor, entries);
     emplaceStrings(BULK_CHUNK_SIZE_FIELD, flexCounterGroupParam->bulk_chunk_size, entries);
     emplaceStrings(BULK_CHUNK_SIZE_PER_PREFIX_FIELD, flexCounterGroupParam->bulk_chunk_size_per_prefix, entries);
     emplaceStrings(STATS_MODE_FIELD, flexCounterGroupParam->stats_mode, entries);

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -607,6 +607,7 @@ sai_status_t RedisRemoteSaiInterface::notifyCounterGroupOperations(
     std::string key((const char*)flexCounterGroupParam->counter_group_name.list, flexCounterGroupParam->counter_group_name.count);
 
     emplaceStrings(POLL_INTERVAL_FIELD, flexCounterGroupParam->poll_interval, entries);
+    emplaceStrings(SECONDARY_POLL_FACTOR_FIELD, flexCounterGroupParam->secondary_poll_factor, entries);
     emplaceStrings(BULK_CHUNK_SIZE_FIELD, flexCounterGroupParam->bulk_chunk_size, entries);
     emplaceStrings(BULK_CHUNK_SIZE_PER_PREFIX_FIELD, flexCounterGroupParam->bulk_chunk_size_per_prefix, entries);
     emplaceStrings(STATS_MODE_FIELD, flexCounterGroupParam->stats_mode, entries);

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -531,6 +531,10 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
             return notifyCounterOperations(objectId,
                                            reinterpret_cast<sai_redis_flex_counter_parameter_t*>(attr->value.ptr));
 
+        case SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP_SECONDARY_POLL_FACTOR:
+            return notifyCounterGroupSecondaryPollFactor(objectId,
+                                                         reinterpret_cast<sai_redis_flex_counter_group_secondary_poll_factor_parameter_t*>(attr->value.ptr));
+
         default:
             break;
     }
@@ -692,7 +696,6 @@ sai_status_t RedisRemoteSaiInterface::notifyCounterGroupOperations(
     std::string key((const char*)flexCounterGroupParam->counter_group_name.list, flexCounterGroupParam->counter_group_name.count);
 
     emplaceStrings(POLL_INTERVAL_FIELD, flexCounterGroupParam->poll_interval, entries);
-    emplaceStrings(SECONDARY_POLL_FACTOR_FIELD, flexCounterGroupParam->secondary_poll_factor, entries);
     emplaceStrings(BULK_CHUNK_SIZE_FIELD, flexCounterGroupParam->bulk_chunk_size, entries);
     emplaceStrings(BULK_CHUNK_SIZE_PER_PREFIX_FIELD, flexCounterGroupParam->bulk_chunk_size_per_prefix, entries);
     emplaceStrings(STATS_MODE_FIELD, flexCounterGroupParam->stats_mode, entries);
@@ -736,6 +739,41 @@ sai_status_t RedisRemoteSaiInterface::notifyCounterOperations(
 
     m_recorder->recordGenericCounterPolling(key, entries);
     m_communicationChannel->set(key, entries, command);
+
+    return waitForResponse(SAI_COMMON_API_SET);
+}
+
+sai_status_t RedisRemoteSaiInterface::notifyCounterGroupSecondaryPollFactor(
+        _In_ sai_object_id_t objectId,
+        _In_ const sai_redis_flex_counter_group_secondary_poll_factor_parameter_t *param)
+{
+    SWSS_LOG_ENTER();
+
+    if (param == nullptr ||
+        !isSaiS8ListValidString(param->counter_group_name) ||
+        !isSaiS8ListValidString(param->secondary_poll_factor))
+    {
+        SWSS_LOG_ERROR("Invalid secondary poll factor parameters");
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    std::string key(
+        reinterpret_cast<const char *>(param->counter_group_name.list),
+        param->counter_group_name.count);
+
+    std::vector<swss::FieldValueTuple> entries;
+
+    emplaceStrings(
+        SECONDARY_POLL_FACTOR_FIELD,
+        param->secondary_poll_factor,
+        entries);
+
+    m_recorder->recordGenericCounterPolling(key, entries);
+
+    m_communicationChannel->set(
+        key,
+        entries,
+        REDIS_FLEX_COUNTER_COMMAND_SET_GROUP);
 
     return waitForResponse(SAI_COMMON_API_SET);
 }

--- a/lib/RedisRemoteSaiInterface.h
+++ b/lib/RedisRemoteSaiInterface.h
@@ -436,6 +436,10 @@ namespace sairedis
                     _In_ sai_object_id_t objectId,
                     _In_ const sai_redis_flex_counter_parameter_t *flexCounterParam);
 
+            sai_status_t notifyCounterGroupSecondaryPollFactor(
+                    _In_ sai_object_id_t objectId,
+                    _In_ const sai_redis_flex_counter_group_secondary_poll_factor_parameter_t *param);
+
         private:
 
             sai_status_t sai_redis_notify_syncd(

--- a/lib/sairedis.h
+++ b/lib/sairedis.h
@@ -117,6 +117,13 @@ typedef struct _sai_redis_flex_counter_group_parameter_t
     sai_s8_list_t poll_interval;
 
     /**
+     * @brief The secondary poll factor for counter group
+     *
+     * It should be a multiplicative factor of the poll_interval.
+     */
+    sai_s8_list_t secondary_poll_factor;
+
+    /**
      * @brief The operation of the counter group
      *
      * It should be either "enable" or "disable"

--- a/lib/sairedis.h
+++ b/lib/sairedis.h
@@ -117,13 +117,6 @@ typedef struct _sai_redis_flex_counter_group_parameter_t
     sai_s8_list_t poll_interval;
 
     /**
-     * @brief The secondary poll factor for counter group
-     *
-     * It should be a multiplicative factor of the poll_interval.
-     */
-    sai_s8_list_t secondary_poll_factor;
-
-    /**
      * @brief The operation of the counter group
      *
      * It should be either "enable" or "disable"
@@ -162,6 +155,12 @@ typedef struct _sai_redis_flex_counter_group_parameter_t
     sai_s8_list_t bulk_chunk_size_per_prefix;
 
 } sai_redis_flex_counter_group_parameter_t;
+
+typedef struct _sai_redis_flex_counter_group_secondary_poll_factor_parameter_t
+{
+    sai_s8_list_t counter_group_name;
+    sai_s8_list_t secondary_poll_factor;
+} sai_redis_flex_counter_group_secondary_poll_factor_parameter_t;
 
 typedef struct _sai_redis_flex_counter_parameter_t
 {
@@ -370,6 +369,15 @@ typedef enum _sai_redis_switch_attr_t
      * @default 0
      */
     SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER,
+
+    /**
+    * @brief Set secondary poll factor for a flex counter group
+    *
+    * @type sai_redis_flex_counter_group_secondary_poll_factor_parameter_t
+    * @flags CREATE_AND_SET
+    * @default 0
+    */
+    SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP_SECONDARY_POLL_FACTOR,
 
 } sai_redis_switch_attr_t;
 

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -3035,6 +3035,7 @@ FlexCounter::FlexCounter(
         _In_ const bool noDoubleCheckBulkCapability):
     m_readyToPoll(false),
     m_pollInterval(0),
+    m_secondaryPollFactor(0),
     m_instanceId(instanceId),
     m_vendorSai(vendorSai),
     m_dbCounters(dbCounters),
@@ -3068,6 +3069,20 @@ void FlexCounter::setPollInterval(
         m_cvSleep.notify_all();
 
         SWSS_LOG_INFO("Set POLL INTERVAL %d for FC %s", pollInterval, m_instanceId.c_str());
+    }
+}
+
+void FlexCounter::setSecondaryPollFactor(
+        _In_ uint32_t secondaryPollFactor)
+{
+    SWSS_LOG_ENTER();
+
+    if (m_secondaryPollFactor != secondaryPollFactor)
+    {
+        m_secondaryPollFactor = secondaryPollFactor;
+        m_cvSleep.notify_all();
+
+        SWSS_LOG_INFO("SET SECONDARY POLL INTERVAL %d for FC %s", secondaryPollFactor, m_instanceId.c_str());
     }
 }
 
@@ -3167,6 +3182,10 @@ void FlexCounter::addCounterPlugin(
         if (field == POLL_INTERVAL_FIELD)
         {
             setPollInterval(stoi(value));
+        }
+        else if (field == SECONDARY_POLL_FACTOR_FIELD)
+        {
+            setSecondaryPollFactor(stoi(value));
         }
         else if (field == BULK_CHUNK_SIZE_FIELD)
         {
@@ -3510,12 +3529,17 @@ void FlexCounter::runPlugins(
 {
     SWSS_LOG_ENTER();
 
-    const std::vector<std::string> argv =
+    std::vector<std::string> argv =
     {
         std::to_string(counters_db.getDbId()),
         COUNTERS_TABLE,
         std::to_string(m_pollInterval)
     };
+
+    if (m_secondaryPollFactor > 0)
+    {
+        argv.push_back(std::to_string(m_secondaryPollFactor));
+    }
 
     for (const auto &it : m_counterContext)
     {

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -3719,7 +3719,7 @@ void FlexCounter::setSecondaryPollFactor(
         m_secondaryPollFactor = secondaryPollFactor;
         m_cvSleep.notify_all();
 
-        SWSS_LOG_INFO("SET SECONDARY POLL INTERVAL %d for FC %s", secondaryPollFactor, m_instanceId.c_str());
+        SWSS_LOG_INFO("Set SECONDARY POLL FACTOR %u for FC %s", secondaryPollFactor, m_instanceId.c_str());
     }
 }
 

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -3672,6 +3672,7 @@ FlexCounter::FlexCounter(
         _In_ const bool noDoubleCheckBulkCapability):
     m_readyToPoll(false),
     m_pollInterval(0),
+    m_secondaryPollFactor(0),
     m_instanceId(instanceId),
     m_vendorSai(vendorSai),
     m_dbCounters(dbCounters),
@@ -3705,6 +3706,20 @@ void FlexCounter::setPollInterval(
         m_cvSleep.notify_all();
 
         SWSS_LOG_INFO("Set POLL INTERVAL %d for FC %s", pollInterval, m_instanceId.c_str());
+    }
+}
+
+void FlexCounter::setSecondaryPollFactor(
+        _In_ uint32_t secondaryPollFactor)
+{
+    SWSS_LOG_ENTER();
+
+    if (m_secondaryPollFactor != secondaryPollFactor)
+    {
+        m_secondaryPollFactor = secondaryPollFactor;
+        m_cvSleep.notify_all();
+
+        SWSS_LOG_INFO("SET SECONDARY POLL INTERVAL %d for FC %s", secondaryPollFactor, m_instanceId.c_str());
     }
 }
 
@@ -3804,6 +3819,10 @@ void FlexCounter::addCounterPlugin(
         if (field == POLL_INTERVAL_FIELD)
         {
             setPollInterval(stoi(value));
+        }
+        else if (field == SECONDARY_POLL_FACTOR_FIELD)
+        {
+            setSecondaryPollFactor(stoi(value));
         }
         else if (field == BULK_CHUNK_SIZE_FIELD)
         {
@@ -4147,12 +4166,17 @@ void FlexCounter::runPlugins(
 {
     SWSS_LOG_ENTER();
 
-    const std::vector<std::string> argv =
+    std::vector<std::string> argv =
     {
         std::to_string(counters_db.getDbId()),
         COUNTERS_TABLE,
         std::to_string(m_pollInterval)
     };
+
+    if (m_secondaryPollFactor > 0)
+    {
+        argv.push_back(std::to_string(m_secondaryPollFactor));
+    }
 
     for (const auto &it : m_counterContext)
     {

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -142,6 +142,9 @@ namespace syncd
             void setPollInterval(
                     _In_ uint32_t pollInterval);
 
+            void setSecondaryPollFactor(
+                    _In_ uint32_t secondaryPollInterval);
+
             void setStatus(
                     _In_ const std::string& status);
 
@@ -205,6 +208,8 @@ namespace syncd
             bool m_readyToPoll;
 
             uint32_t m_pollInterval;
+
+            uint32_t m_secondaryPollFactor;
 
             std::string m_instanceId;
 

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -155,6 +155,9 @@ namespace syncd
             void setPollInterval(
                     _In_ uint32_t pollInterval);
 
+            void setSecondaryPollFactor(
+                    _In_ uint32_t secondaryPollFactor);
+
             void setStatus(
                     _In_ const std::string& status);
 
@@ -218,6 +221,8 @@ namespace syncd
             bool m_readyToPoll;
 
             uint32_t m_pollInterval;
+
+            uint32_t m_secondaryPollFactor;
 
             std::string m_instanceId;
 

--- a/syncd/tests/TestSyncdMlnx.cpp
+++ b/syncd/tests/TestSyncdMlnx.cpp
@@ -273,7 +273,7 @@ TEST_F(SyncdMlnxTest, portBulkAddRemove)
 
     // Counter operations based on the created port
     // 1. Enable counter polling for port stat counter group
-    sai_redis_flex_counter_group_parameter_t flexCounterGroupParam;
+    sai_redis_flex_counter_group_parameter_t flexCounterGroupParam{};
 
     std::string group("PORT_STAT_COUNTER");
     std::string poll_interval = "10000";

--- a/unittest/lib/TestRedisRemoteSaiInterface.cpp
+++ b/unittest/lib/TestRedisRemoteSaiInterface.cpp
@@ -33,7 +33,22 @@ public:
       return SAI_STATUS_SUCCESS;
     }
 
+  void set(
+      _In_ const string &key,
+      _In_ const vector<FieldValueTuple> &values,
+      _In_ const string &command) override
+    {
+      SWSS_LOG_ENTER();
+
+      m_set_key = key;
+      m_set_values = values;
+      m_set_command = command;
+    }
+
   function<sai_status_t(const string &command, KeyOpFieldsValuesTuple &kco)> m_wait_mock;
+  string m_set_key;
+  vector<FieldValueTuple> m_set_values;
+  string m_set_command;
 };
 
 // Helper: build a ContextConfig with a given zmq state and unique IPC
@@ -64,6 +79,58 @@ TEST(RedisRemoteSaiInterface, queryStatsCapabilityNegative)
               sai.queryStatsCapability(0,
                 SAI_OBJECT_TYPE_NULL,
                 0));
+}
+
+TEST(RedisRemoteSaiInterface, setSecondaryPollFactor)
+{
+    auto ctx = ContextConfigContainer::loadFromFile("foo");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(ctx->get(0), nullptr, rec);
+
+    auto channel = make_shared<TestRedisRemoteSaiInterfaceMockChannel>(
+            sai.m_contextConfig->m_dbAsic,
+            std::bind(&RedisRemoteSaiInterface::handleNotification,
+                      &sai,
+                      placeholders::_1,
+                      placeholders::_2,
+                      placeholders::_3));
+    sai.m_communicationChannel = channel;
+
+    string group = "PORT_STAT_COUNTER";
+    string factor = "2";
+    sai_redis_flex_counter_group_secondary_poll_factor_parameter_t param{};
+    param.counter_group_name.list =
+        reinterpret_cast<int8_t *>(const_cast<char *>(group.c_str()));
+    param.counter_group_name.count = static_cast<uint32_t>(group.size());
+    param.secondary_poll_factor.list =
+        reinterpret_cast<int8_t *>(const_cast<char *>(factor.c_str()));
+    param.secondary_poll_factor.count = static_cast<uint32_t>(factor.size());
+
+    sai_attribute_t attr{};
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP_SECONDARY_POLL_FACTOR;
+    attr.value.ptr = &param;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS,
+              sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+    EXPECT_EQ(group, channel->m_set_key);
+    EXPECT_EQ(REDIS_FLEX_COUNTER_COMMAND_SET_GROUP, channel->m_set_command);
+    ASSERT_EQ(1u, channel->m_set_values.size());
+    EXPECT_EQ(SECONDARY_POLL_FACTOR_FIELD, fvField(channel->m_set_values[0]));
+    EXPECT_EQ(factor, fvValue(channel->m_set_values[0]));
+}
+
+TEST(RedisRemoteSaiInterface, setSecondaryPollFactorNullPayload)
+{
+    auto ctx = ContextConfigContainer::loadFromFile("foo");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(ctx->get(0), nullptr, rec);
+
+    sai_attribute_t attr{};
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP_SECONDARY_POLL_FACTOR;
+    attr.value.ptr = nullptr;
+
+    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER,
+              sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
 }
 
 TEST(RedisRemoteSaiInterface, queryStatsStCapability)

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -248,6 +248,7 @@ void testAddRemoveCounter(
 
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(SECONDARY_POLL_FACTOR_FIELD, "2");
     values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
     values.emplace_back(STATS_MODE_FIELD, statsMode);
     std::vector<swss::FieldValueTuple> fcValues = values;

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -267,7 +267,8 @@ void testAddRemoveCounter(
         bool bulkChunkSizeAfterPort = true,
         const std::string pluginName = "",
         bool immediatelyRemoveBulkChunkSizePerCounter = false,
-        bool forceSingleCreate = false)
+        bool forceSingleCreate = false,
+        const std::string secondaryPollFactor = "")
 {
     SWSS_LOG_ENTER();
 
@@ -280,7 +281,10 @@ void testAddRemoveCounter(
 
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(POLL_INTERVAL_FIELD, "1000");
-    values.emplace_back(SECONDARY_POLL_FACTOR_FIELD, "2");
+    if (!secondaryPollFactor.empty())
+    {
+        values.emplace_back(SECONDARY_POLL_FACTOR_FIELD, secondaryPollFactor);
+    }
     values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
     values.emplace_back(STATS_MODE_FIELD, statsMode);
     std::vector<swss::FieldValueTuple> fcValues = values;
@@ -1692,7 +1696,8 @@ TEST(FlexCounter, bulkChunksize)
         "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2");
     EXPECT_TRUE(allObjectIds.empty());
 
-    // set bulk chunk size + per counter bulk chunk size first and then create ports
+    // Set the secondary poll factor explicitly. Other calls omit it to cover
+    // the legacy/default behavior.
     initialCheckCount = 6;
     testAddRemoveCounter(
         6,
@@ -1709,7 +1714,8 @@ TEST(FlexCounter, bulkChunksize)
         false,
         PORT_PLUGIN_FIELD,
         false,
-        true);
+        true,
+        "2");
     EXPECT_TRUE(allObjectIds.empty());
 
     // Remove per counter bulk chunk size after initializing it

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -280,6 +280,7 @@ void testAddRemoveCounter(
 
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(SECONDARY_POLL_FACTOR_FIELD, "2");
     values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
     values.emplace_back(STATS_MODE_FIELD, statsMode);
     std::vector<swss::FieldValueTuple> fcValues = values;


### PR DESCRIPTION
HLD Link : [fec-flr-hld](https://github.com/sonic-net/SONiC/blob/master/doc/port_fec_flr/port_fec_flr.md)

<!--
Please make sure you have read and understood the contribution guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generated with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, assignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Added a secondary poll factor feature to the flex counter infrastructure. This enhancement introduces a new `secondary_poll_factor` parameter that allows dynamic adjustment of polling intervals for specific counter types. The implementation includes:
- Modified FlexCounter class to support secondary poll factor configuration
- Updated Redis remote SAI interface to handle the new parameter
- Enhanced counter polling logic to apply secondary poll factor when configured
- Maintained backward compatibility when secondary poll factor is not specified

**Why I did it**

To provide more granular control over counter polling intervals, especially for FEC FLR (Forward Error Correction Frame Loss Rate) counters. This feature allows:
- Different polling frequencies for performance-critical counters
- Optimized resource utilization by adjusting poll rates based on counter importance
- Better monitoring capabilities for specific counter types that require different sampling rates
- Reduced system overhead by allowing less frequent polling for non-critical counters while maintaining high-frequency polling for critical ones

**How I verified it**

- Verified that secondary poll factor correctly modifies polling intervals when configured
- Ensured backward compatibility - existing behavior is preserved when secondary poll factor is not configured
- Tested with FEC FLR counters to validate the intended use case
- Verified the feature through manual testing with different poll factor values
- Confirmed proper integration with the Redis database layer

**Details if related**

- This feature is particularly useful for monitoring FEC FLR counters which may require different polling frequencies than other counter types
- The secondary poll factor is applied as a multiplier to the base polling interval
- When not configured, the system defaults to the primary polling interval, ensuring no impact on existing deployments
- Related to performance optimization efforts for counter collection in high-scale environments

## Build Order Requirements

```
┌──────────────────────────────┐
│  sonic-swss-common (#1110)   │  ◄── Foundation (no dependencies)
└──────────────────────────────┘
         │                  
         │                  
         ├──────────────────────────┐
         │                          │
         │                          │
         v                          │
┌──────────────────────────────┐    │
│  sonic-sairedis (#1699)      │    │
│  depends on:                 │    │
│    - sonic-swss-common       │    │
└──────────────────────────────┘    │
         │                          │
         │                          │
         └──────────┬───────────────┘
                    │
                    v
         ┌──────────────────────────────┐
         │  sonic-swss (#4002)          │
         │  depends on:                 │
         │    - sonic-sairedis          │
         │    - sonic-swss-common       │
         └──────────────────────────────┘
```

Build Order (bottom-up):
sonic-swss-common ([#1110](https://github.com/sonic-net/sonic-swss-common/pull/1110)) - build first
sonic-sairedis ([#1699](https://github.com/sonic-net/sonic-sairedis/pull/1699)) - build second
sonic-swss ([#4002](https://github.com/sonic-net/sonic-swss/pull/4002)) - build last
PR Merge Order: The PRs should be merged in the same order: [#1110](https://github.com/sonic-net/sonic-swss-common/pull/1110) → [#1699](https://github.com/sonic-net/sonic-sairedis/pull/1699) → [#4002](https://github.com/sonic-net/sonic-swss/pull/4002)

Issue Tracking the merge/backport of this PR : https://github.com/aristanetworks/sonic-qual.msft/issues/1338