### PR TITLE
Graceful shutdown vpp to avoid core dump

### DIFF
--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -39,6 +39,21 @@ SwitchVpp::SwitchVpp(
     vpp_dp_initialize();
 }
 
+SwitchVpp::~SwitchVpp()
+{
+    SWSS_LOG_ENTER();
+
+    // Signal the vpp events thread to stop
+    m_run_vpp_events_thread = false;
+
+    // Wait for the thread to finish gracefully
+    if (m_vpp_thread && m_vpp_thread->joinable()) {
+        m_vpp_thread->join();
+    }
+
+    SWSS_LOG_NOTICE("SwitchVpp destructor completed");
+}
+
 sai_status_t SwitchVpp::create_qos_queues_per_port(
         _In_ sai_object_id_t port_id)
 {

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -41,7 +41,7 @@ namespace saivs
                     _In_ std::shared_ptr<SwitchConfig> config,
                     _In_ std::shared_ptr<WarmBootState> warmBootState);
 
-            virtual ~SwitchVpp() = default;
+            virtual ~SwitchVpp();
 
         protected:
 


### PR DESCRIPTION
### why
when we shutdown vpp syncd, such as config reload, syncd produces a core due to ungraceful shutdown. Here is the stack trace.

```
#0  0x00007f191a069eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f191a01afb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f191a005472 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007f191a27e919 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f191a289e1a in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007f191a289e85 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x000056339ef8f7de in std::__terminate () at /usr/include/x86_64-linux-gnu/c++/12/bits/c++config.h:312
#7  std::thread::~thread (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/std_thread.h:151
#8  std::_Destroy<std::thread> (__pointer=<optimized out>) at /usr/include/c++/12/bits/stl_construct.h:151
#9  std::allocator_traits<std::allocator<void> >::destroy<std::thread> (__p=<optimized out>) at /usr/include/c++/12/bits/alloc_traits.h:648
#10 std::_Sp_counted_ptr_inplace<std::thread, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose (this=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:613
#11 0x00007f191a59bd23 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x5633b57bfb40) at /usr/include/c++/12/bits/shared_ptr_base.h:346
#12 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x5633b57bfb40) at /usr/include/c++/12/bits/shared_ptr_base.h:317
#13 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x5633b57c27c8, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#14 std::__shared_ptr<std::thread, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x5633b57c27c0, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#15 std::shared_ptr<std::thread>::~shared_ptr (this=0x5633b57c27c0, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#16 saivs::SwitchVpp::~SwitchVpp (this=0x5633b57c20b0, __in_chrg=<optimized out>) at vpp/SwitchVpp.h:44
#17 0x000056339ef65507 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x5633b57c20a0) at /usr/include/c++/12/bits/shared_ptr_base.h:346
#18 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x5633b57c20a0) at /usr/include/c++/12/bits/shared_ptr_base.h:317
#19 0x00007f191a588fe3 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=<synthetic pointer>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#20 std::__shared_ptr<saivs::SwitchStateBase, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=<synthetic pointer>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#21 std::shared_ptr<saivs::SwitchStateBase>::~shared_ptr (this=<synthetic pointer>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#22 saivs::VirtualSwitchSaiInterface::remove (this=this@entry=0x5633b57a2eb0, switchId=switchId@entry=141733920768, objectType=objectType@entry=SAI_OBJECT_TYPE_SWITCH, serializedObjectId="oid:0x2100000000")
    at ./vslib/VirtualSwitchSaiInterface.cpp:793
#23 0x00007f191a5894cc in saivs::VirtualSwitchSaiInterface::remove (this=0x5633b57a2eb0, objectType=SAI_OBJECT_TYPE_SWITCH, objectId=<optimized out>) at ./vslib/VirtualSwitchSaiInterface.cpp:354
#24 0x00007f191a8d214e in saimeta::Meta::remove (this=0x5633b57ab300, object_type=SAI_OBJECT_TYPE_SWITCH, object_id=<optimized out>) at ./meta/Meta.cpp:264
#25 0x00007f191a5643a2 in saivs::Sai::remove (this=0x5633b5795f50, objectType=SAI_OBJECT_TYPE_SWITCH, objectId=141733920768) at ./vslib/Sai.cpp:355
#26 0x00007f191a55eea5 in stub_remove_switch (switch_id=141733920768) at ./vslib/sai_vs.cpp:36
#27 0x000056339ef920d3 in syncd::VendorSai::remove (this=0x5633b57a3140, objectType=SAI_OBJECT_TYPE_SWITCH, objectId=141733920768) at ./syncd/VendorSai.cpp:206
#28 0x000056339ef69fdc in syncd::Syncd::removeAllSwitches (this=this@entry=0x5633b579f850) at ./syncd/Syncd.cpp:5516
#29 0x000056339ef85dd2 in syncd::Syncd::run (this=this@entry=0x5633b579f850) at ./syncd/Syncd.cpp:5960
#30 0x000056339ef65074 in syncd_main (argc=argc@entry=7, argv=argv@entry=0x7ffcc53269b8) at ./syncd/syncd_main.cpp:71
#31 0x000056339ef6302e in main (argc=7, argv=0x7ffcc53269b8) at ./syncd/main.cpp:9
```

This is due to a live thread was not terminated gracefully.

### what this PR does
shutdown the vpp thread gracefully.