### PR TITLE
[202505][ci] Use 1ES agent pool to provide more disk when building swss.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,6 +110,7 @@ stages:
   - template: .azure-pipelines/build-swss-template.yml
     parameters:
       arch: amd64
+      pool: sonicso1ES-amd64
       sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-sairedis/pull/1710 from master.