### PR TITLE
Fix dash meter COUNTERS_DB keys to use VID instead of RID

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1746,6 +1746,7 @@ public:
         if (m_switchId == 0UL)
         {
             m_switchId = m_vendorSai->switchIdQuery(rid);
+            m_switchVid = VidManager::switchIdQuery(vid);
         }
 
         if (m_meterBucketsPerEni == 0)
@@ -1807,7 +1808,9 @@ public:
         swss::RedisPipeline pipeline(&db);
         swss::Table countersTable(&pipeline, COUNTERS_TABLE, true);
         for (const auto& object_key: it->second.object_keys) {
-           countersTable.del(sai_serialize_meter_bucket_entry(object_key.key.meter_bucket_entry));
+            auto meter_bucket_entry =
+                meterBucketRidToVid(object_key.key.meter_bucket_entry, vid);
+            countersTable.del(sai_serialize_meter_bucket_entry(meter_bucket_entry));
         }
         // remove from flex counter poll
         m_bulkMeterContexts.erase(it);
@@ -1840,7 +1843,10 @@ public:
             idStrings.reserve(m_meterBucketsPerEni);
 
             for (uint32_t i = 0; i < m_meterBucketsPerEni; ++i) {
-                idStrings.push_back(sai_serialize_meter_bucket_entry(ctx.object_keys[i].key.meter_bucket_entry));
+                auto meter_bucket_entry =
+                    meterBucketRidToVid(ctx.object_keys[i].key.meter_bucket_entry,
+                                        ctx.eni_vid);
+                idStrings.push_back(sai_serialize_meter_bucket_entry(meter_bucket_entry));
             }
             std::for_each(m_plugins.begin(),
                           m_plugins.end(),
@@ -1934,7 +1940,10 @@ private:
             {
                 values.emplace_back(serializeStat(ctx.counter_ids[j]), std::to_string(ctx.counters[i * ctx.counter_ids.size() + j]));
             }
-            countersTable.set(sai_serialize_meter_bucket_entry(ctx.object_keys[i].key.meter_bucket_entry), values, "");
+            auto meter_bucket_entry =
+                meterBucketRidToVid(ctx.object_keys[i].key.meter_bucket_entry,
+                                    ctx.eni_vid);
+            countersTable.set(sai_serialize_meter_bucket_entry(meter_bucket_entry), values, "");
             values.clear();
         }
         return true;
@@ -2076,6 +2085,16 @@ private:
         m_bulkMeterContexts.emplace(vid, makeBulkMeterContext(vid, rid));
     }
 
+    sai_meter_bucket_entry_t meterBucketRidToVid(
+        const sai_meter_bucket_entry_t& in_entry, sai_object_id_t eniVid)
+    {
+        SWSS_LOG_ENTER();
+        auto out_entry = in_entry;
+        out_entry.eni_id = eniVid;
+        out_entry.switch_id = m_switchVid;
+        return out_entry;
+    }
+
     std::map<sai_object_id_t, BulkMeterStatsContext> m_bulkMeterContexts;
     std::vector<sai_meter_bucket_entry_stat_t> m_supportedMeterCounters;
     sai_object_type_t m_objectType = (sai_object_type_t) SAI_OBJECT_TYPE_METER_BUCKET_ENTRY;
@@ -2083,6 +2102,7 @@ private:
     sairedis::SaiInterface *m_vendorSai;
     sai_stats_mode_t m_groupStatsMode = SAI_STATS_MODE_READ;
     sai_object_id_t m_switchId = 0UL;
+    sai_object_id_t m_switchVid = 0UL;
     uint32_t m_meterBucketsPerEni = 0;
     bool m_initalized = false;
 };

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -3,6 +3,7 @@
 #include "MockableSaiInterface.h"
 #include "MockHelper.h"
 #include "VirtualObjectIdManager.h"
+#include "VidManager.h"
 #include "NumberOidIndexGenerator.h"
 #include <string>
 #include <gtest/gtest.h>
@@ -1931,9 +1932,10 @@ TEST(FlexCounter, addRemoveDashMeterCounter)
     auto counterVerifyFunc = [] (swss::Table &countersTable, sai_object_id_t eni_id, const std::vector<std::string>& counterIdNames, const dash_meter_expected_val_t& expectedValues)
     {
         std::string value;
+        auto switchVid = VidManager::switchIdQuery(eni_id);
         for (uint32_t i = 0; i < (expectedValues.size()/counterIdNames.size()); i++)
         {
-            auto entry_key = sai_meter_bucket_entry_t {.switch_id = 0, .eni_id = eni_id,
+            auto entry_key = sai_meter_bucket_entry_t {.switch_id = switchVid, .eni_id = eni_id,
                                                        .meter_class = (i*100) + 1};
             auto key = sai_serialize_meter_bucket_entry(entry_key);
             for (size_t j = 0; j < 2; ++j) {


### PR DESCRIPTION
**Problem**
All dash ENI meter class stats were incorrectly written to COUNTERS_DB using the RID instead of the VID as the keys for the switch and ENI oid. 

**Fix**
Use the Switch and ENI VID in the COUNTER_DB keys for dash meter class.

```
sonic-db-cli COUNTERS_DB hgetall 'COUNTERS:{"switch_id":"oid:0x21000000000000","eni_id":"oid:0x700800000001c","meter_class":"89"}'
{'SAI_METER_BUCKET_ENTRY_STAT_INBOUND_BYTES': '0', 'SAI_METER_BUCKET_ENTRY_STAT_OUTBOUND_BYTES': '210'}
```

