### PR TITLE
Skip FlexCounters Poll with RID 0x0

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -532,6 +532,41 @@ void deserializeAttr(
     sai_deserialize_port_attr(name, attr);
 }
 
+bool BaseCounterContext::resolveRid(
+        _In_ sai_object_id_t vid,
+        _Inout_ sai_object_id_t &rid)
+{
+    SWSS_LOG_ENTER();
+
+    if (rid != SAI_NULL_OBJECT_ID)
+    {
+        return true;
+    }
+
+    if (!m_vidToRidResolver)
+    {
+        return false;
+    }
+
+    sai_object_id_t resolvedRid = SAI_NULL_OBJECT_ID;
+
+    try
+    {
+        if (m_vidToRidResolver(vid, resolvedRid) && resolvedRid != SAI_NULL_OBJECT_ID)
+        {
+            rid = resolvedRid;
+            SWSS_LOG_DEBUG("FlexCounter: resolved VID 0x%" PRIx64 " -> RID 0x%" PRIx64 " (VIDTORID)", vid, rid);
+            return true;
+        }
+    }
+    catch (const std::exception &e)
+    {
+        SWSS_LOG_WARN("FlexCounter: failed to resolve VID 0x%" PRIx64 ": %s, skipping", vid, e.what());
+    }
+
+    return false;
+}
+
 template <typename StatType>
 class CounterContext : public BaseCounterContext
 {
@@ -1539,35 +1574,12 @@ public:
             sai_object_id_t rid = kv.second->rid;
             const auto &statIds = kv.second->counter_ids;
 
-            if (rid == SAI_NULL_OBJECT_ID)
+            if (!resolveRid(vid, rid))
             {
-                if (m_vidToRidResolver)
-                {
-                    sai_object_id_t resolvedRid = SAI_NULL_OBJECT_ID;
-                    try
-                    {
-                        if (m_vidToRidResolver(vid, resolvedRid) && resolvedRid != SAI_NULL_OBJECT_ID)
-                        {
-                            kv.second->rid = resolvedRid;
-                            rid = resolvedRid;
-                            SWSS_LOG_DEBUG("FlexCounter: resolved VID 0x%" PRIx64 " -> RID 0x%" PRIx64 " (VIDTORID)", vid, rid);
-                        }
-                        else
-                        {
-                            continue;
-                        }
-                    }
-                    catch (const std::exception &e)
-                    {
-                        SWSS_LOG_WARN("FlexCounter: failed to resolve VID 0x%" PRIx64 ": %s, skipping", vid, e.what());
-                        continue;
-                    }
-                }
-                else
-                {
-                    continue;
-                }
+                continue;
             }
+
+            kv.second->rid = rid;
 
             // TODO: use if const expression when cpp17 is supported
             if (HasStatsMode<CounterIdsType>::value)
@@ -2356,42 +2368,18 @@ public:
     {
         SWSS_LOG_ENTER();
 
-        for (const auto &kv : Base::m_objectIdsMap)
+        for (auto &kv : Base::m_objectIdsMap)
         {
             const auto &vid = kv.first;
             sai_object_id_t rid = kv.second->rid;
             const auto &attrIds = kv.second->counter_ids;
 
-            if (rid == SAI_NULL_OBJECT_ID)
+            if (!this->resolveRid(vid, rid))
             {
-                if (Base::m_vidToRidResolver)
-                {
-                    sai_object_id_t resolvedRid = SAI_NULL_OBJECT_ID;
-                    try
-                    {
-                        if (Base::m_vidToRidResolver(vid, resolvedRid) && resolvedRid != SAI_NULL_OBJECT_ID)
-                        {
-                            kv.second->rid = resolvedRid;
-                            rid = resolvedRid;
-                            SWSS_LOG_DEBUG("FlexCounter: resolved VID 0x%" PRIx64 " -> RID 0x%" PRIx64 " (VIDTORID)", vid, rid);
-                        }
-                        else
-                        {
-                            continue;
-                        }
-                    }
-                    catch (const std::exception &e)
-                    {
-                        SWSS_LOG_WARN("FlexCounter: failed to resolve VID 0x%" PRIx64 ": %s, skipping", vid, e.what());
-                        continue;
-                    }
-                }
-                else
-                {
-                    // Still no RID in VIDTORID; skip this object this poll (do not call SAI with RID=0)
-                    continue;
-                }
+                continue;
             }
+
+            kv.second->rid = rid;
 
             std::vector<sai_attribute_t> attrs(attrIds.size());
             for (size_t i = 0; i < attrIds.size(); i++)

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2329,8 +2329,25 @@ public:
         for (const auto &kv : Base::m_objectIdsMap)
         {
             const auto &vid = kv.first;
-            const auto &rid = kv.second->rid;
+            sai_object_id_t rid = kv.second->rid;
             const auto &attrIds = kv.second->counter_ids;
+
+            // When RID is 0 (e.g. flex counter enabled before VIDTORID was ready), try to resolve from Redis
+            if (rid == SAI_NULL_OBJECT_ID && Base::m_vidToRidResolver)
+            {
+                sai_object_id_t resolvedRid = SAI_NULL_OBJECT_ID;
+                if (Base::m_vidToRidResolver(vid, resolvedRid) && resolvedRid != SAI_NULL_OBJECT_ID)
+                {
+                    kv.second->rid = resolvedRid;
+                    rid = resolvedRid;
+                    SWSS_LOG_DEBUG("FlexCounter: resolved VID 0x%" PRIx64 " -> RID 0x%" PRIx64 " (VIDTORID)", vid, rid);
+                }
+                else
+                {
+                    // Still no RID in VIDTORID; skip this object this poll (do not call SAI with RID=0)
+                    continue;
+                }
+            }
 
             std::vector<sai_attribute_t> attrs(attrIds.size());
             for (size_t i = 0; i < attrIds.size(); i++)
@@ -2347,8 +2364,8 @@ public:
 
             if (status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_ERROR("Failed to get attr of %s 0x%" PRIx64 ": %d",
-                        sai_serialize_object_type(Base::m_objectType).c_str(), vid, status);
+                SWSS_LOG_ERROR("Failed to get attr of %s VID 0x%" PRIx64 " RID 0x%" PRIx64 ": %s",
+                        sai_serialize_object_type(Base::m_objectType).c_str(), vid, rid, sai_serialize_status(status).c_str());
                 continue;
             }
 
@@ -3729,6 +3746,16 @@ void FlexCounter::setStatus(
     }
 }
 
+void FlexCounter::setVidToRidResolver(
+        _In_ std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> resolver)
+{
+    m_vidToRidResolver = std::move(resolver);
+    for (auto& it : m_counterContext)
+    {
+        it.second->setVidToRidResolver(m_vidToRidResolver);
+    }
+}
+
 void FlexCounter::setStatsMode(
         _In_ const std::string& mode)
 {
@@ -4096,6 +4123,10 @@ std::shared_ptr<BaseCounterContext> FlexCounter::getCounterContext(
 
     auto counterContext = createCounterContext(name, m_instanceId);
 
+    if (m_vidToRidResolver)
+    {
+        counterContext->setVidToRidResolver(m_vidToRidResolver);
+    }
     if (m_noDoubleCheckBulkCapability)
     {
         counterContext->setNoDoubleCheckBulkCapability(true);

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1533,11 +1533,41 @@ public:
     {
         SWSS_LOG_ENTER();
         sai_stats_mode_t effective_stats_mode = m_groupStatsMode;
-        for (const auto &kv : m_objectIdsMap)
+        for (auto &kv : m_objectIdsMap)
         {
             const auto &vid = kv.first;
-            const auto &rid = kv.second->rid;
+            sai_object_id_t rid = kv.second->rid;
             const auto &statIds = kv.second->counter_ids;
+
+            if (rid == SAI_NULL_OBJECT_ID)
+            {
+                if (m_vidToRidResolver)
+                {
+                    sai_object_id_t resolvedRid = SAI_NULL_OBJECT_ID;
+                    try
+                    {
+                        if (m_vidToRidResolver(vid, resolvedRid) && resolvedRid != SAI_NULL_OBJECT_ID)
+                        {
+                            kv.second->rid = resolvedRid;
+                            rid = resolvedRid;
+                            SWSS_LOG_DEBUG("FlexCounter: resolved VID 0x%" PRIx64 " -> RID 0x%" PRIx64 " (VIDTORID)", vid, rid);
+                        }
+                        else
+                        {
+                            continue;
+                        }
+                    }
+                    catch (const std::exception &e)
+                    {
+                        SWSS_LOG_WARN("FlexCounter: failed to resolve VID 0x%" PRIx64 ": %s, skipping", vid, e.what());
+                        continue;
+                    }
+                }
+                else
+                {
+                    continue;
+                }
+            }
 
             // TODO: use if const expression when cpp17 is supported
             if (HasStatsMode<CounterIdsType>::value)
@@ -2332,15 +2362,29 @@ public:
             sai_object_id_t rid = kv.second->rid;
             const auto &attrIds = kv.second->counter_ids;
 
-            // When RID is 0 (e.g. flex counter enabled before VIDTORID was ready), try to resolve from Redis
-            if (rid == SAI_NULL_OBJECT_ID && Base::m_vidToRidResolver)
+            if (rid == SAI_NULL_OBJECT_ID)
             {
-                sai_object_id_t resolvedRid = SAI_NULL_OBJECT_ID;
-                if (Base::m_vidToRidResolver(vid, resolvedRid) && resolvedRid != SAI_NULL_OBJECT_ID)
+                if (Base::m_vidToRidResolver)
                 {
-                    kv.second->rid = resolvedRid;
-                    rid = resolvedRid;
-                    SWSS_LOG_DEBUG("FlexCounter: resolved VID 0x%" PRIx64 " -> RID 0x%" PRIx64 " (VIDTORID)", vid, rid);
+                    sai_object_id_t resolvedRid = SAI_NULL_OBJECT_ID;
+                    try
+                    {
+                        if (Base::m_vidToRidResolver(vid, resolvedRid) && resolvedRid != SAI_NULL_OBJECT_ID)
+                        {
+                            kv.second->rid = resolvedRid;
+                            rid = resolvedRid;
+                            SWSS_LOG_DEBUG("FlexCounter: resolved VID 0x%" PRIx64 " -> RID 0x%" PRIx64 " (VIDTORID)", vid, rid);
+                        }
+                        else
+                        {
+                            continue;
+                        }
+                    }
+                    catch (const std::exception &e)
+                    {
+                        SWSS_LOG_WARN("FlexCounter: failed to resolve VID 0x%" PRIx64 ": %s, skipping", vid, e.what());
+                        continue;
+                    }
                 }
                 else
                 {
@@ -3749,6 +3793,8 @@ void FlexCounter::setStatus(
 void FlexCounter::setVidToRidResolver(
         _In_ std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> resolver)
 {
+    MUTEX;
+
     m_vidToRidResolver = std::move(resolver);
     for (auto& it : m_counterContext)
     {
@@ -4207,9 +4253,16 @@ void FlexCounter::flexCounterThreadRunFunction()
         {
             auto start = std::chrono::steady_clock::now();
 
-            collectCounters(countersTable);
+            try
+            {
+                collectCounters(countersTable);
 
-            runPlugins(db);
+                runPlugins(db);
+            }
+            catch (const std::exception &e)
+            {
+                SWSS_LOG_ERROR("FlexCounter %s: exception during poll: %s", m_instanceId.c_str(), e.what());
+            }
 
             auto finish = std::chrono::steady_clock::now();
 

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -105,6 +105,20 @@ namespace syncd
         }
 
     protected:
+
+        /**
+         * @brief Attempt to resolve a VID to RID when the stored RID is SAI_NULL_OBJECT_ID.
+         *
+         * @param vid        The virtual object id.
+         * @param[in,out] rid On entry the current (possibly null) RID; on success updated to resolved RID.
+         *
+         * @return true if rid is valid and the caller should proceed; false if the
+         *         object should be skipped this poll cycle.
+         */
+        bool resolveRid(
+                _In_ sai_object_id_t vid,
+                _Inout_ sai_object_id_t &rid);
+
         std::string m_name;
         std::string m_instanceId;
         std::set<std::string> m_plugins;

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <unordered_map>
 #include <memory>
 #include <type_traits>
+#include <functional>
 
 // Placeholder type for attributes not requiring data allocation
 // Used as default template parameter for simple attributes
@@ -96,12 +97,20 @@ namespace syncd
 
         virtual bool hasObject() const = 0;
 
+        /** Optional: when RID is 0, collectData can call this to resolve VID from Redis (VIDTORID). */
+        void setVidToRidResolver(
+                _In_ std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> resolver)
+        {
+            m_vidToRidResolver = std::move(resolver);
+        }
+
     protected:
         std::string m_name;
         std::string m_instanceId;
         std::set<std::string> m_plugins;
         std::string m_bulkChunkSizePerPrefix;
         std::map<std::pair<sai_object_id_t, sai_object_id_t>, uint32_t> m_failedPolls;
+        std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> m_vidToRidResolver;
 
     public:
         bool always_check_supported_counters = false;
@@ -237,8 +246,15 @@ namespace syncd
 
             bool m_noDoubleCheckBulkCapability;
 
+            std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> m_vidToRidResolver;
+
             static const std::map<std::string, std::string> m_plugIn2CounterType;
 
             static const std::map<std::tuple<sai_object_type_t, std::string>, std::string> m_objectTypeField2CounterType;
+
+        public:
+            /** Set resolver for VID->RID when RID is 0 (e.g. warm reboot). Called by FlexCounterManager. */
+            void setVidToRidResolver(
+                    _In_ std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> resolver);
     };
 }

--- a/syncd/FlexCounterManager.cpp
+++ b/syncd/FlexCounterManager.cpp
@@ -31,11 +31,24 @@ std::shared_ptr<FlexCounter> FlexCounterManager::getInstance(
     {
         bool supportingBulk = (m_supportingBulkGroups.find(instanceId) != std::string::npos);
         auto counter = std::make_shared<FlexCounter>(instanceId, m_vendorSai, m_dbCounters, supportingBulk);
-
+        if (m_vidToRidResolver)
+        {
+            counter->setVidToRidResolver(m_vidToRidResolver);
+        }
         m_flexCounters[instanceId] = counter;
     }
 
     return m_flexCounters.at(instanceId);
+}
+
+void FlexCounterManager::setVidToRidResolver(
+        _In_ std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> resolver)
+{
+    m_vidToRidResolver = std::move(resolver);
+    for (auto& it : m_flexCounters)
+    {
+        it.second->setVidToRidResolver(m_vidToRidResolver);
+    }
 }
 
 void FlexCounterManager::removeInstance(

--- a/syncd/FlexCounterManager.h
+++ b/syncd/FlexCounterManager.h
@@ -2,6 +2,8 @@
 
 #include "FlexCounter.h"
 
+#include <functional>
+
 namespace syncd
 {
     class FlexCounterManager
@@ -48,6 +50,10 @@ namespace syncd
                     _In_ sai_object_id_t vid,
                     _In_ const std::string& instanceId);
 
+            /** Set resolver for VID->RID when RID is 0 (read from Redis VIDTORID). Syncd sets this after translator is created. */
+            void setVidToRidResolver(
+                    _In_ std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> resolver);
+
         private:
 
                 std::map<std::string, std::shared_ptr<FlexCounter>> m_flexCounters;
@@ -59,6 +65,8 @@ namespace syncd
                 std::string m_dbCounters;
 
                 std::string m_supportingBulkGroups;
+
+                std::function<bool(sai_object_id_t vid, sai_object_id_t& rid)> m_vidToRidResolver;
     };
 }
 

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -25,6 +25,7 @@
 #include "swss/exec.h"
 #include "swss/dbconnector.h"
 #include "swss/table.h"
+#include "swss/warm_restart.h"
 
 #include "meta/sai_serialize.h"
 #include "meta/ZeroMQSelectableChannel.h"
@@ -42,6 +43,7 @@
 #include <iterator>
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 
 #define DEF_SAI_WARM_BOOT_DATA_FILE "/var/warmboot/sai-warmboot.bin"
 #define SAI_FAILURE_DUMP_SCRIPT "/usr/bin/sai_failure_dump.sh"
@@ -269,6 +271,9 @@ Syncd::Syncd(
     m_translator = std::make_shared<VirtualOidTranslator>(m_client, m_virtualObjectIdManager,  vendorSai);
 
     m_processor->m_translator = m_translator; // TODO as param
+
+    m_manager->setVidToRidResolver(
+        [this](sai_object_id_t vid, sai_object_id_t& rid) { return m_translator->tryTranslateVidToRid(vid, rid); });
 
     m_veryFirstRun = isVeryFirstRun();
 
@@ -4177,7 +4182,7 @@ sai_status_t Syncd::processFlexCounterEvent(
         sai_object_id_t vid;
         sai_deserialize_object_id(strVid, vid);
 
-        sai_object_id_t rid;
+        sai_object_id_t rid = SAI_NULL_OBJECT_ID; // Initialize to NULL
 
         if (!m_translator->tryTranslateVidToRid(vid, rid))
         {
@@ -4194,7 +4199,12 @@ sai_status_t Syncd::processFlexCounterEvent(
             effective_op = DEL_COMMAND;
         }
 
-        if (effective_op == SET_COMMAND)
+        if (effective_op == SET_COMMAND && rid == SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_INFO("Skipping counter add for null object in group %s",
+                    groupName.c_str());
+        }
+        else if (effective_op == SET_COMMAND)
         {
             m_manager->addCounter(vid, rid, groupName, values);
             if (fromAsicChannel)

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -3096,18 +3096,18 @@ TEST(FlexCounter, VidToRidResolver_StatsCounter_WhenRidZero_ResolvesAndPolls)
     values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
     fc.addCounterPlugin(values);
 
+    values.clear();
+    values.emplace_back(FLOW_COUNTER_ID_LIST, "SAI_COUNTER_STAT_PACKETS,SAI_COUNTER_STAT_BYTES");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+
     auto resolver = [resolvedRid](sai_object_id_t, sai_object_id_t& rid) {
         rid = resolvedRid;
         return true;
     };
     fc.setVidToRidResolver(resolver);
 
-    values.clear();
-    values.emplace_back(FLOW_COUNTER_ID_LIST, "SAI_COUNTER_STAT_PACKETS,SAI_COUNTER_STAT_BYTES");
-    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
-
     pollingPhase = true;
-    usleep(1000 * 1050);
+    usleep(1000 * 2050);
     swss::DBConnector db("COUNTERS_DB", 0);
     swss::Table countersTable(&db, COUNTERS_TABLE);
     std::string value;
@@ -3118,4 +3118,247 @@ TEST(FlexCounter, VidToRidResolver_StatsCounter_WhenRidZero_ResolvesAndPolls)
 
     fc.removeCounter(vid);
     countersTable.del(toOid(vid));
+}
+
+TEST(FlexCounter, VidToRidResolver_AttrCounter_WhenRidZero_ResolvesAndPolls)
+{
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_ACL_COUNTER);
+    std::vector<sai_object_id_t> vids = generateOids(1, SAI_OBJECT_TYPE_ACL_COUNTER);
+    ASSERT_EQ(vids.size(), 1u);
+    sai_object_id_t vid = vids[0];
+    const sai_object_id_t resolvedRid = 0x0900000000001234ULL;
+
+    bool pollingPhase = false;
+    sai->mock_get = [&pollingPhase, resolvedRid](sai_object_type_t, sai_object_id_t objectId, uint32_t attr_count, sai_attribute_t *attrs) {
+        if (pollingPhase)
+        {
+            EXPECT_EQ(objectId, resolvedRid);
+        }
+        for (uint32_t i = 0; i < attr_count; i++)
+        {
+            if (attrs[i].id == SAI_ACL_COUNTER_ATTR_PACKETS)
+                attrs[i].value.u64 = 100;
+        }
+        return SAI_STATUS_SUCCESS;
+    };
+
+    FlexCounter fc("test_attr_resolver_ok", sai, "COUNTERS_DB");
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    fc.addCounterPlugin(values);
+
+    auto resolver = [resolvedRid](sai_object_id_t, sai_object_id_t& rid) {
+        rid = resolvedRid;
+        return true;
+    };
+    fc.setVidToRidResolver(resolver);
+
+    values.clear();
+    values.emplace_back(ACL_COUNTER_ATTR_ID_LIST, "SAI_ACL_COUNTER_ATTR_PACKETS");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+
+    pollingPhase = true;
+    usleep(1000 * 1050);
+
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::Table countersTable(&db, COUNTERS_TABLE);
+    std::string value;
+    ASSERT_TRUE(countersTable.hget(toOid(vid), "SAI_ACL_COUNTER_ATTR_PACKETS", value));
+    EXPECT_EQ(value, "100");
+
+    fc.removeCounter(vid);
+    countersTable.del(toOid(vid));
+}
+
+TEST(FlexCounter, VidToRidResolver_AttrCounter_ResolverFails_SkipsSaiCall)
+{
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_ACL_COUNTER);
+    std::vector<sai_object_id_t> vids = generateOids(1, SAI_OBJECT_TYPE_ACL_COUNTER);
+    ASSERT_EQ(vids.size(), 1u);
+    sai_object_id_t vid = vids[0];
+
+    int getCallCount = 0;
+    sai->mock_get = [&getCallCount](sai_object_type_t, sai_object_id_t, uint32_t, sai_attribute_t *) {
+        getCallCount++;
+        return SAI_STATUS_SUCCESS;
+    };
+
+    FlexCounter fc("test_attr_resolver_fail", sai, "COUNTERS_DB");
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    fc.addCounterPlugin(values);
+
+    auto resolverFail = [](sai_object_id_t, sai_object_id_t& rid) {
+        rid = SAI_NULL_OBJECT_ID;
+        return false;
+    };
+    fc.setVidToRidResolver(resolverFail);
+
+    values.clear();
+    values.emplace_back(ACL_COUNTER_ATTR_ID_LIST, "SAI_ACL_COUNTER_ATTR_PACKETS");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+
+    usleep(1000 * 1050);
+    EXPECT_EQ(getCallCount, 0);
+
+    fc.removeCounter(vid);
+}
+
+TEST(FlexCounter, VidToRidResolver_StatsCounter_WhenResolverThrows_SkipsWithoutCrash)
+{
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_COUNTER);
+    std::vector<sai_object_id_t> vids = generateOids(1, SAI_OBJECT_TYPE_COUNTER);
+    ASSERT_EQ(vids.size(), 1u);
+    sai_object_id_t vid = vids[0];
+
+    bool addObjectDone = false;
+    int pollGetStatsCount = 0;
+    sai->mock_getStatsExt = [&addObjectDone, &pollGetStatsCount](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, sai_stats_mode_t, uint64_t *counters) {
+        if (addObjectDone)
+            pollGetStatsCount++;
+        for (uint32_t i = 0; i < number_of_counters; i++)
+            counters[i] = 0;
+        return SAI_STATUS_SUCCESS;
+    };
+    sai->mock_getStats = [&addObjectDone, &pollGetStatsCount](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, uint64_t *counters) {
+        if (addObjectDone)
+            pollGetStatsCount++;
+        for (uint32_t i = 0; i < number_of_counters; i++)
+            counters[i] = 0;
+        return SAI_STATUS_SUCCESS;
+    };
+    sai->mock_queryStatsCapability = [](sai_object_id_t, sai_object_type_t, sai_stat_capability_list_t *) {
+        return SAI_STATUS_FAILURE;
+    };
+    sai->mock_bulkGetStats = [](sai_object_id_t, sai_object_type_t, uint32_t, const sai_object_key_t *, uint32_t, const sai_stat_id_t *, sai_stats_mode_t, sai_status_t *, uint64_t *) {
+        return SAI_STATUS_FAILURE;
+    };
+
+    FlexCounter fc("test_stats_throw", sai, "COUNTERS_DB");
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    fc.addCounterPlugin(values);
+
+    auto resolverThrows = [](sai_object_id_t, sai_object_id_t&) -> bool {
+        throw std::runtime_error("Redis connection lost");
+    };
+    fc.setVidToRidResolver(resolverThrows);
+
+    values.clear();
+    values.emplace_back(FLOW_COUNTER_ID_LIST, "SAI_COUNTER_STAT_PACKETS,SAI_COUNTER_STAT_BYTES");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+    addObjectDone = true;
+
+    usleep(1000 * 1050);
+    EXPECT_EQ(pollGetStatsCount, 0);
+
+    fc.removeCounter(vid);
+}
+
+TEST(FlexCounter, VidToRidResolver_StatsCounter_NoResolverSet_SkipsSaiCall)
+{
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_COUNTER);
+    std::vector<sai_object_id_t> vids = generateOids(1, SAI_OBJECT_TYPE_COUNTER);
+    ASSERT_EQ(vids.size(), 1u);
+    sai_object_id_t vid = vids[0];
+
+    bool addObjectDone = false;
+    int pollGetStatsCount = 0;
+    sai->mock_getStatsExt = [&addObjectDone, &pollGetStatsCount](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, sai_stats_mode_t, uint64_t *counters) {
+        if (addObjectDone)
+            pollGetStatsCount++;
+        for (uint32_t i = 0; i < number_of_counters; i++)
+            counters[i] = 0;
+        return SAI_STATUS_SUCCESS;
+    };
+    sai->mock_getStats = [&addObjectDone, &pollGetStatsCount](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, uint64_t *counters) {
+        if (addObjectDone)
+            pollGetStatsCount++;
+        for (uint32_t i = 0; i < number_of_counters; i++)
+            counters[i] = 0;
+        return SAI_STATUS_SUCCESS;
+    };
+    sai->mock_queryStatsCapability = [](sai_object_id_t, sai_object_type_t, sai_stat_capability_list_t *) {
+        return SAI_STATUS_FAILURE;
+    };
+    sai->mock_bulkGetStats = [](sai_object_id_t, sai_object_type_t, uint32_t, const sai_object_key_t *, uint32_t, const sai_stat_id_t *, sai_stats_mode_t, sai_status_t *, uint64_t *) {
+        return SAI_STATUS_FAILURE;
+    };
+
+    FlexCounter fc("test_stats_no_resolver", sai, "COUNTERS_DB");
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    fc.addCounterPlugin(values);
+
+    values.clear();
+    values.emplace_back(FLOW_COUNTER_ID_LIST, "SAI_COUNTER_STAT_PACKETS,SAI_COUNTER_STAT_BYTES");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+    addObjectDone = true;
+
+    usleep(1000 * 1050);
+    EXPECT_EQ(pollGetStatsCount, 0);
+
+    fc.removeCounter(vid);
+}
+
+TEST(FlexCounter, VidToRidResolver_StatsCounter_ResolverFails_SkipsSaiCall)
+{
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_COUNTER);
+    std::vector<sai_object_id_t> vids = generateOids(1, SAI_OBJECT_TYPE_COUNTER);
+    ASSERT_EQ(vids.size(), 1u);
+    sai_object_id_t vid = vids[0];
+
+    bool addObjectDone = false;
+    int pollGetStatsCount = 0;
+    sai->mock_getStatsExt = [&addObjectDone, &pollGetStatsCount](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, sai_stats_mode_t, uint64_t *counters) {
+        if (addObjectDone)
+            pollGetStatsCount++;
+        for (uint32_t i = 0; i < number_of_counters; i++)
+            counters[i] = 0;
+        return SAI_STATUS_SUCCESS;
+    };
+    sai->mock_getStats = [&addObjectDone, &pollGetStatsCount](sai_object_type_t, sai_object_id_t, uint32_t number_of_counters, const sai_stat_id_t *, uint64_t *counters) {
+        if (addObjectDone)
+            pollGetStatsCount++;
+        for (uint32_t i = 0; i < number_of_counters; i++)
+            counters[i] = 0;
+        return SAI_STATUS_SUCCESS;
+    };
+    sai->mock_queryStatsCapability = [](sai_object_id_t, sai_object_type_t, sai_stat_capability_list_t *) {
+        return SAI_STATUS_FAILURE;
+    };
+    sai->mock_bulkGetStats = [](sai_object_id_t, sai_object_type_t, uint32_t, const sai_object_key_t *, uint32_t, const sai_stat_id_t *, sai_stats_mode_t, sai_status_t *, uint64_t *) {
+        return SAI_STATUS_FAILURE;
+    };
+
+    FlexCounter fc("test_stats_resolver_fail", sai, "COUNTERS_DB");
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    fc.addCounterPlugin(values);
+
+    auto resolverFail = [](sai_object_id_t, sai_object_id_t& rid) {
+        rid = SAI_NULL_OBJECT_ID;
+        return false;
+    };
+    fc.setVidToRidResolver(resolverFail);
+
+    values.clear();
+    values.emplace_back(FLOW_COUNTER_ID_LIST, "SAI_COUNTER_STAT_PACKETS,SAI_COUNTER_STAT_BYTES");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+    addObjectDone = true;
+
+    usleep(1000 * 1050);
+    EXPECT_EQ(pollGetStatsCount, 0);
+
+    fc.removeCounter(vid);
 }

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -2988,3 +2988,134 @@ TEST(FlexCounter, failedPollsCountAndCleanUp)
     removeTimeStamp(keys, countersTable);
     ASSERT_TRUE(keys.empty());
 }
+
+TEST(FlexCounter, VidToRidResolver_WhenResolverThrows_SkipsWithoutCrash)
+{
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_ACL_COUNTER);
+    std::vector<sai_object_id_t> vids = generateOids(1, SAI_OBJECT_TYPE_ACL_COUNTER);
+    ASSERT_EQ(vids.size(), 1u);
+    sai_object_id_t vid = vids[0];
+
+    int getCallCount = 0;
+    sai->mock_get = [&getCallCount](sai_object_type_t, sai_object_id_t, uint32_t, sai_attribute_t *) {
+        getCallCount++;
+        return SAI_STATUS_SUCCESS;
+    };
+
+    FlexCounter fc("test_resolver_throws", sai, "COUNTERS_DB");
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    fc.addCounterPlugin(values);
+
+    auto resolverThrows = [](sai_object_id_t, sai_object_id_t&) -> bool {
+        throw std::runtime_error("Redis connection lost");
+    };
+    fc.setVidToRidResolver(resolverThrows);
+
+    values.clear();
+    values.emplace_back(ACL_COUNTER_ATTR_ID_LIST, "SAI_ACL_COUNTER_ATTR_PACKETS");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+
+    usleep(1000 * 1050);
+    EXPECT_EQ(getCallCount, 0);
+
+    fc.removeCounter(vid);
+}
+
+TEST(FlexCounter, VidToRidResolver_NoResolverSet_SkipsSaiCall)
+{
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_ACL_COUNTER);
+    std::vector<sai_object_id_t> vids = generateOids(1, SAI_OBJECT_TYPE_ACL_COUNTER);
+    ASSERT_EQ(vids.size(), 1u);
+    sai_object_id_t vid = vids[0];
+
+    int getCallCount = 0;
+    sai->mock_get = [&getCallCount](sai_object_type_t, sai_object_id_t, uint32_t, sai_attribute_t *) {
+        getCallCount++;
+        return SAI_STATUS_SUCCESS;
+    };
+
+    FlexCounter fc("test_no_resolver", sai, "COUNTERS_DB");
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    fc.addCounterPlugin(values);
+
+    values.clear();
+    values.emplace_back(ACL_COUNTER_ATTR_ID_LIST, "SAI_ACL_COUNTER_ATTR_PACKETS");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+
+    usleep(1000 * 1050);
+    EXPECT_EQ(getCallCount, 0);
+
+    fc.removeCounter(vid);
+}
+
+TEST(FlexCounter, VidToRidResolver_StatsCounter_WhenRidZero_ResolvesAndPolls)
+{
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_COUNTER);
+    std::vector<sai_object_id_t> vids = generateOids(1, SAI_OBJECT_TYPE_COUNTER);
+    ASSERT_EQ(vids.size(), 1u);
+    sai_object_id_t vid = vids[0];
+    const sai_object_id_t resolvedRid = 0x900000000009999ULL;
+
+    bool pollingPhase = false;
+    sai->mock_getStats = [&pollingPhase, resolvedRid](sai_object_type_t objectType, sai_object_id_t objectId, uint32_t number_of_counters, const sai_stat_id_t *, uint64_t *counters) {
+        EXPECT_EQ(objectType, SAI_OBJECT_TYPE_COUNTER);
+        if (pollingPhase)
+        {
+            EXPECT_EQ(objectId, resolvedRid);
+        }
+        for (uint32_t i = 0; i < number_of_counters; i++)
+            counters[i] = (i + 1) * 500;
+        return SAI_STATUS_SUCCESS;
+    };
+    sai->mock_getStatsExt = [&pollingPhase, resolvedRid](sai_object_type_t, sai_object_id_t objectId, uint32_t number_of_counters, const sai_stat_id_t *, sai_stats_mode_t, uint64_t *counters) {
+        if (pollingPhase)
+        {
+            EXPECT_EQ(objectId, resolvedRid);
+        }
+        for (uint32_t i = 0; i < number_of_counters; i++)
+            counters[i] = (i + 1) * 500;
+        return SAI_STATUS_SUCCESS;
+    };
+    sai->mock_queryStatsCapability = [](sai_object_id_t, sai_object_type_t, sai_stat_capability_list_t *) {
+        return SAI_STATUS_FAILURE;
+    };
+    sai->mock_bulkGetStats = [](sai_object_id_t, sai_object_type_t, uint32_t, const sai_object_key_t *, uint32_t, const sai_stat_id_t *, sai_stats_mode_t, sai_status_t *, uint64_t *) {
+        return SAI_STATUS_FAILURE;
+    };
+
+    FlexCounter fc("test_stats_resolver", sai, "COUNTERS_DB");
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    fc.addCounterPlugin(values);
+
+    auto resolver = [resolvedRid](sai_object_id_t, sai_object_id_t& rid) {
+        rid = resolvedRid;
+        return true;
+    };
+    fc.setVidToRidResolver(resolver);
+
+    values.clear();
+    values.emplace_back(FLOW_COUNTER_ID_LIST, "SAI_COUNTER_STAT_PACKETS,SAI_COUNTER_STAT_BYTES");
+    fc.addCounter(vid, SAI_NULL_OBJECT_ID, values);
+
+    pollingPhase = true;
+    usleep(1000 * 1050);
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::Table countersTable(&db, COUNTERS_TABLE);
+    std::string value;
+    ASSERT_TRUE(countersTable.hget(toOid(vid), "SAI_COUNTER_STAT_PACKETS", value));
+    EXPECT_EQ(value, "500");
+    ASSERT_TRUE(countersTable.hget(toOid(vid), "SAI_COUNTER_STAT_BYTES", value));
+    EXPECT_EQ(value, "1000");
+
+    fc.removeCounter(vid);
+    countersTable.del(toOid(vid));
+}


### PR DESCRIPTION
## Problem Description

Observed on a device with 600+ ACLs.

During warm reboot reconciliation, FLEX COUNTERS are enabled and pushed to syncd at the end of the process. At that time, VIDTORID mapping is still being populated (syncd has not yet finished translating all VIDs to RIDs). Some flex counter entries therefore have RID 0x0 when polling starts. SAI calls with RID 0x0 fail (e.g. SAI_STATUS_INVALID_PARAMETER, -5), and those entries remain in the data structures with RID 0x0, so the same errors repeat every 10 seconds during flex counter polling in syncd. This leads to repeated syncd errors and log noise every poll cycle for the lifetime of those entries, since RID 0x0 is never updated.

**Root cause**: flex counter entries are added and polling starts while VIDTORID is still being built, so some entries have RID 0x0 when polled.

Sample log output:

```
2026 Feb  2 04:24:57.602981 t0-r1-Leaf0 ERR syncd#syncd: :- collectData: Failed to get attr of SAI_OBJECT_TYPE_ACL_COUNTER 0x9000000001f55: -5
2026 Feb  2 04:24:57.603017 t0-r1-Leaf0 ERR syncd#syncd: :- collectData: Failed to get attr of SAI_OBJECT_TYPE_ACL_COUNTER 0x9000000001f57: -5
2026 Feb  2 04:24:57.603067 t0-r1-Leaf0 ERR syncd#syncd: :- collectData: Failed to get attr of SAI_OBJECT_TYPE_ACL_COUNTER 0x9000000001f59: -5
```

## Solution

* During flex counter polling, if an object has RID 0x0, try to resolve VID→RID from Redis (VIDTORID) using the existing translator. If resolution succeeds, update the stored RID and perform the SAI get; otherwise skip the SAI call for that object and retry resolution on the next poll iteration. This avoids calling SAI with RID 0x0 and prevents repeated -5 errors.
* Wire the translator's tryTranslateVidToRid into flex counter collection (Syncd → FlexCounterManager → FlexCounter → counter contexts) so resolution can run during collectData().

Behavior is unchanged once VIDTORID is populated; resolution is only used when RID is 0x0.