### PR TITLE
Port Serdes Attribute Flex Counter Phase 2

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -2011,6 +2011,7 @@ void Meta::meta_generic_validation_post_remove(
 
             case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
+            case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
                 // no special action required
                 break;
 
@@ -3772,6 +3773,10 @@ sai_status_t Meta::meta_generic_validation_create(
                 VALIDATION_LIST(md, value.portsnrlist);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
+                VALIDATION_LIST(md, value.portserdestaps);
+                break;
+
             default:
 
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -4398,6 +4403,10 @@ sai_status_t Meta::meta_generic_validation_set(
             VALIDATION_LIST(md, value.portsnrlist);
             break;
 
+        case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
+            VALIDATION_LIST(md, value.portserdestaps);
+            break;
+
         default:
 
             META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -4794,6 +4803,10 @@ sai_status_t Meta::meta_generic_validation_get(
                 VALIDATION_LIST(md, value.portsnrlist);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
+                VALIDATION_LIST(md, value.portserdestaps);
+                break;
+
             default:
 
                 // acl capability will is more complex since is in/out we need to check stage
@@ -5082,6 +5095,10 @@ void Meta::meta_generic_validation_post_get(
 
             case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
                 VALIDATION_LIST_GET(md, value.portsnrlist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
+                VALIDATION_LIST_GET(md, value.portserdestaps);
                 break;
 
             default:

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -1459,6 +1459,65 @@ std::string sai_serialize_number_list(
     return sai_serialize_list(list, countOnly, [&](decltype(*list.list)& item) { return sai_serialize_number(item, hex);} );
 }
 
+
+/**
+ *   @brief Converts the seralized uint32 list string to json dict string
+ *
+ *   Parse input "count:v1,v2,v3" and convert to JSON {"0":v1, "1":v2, "2":v3}
+ *
+ *   @param uint32_list_string seralized uint32 list string.
+ *   @return std::string in json dict format.
+ */
+std::string sai_serialize_uint32_list_to_json_dict(
+        _In_ const std::string& uint32_list_string)
+{
+    SWSS_LOG_ENTER();
+
+
+    size_t colon_pos = uint32_list_string.find(':');
+    if (colon_pos == std::string::npos)
+    {
+        SWSS_LOG_ERROR("Invalid uint32 list format: missing colon separator");
+        return "{}";
+    }
+
+    std::string values_str = uint32_list_string.substr(colon_pos + 1);
+
+    if (values_str.empty())
+    {
+        return "{}";
+    }
+
+    json j = json::object();
+
+    std::istringstream iss(values_str);
+    std::string value;
+    uint32_t index = 0;
+
+    while (std::getline(iss, value, ','))
+    {
+        // Trim whitespace
+        value.erase(0, value.find_first_not_of(" \t"));
+        value.erase(value.find_last_not_of(" \t") + 1);
+
+        if (!value.empty())
+        {
+            try
+            {
+                uint32_t val = static_cast<uint32_t>(std::stoul(value));
+                j[std::to_string(index)] = val;
+                index++;
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_ERROR("Failed to parse value '%s': %s", value.c_str(), e.what());
+            }
+        }
+    }
+
+    return j.dump();
+}
+
 static json sai_serialize_qos_map_params(
         _In_ const sai_qos_map_params_t& params)
 {
@@ -1701,48 +1760,51 @@ std::string sai_serialize_taps_list(
         return sai_serialize_number(port_serdes_taps_list.count);
     }
 
+    json j = json::object();
+
     if (port_serdes_taps_list.list == NULL || port_serdes_taps_list.count == 0)
     {
-        return "[]";
+        return j.dump();
     }
 
-    std::string result = "[";
+    // Create lane-centric format: {"0": [{tap0: val}, {tap1: val}, ...], "1": [...], ...}
+    uint32_t lane_idx = 0;
 
-    for (uint32_t tap_idx = 0; tap_idx < port_serdes_taps_list.count; ++tap_idx)
+    while (true)
     {
-        const sai_s32_list_t& tap_lanes = port_serdes_taps_list.list[tap_idx];
+        json lane_taps_array = json::array();
+        bool found_any_tap = false;
 
-        result += "{";
-
-        // Add tap index with "tap" prefix (tap1, tap2, etc.)
-        result += "tap" + sai_serialize_number(tap_idx + 1) + ":";
-
-        // Only add lane values if count > 0 and list is not null
-        if (tap_lanes.list != NULL && tap_lanes.count > 0)
+        // For this lane, collect all tap values
+        for (uint32_t tap_idx = 0; tap_idx < port_serdes_taps_list.count; ++tap_idx)
         {
-            for (uint32_t lane_idx = 0; lane_idx < tap_lanes.count; ++lane_idx)
-            {
-                result += sai_serialize_number(tap_lanes.list[lane_idx]);
+            const sai_s32_list_t& tap_lanes = port_serdes_taps_list.list[tap_idx];
 
-                if (lane_idx != tap_lanes.count - 1)
-                {
-                    result += ",";
-                }
+            if (tap_lanes.list != NULL && lane_idx < tap_lanes.count)
+            {
+                json tap_obj = json::object();
+                // Use the current position in lane_taps_array for sequential tap numbering
+                std::string tap_key = "tap" + std::to_string(lane_taps_array.size());
+                tap_obj[tap_key] = tap_lanes.list[lane_idx];
+                lane_taps_array.push_back(tap_obj);
+                found_any_tap = true;
             }
         }
-        // If count is 0 or list is NULL, we just have "index:" with no values
 
-        result += "}";
-
-        if (tap_idx != port_serdes_taps_list.count - 1)
+        // If no taps were found for this lane, we're done
+        if (!found_any_tap)
         {
-            result += ",";
+            break;
         }
+
+        // Add this lane's taps to the result
+        std::string lane_key = std::to_string(lane_idx);
+        j[lane_key] = lane_taps_array;
+
+        lane_idx++;
     }
 
-    result += "]";
-
-    return result;
+    return j.dump();
 }
 
 template <typename T>
@@ -4562,49 +4624,88 @@ void sai_deserialize_taps_list(
         return;
     }
 
-    // Handle empty list "[]"
-    if (s == "[]")
+    try
     {
-        port_serdes_taps_list.count = 0;
-        port_serdes_taps_list.list = NULL;
-        return;
-    }
+        json j = json::parse(s);
 
-    // Parse format: [{tap1:v1,v2,...},{tap2:v1,v2,...},...]
-    // Count taps by counting ':' (each tap has exactly one colon)
-    uint32_t tap_count = static_cast<uint32_t>(std::count(s.begin(), s.end(), ':'));
-
-    port_serdes_taps_list.count = tap_count;
-    port_serdes_taps_list.list = sai_alloc_n_of_ptr_type(tap_count, port_serdes_taps_list.list);
-
-    // parse each tap
-    size_t tap_idx = 0;
-    size_t pos = 1;
-
-    while (pos < s.length() - 1 && tap_idx < tap_count)
-    {
-        if (s[pos] == '{')
+        if (j.empty() || !j.is_object())
         {
-            size_t end = s.find('}', pos);
-            size_t colon = s.find(':', pos);
+            port_serdes_taps_list.count = 0;
+            port_serdes_taps_list.list = NULL;
+            return;
+        }
 
-            // Extract lane values after colon
-            std::string vals = s.substr(colon + 1, end - colon - 1);
-            auto tokens = vals.empty() ? std::vector<std::string>() : swss::tokenize(vals, ',');
+        // Get lane count
+        uint32_t lane_count = static_cast<uint32_t>(j.size());
 
-            port_serdes_taps_list.list[tap_idx].count = static_cast<uint32_t>(tokens.size());
-            port_serdes_taps_list.list[tap_idx].list = tokens.empty() ? NULL :
-                sai_alloc_n_of_ptr_type(tokens.size(), port_serdes_taps_list.list[tap_idx].list);
+        // Use a vector to collect all taps dynamically
+        std::vector<std::vector<int32_t>> all_taps;
 
-            for (size_t lane_idx = 0; lane_idx < tokens.size(); lane_idx++)
+        uint32_t tap_idx = 0;
+        while (true)
+        {
+            std::vector<int32_t> tap_vec;
+
+            // Iterate through all lanes to get tap_idx'th tap value
+            for (uint32_t i = 0; i < lane_count; ++i)
             {
-                sai_deserialize_number(tokens[lane_idx], port_serdes_taps_list.list[tap_idx].list[lane_idx]);
+                std::string lane_key = std::to_string(i);
+                std::string tap_key = "tap" + std::to_string(tap_idx);
+
+                if (j.contains(lane_key) && j[lane_key].is_array() && tap_idx < j[lane_key].size())
+                {
+                    const json& tap_obj = j[lane_key][tap_idx];
+
+                    if (tap_obj.is_object() && tap_obj.contains(tap_key))
+                    {
+                        tap_vec.push_back(tap_obj[tap_key].get<int32_t>());
+                    }
+                }
             }
 
+            // If no values were found for this tap, we're done
+            if (tap_vec.empty())
+            {
+                break;
+            }
+
+            // Store this tap's values
+            all_taps.push_back(tap_vec);
             tap_idx++;
-            pos = end + 2;  // Skip },
         }
-        else pos++;
+
+        // Now allocate the final data structure
+        port_serdes_taps_list.count = static_cast<uint32_t>(all_taps.size());
+        if (port_serdes_taps_list.count == 0)
+        {
+            port_serdes_taps_list.list = NULL;
+            return;
+        }
+
+        port_serdes_taps_list.list = sai_alloc_n_of_ptr_type(port_serdes_taps_list.count, port_serdes_taps_list.list);
+
+        for (uint32_t i = 0; i < all_taps.size(); ++i)
+        {
+            port_serdes_taps_list.list[i].count = static_cast<uint32_t>(all_taps[i].size());
+            port_serdes_taps_list.list[i].list = sai_alloc_n_of_ptr_type(all_taps[i].size(), port_serdes_taps_list.list[i].list);
+
+            for (uint32_t lane_val_idx = 0; lane_val_idx < all_taps[i].size(); ++lane_val_idx)
+            {
+                port_serdes_taps_list.list[i].list[lane_val_idx] = all_taps[i][lane_val_idx];
+            }
+        }
+    }
+    catch (const json::parse_error& e)
+    {
+        SWSS_LOG_ERROR("JSON parse error in sai_deserialize_taps_list: %s", e.what());
+        port_serdes_taps_list.count = 0;
+        port_serdes_taps_list.list = NULL;
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Error in sai_deserialize_taps_list: %s", e.what());
+        port_serdes_taps_list.count = 0;
+        port_serdes_taps_list.list = NULL;
     }
 }
 

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -8,6 +8,7 @@
 #include <inttypes.h>
 #include <vector>
 #include <climits>
+#include <algorithm>
 #include <unordered_map>
 
 #include <arpa/inet.h>
@@ -1059,6 +1060,13 @@ std::string sai_serialize_port_attr(_In_ const sai_port_attr_t port_attr)
     return sai_serialize_enum(port_attr, &sai_metadata_enum_sai_port_attr_t);
 }
 
+std::string sai_serialize_port_serdes_attr(_In_ const sai_port_serdes_attr_t port_serdes_attr)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_enum(port_serdes_attr, &sai_metadata_enum_sai_port_serdes_attr_t);
+}
+
 std::string sai_serialize_port_stat(
         _In_ const sai_port_stat_t counter)
 {
@@ -1682,6 +1690,61 @@ std::string sai_serialize_port_snr_list(
     return j.dump();
 }
 
+std::string sai_serialize_taps_list(
+        _In_ const sai_taps_list_t& port_serdes_taps_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    if (countOnly)
+    {
+        return sai_serialize_number(port_serdes_taps_list.count);
+    }
+
+    if (port_serdes_taps_list.list == NULL || port_serdes_taps_list.count == 0)
+    {
+        return "[]";
+    }
+
+    std::string result = "[";
+
+    for (uint32_t tap_idx = 0; tap_idx < port_serdes_taps_list.count; ++tap_idx)
+    {
+        const sai_s32_list_t& tap_lanes = port_serdes_taps_list.list[tap_idx];
+
+        result += "{";
+
+        // Add tap index with "tap" prefix (tap1, tap2, etc.)
+        result += "tap" + sai_serialize_number(tap_idx + 1) + ":";
+
+        // Only add lane values if count > 0 and list is not null
+        if (tap_lanes.list != NULL && tap_lanes.count > 0)
+        {
+            for (uint32_t lane_idx = 0; lane_idx < tap_lanes.count; ++lane_idx)
+            {
+                result += sai_serialize_number(tap_lanes.list[lane_idx]);
+
+                if (lane_idx != tap_lanes.count - 1)
+                {
+                    result += ",";
+                }
+            }
+        }
+        // If count is 0 or list is NULL, we just have "index:" with no values
+
+        result += "}";
+
+        if (tap_idx != port_serdes_taps_list.count - 1)
+        {
+            result += ",";
+        }
+    }
+
+    result += "]";
+
+    return result;
+}
+
 template <typename T>
 std::string sai_serialize_range(
         _In_ const T& range)
@@ -2192,6 +2255,9 @@ std::string sai_serialize_attr_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             return sai_serialize_port_snr_list(attr.value.portsnrlist, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
+            return sai_serialize_taps_list(attr.value.portserdestaps, countOnly);
 
 //        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
 //            return sai_serialize_number_list(attr.value.u16list, countOnly);
@@ -4483,6 +4549,65 @@ void sai_deserialize_port_snr_list(
     }
 }
 
+void sai_deserialize_taps_list(
+        _In_ const std::string& s,
+        _Out_ sai_taps_list_t& port_serdes_taps_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    if (countOnly)
+    {
+        sai_deserialize_number(s, port_serdes_taps_list.count);
+        return;
+    }
+
+    // Handle empty list "[]"
+    if (s == "[]")
+    {
+        port_serdes_taps_list.count = 0;
+        port_serdes_taps_list.list = NULL;
+        return;
+    }
+
+    // Parse format: [{tap1:v1,v2,...},{tap2:v1,v2,...},...]
+    // Count taps by counting ':' (each tap has exactly one colon)
+    uint32_t tap_count = static_cast<uint32_t>(std::count(s.begin(), s.end(), ':'));
+
+    port_serdes_taps_list.count = tap_count;
+    port_serdes_taps_list.list = sai_alloc_n_of_ptr_type(tap_count, port_serdes_taps_list.list);
+
+    // parse each tap
+    size_t tap_idx = 0;
+    size_t pos = 1;
+
+    while (pos < s.length() - 1 && tap_idx < tap_count)
+    {
+        if (s[pos] == '{')
+        {
+            size_t end = s.find('}', pos);
+            size_t colon = s.find(':', pos);
+
+            // Extract lane values after colon
+            std::string vals = s.substr(colon + 1, end - colon - 1);
+            auto tokens = vals.empty() ? std::vector<std::string>() : swss::tokenize(vals, ',');
+
+            port_serdes_taps_list.list[tap_idx].count = static_cast<uint32_t>(tokens.size());
+            port_serdes_taps_list.list[tap_idx].list = tokens.empty() ? NULL :
+                sai_alloc_n_of_ptr_type(tokens.size(), port_serdes_taps_list.list[tap_idx].list);
+
+            for (size_t lane_idx = 0; lane_idx < tokens.size(); lane_idx++)
+            {
+                sai_deserialize_number(tokens[lane_idx], port_serdes_taps_list.list[tap_idx].list[lane_idx]);
+            }
+
+            tap_idx++;
+            pos = end + 2;  // Skip },
+        }
+        else pos++;
+    }
+}
+
 static void sai_deserialize_system_port_cfg_list_item(
         _In_ const json& j,
         _Out_ sai_system_port_config_t& sysportconfig)
@@ -4619,6 +4744,9 @@ void sai_deserialize_attr_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             return sai_deserialize_port_snr_list(s, attr.value.portsnrlist, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
+            return sai_deserialize_taps_list(s, attr.value.portserdestaps, countOnly);
 
 //        case SAI_ATTR_VALUE_TYPE_UINT16_LIST:
 //            return sai_deserialize_number_list(s, attr.value.u16list, countOnly);
@@ -4794,6 +4922,15 @@ void sai_deserialize_port_attr(
     SWSS_LOG_ENTER();
 
     sai_deserialize_enum(s, &sai_metadata_enum_sai_port_attr_t, (int32_t&)port_attr);
+}
+
+void sai_deserialize_port_serdes_attr(
+      _In_ const std::string& s,
+      _Out_ sai_port_serdes_attr_t& port_serdes_attr)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_enum(s, &sai_metadata_enum_sai_port_serdes_attr_t, (int32_t&)port_serdes_attr);
 }
 
 void sai_deserialize_l2mc_entry_type(
@@ -6061,6 +6198,10 @@ void sai_deserialize_free_attribute_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             sai_free_list(attr.value.portsnrlist);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
+            sai_free_list(attr.value.portserdestaps);
             break;
 
             /* ACL FIELD DATA */

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -1461,11 +1461,11 @@ std::string sai_serialize_number_list(
 
 
 /**
- *   @brief Converts the seralized uint32 list string to json dict string
+ *   @brief Converts the serialized uint32 list string to json dict string
  *
  *   Parse input "count:v1,v2,v3" and convert to JSON {"0":v1, "1":v2, "2":v3}
  *
- *   @param uint32_list_string seralized uint32 list string.
+ *   @param uint32_list_string serialized uint32 list string.
  *   @return std::string in json dict format.
  */
 std::string sai_serialize_uint32_list_to_json_dict(
@@ -1506,12 +1506,12 @@ std::string sai_serialize_uint32_list_to_json_dict(
             {
                 uint32_t val = static_cast<uint32_t>(std::stoul(value));
                 j[std::to_string(index)] = val;
-                index++;
             }
             catch (const std::exception& e)
             {
                 SWSS_LOG_ERROR("Failed to parse value '%s': %s", value.c_str(), e.what());
             }
+            index++;
         }
     }
 
@@ -1767,41 +1767,40 @@ std::string sai_serialize_taps_list(
         return j.dump();
     }
 
-    // Create lane-centric format: {"0": [{tap0: val}, {tap1: val}, ...], "1": [...], ...}
-    uint32_t lane_idx = 0;
+    // Get the number of lanes from the first tap's inner list
+    // All inner lists should have the same size
+    const sai_s32_list_t& first_tap = port_serdes_taps_list.list[0];
 
-    while (true)
+    if (first_tap.list == NULL || first_tap.count == 0)
+    {
+        return j.dump();
+    }
+
+    uint32_t num_lanes = first_tap.count;
+    uint32_t num_taps = port_serdes_taps_list.count;
+
+    // Create lane-centric format: {"0": [{"tap0": val}, {"tap1": val}, ...], "1": [...], ...}
+    for (uint32_t lane_idx = 0; lane_idx < num_lanes; ++lane_idx)
     {
         json lane_taps_array = json::array();
-        bool found_any_tap = false;
 
         // For this lane, collect all tap values
-        for (uint32_t tap_idx = 0; tap_idx < port_serdes_taps_list.count; ++tap_idx)
+        for (uint32_t tap_idx = 0; tap_idx < num_taps; ++tap_idx)
         {
             const sai_s32_list_t& tap_lanes = port_serdes_taps_list.list[tap_idx];
 
             if (tap_lanes.list != NULL && lane_idx < tap_lanes.count)
             {
                 json tap_obj = json::object();
-                // Use the current position in lane_taps_array for sequential tap numbering
-                std::string tap_key = "tap" + std::to_string(lane_taps_array.size());
+                std::string tap_key = "tap" + std::to_string(tap_idx);
                 tap_obj[tap_key] = tap_lanes.list[lane_idx];
                 lane_taps_array.push_back(tap_obj);
-                found_any_tap = true;
             }
-        }
-
-        // If no taps were found for this lane, we're done
-        if (!found_any_tap)
-        {
-            break;
         }
 
         // Add this lane's taps to the result
         std::string lane_key = std::to_string(lane_idx);
         j[lane_key] = lane_taps_array;
-
-        lane_idx++;
     }
 
     return j.dump();
@@ -4638,19 +4637,36 @@ void sai_deserialize_taps_list(
         // Get lane count
         uint32_t lane_count = static_cast<uint32_t>(j.size());
 
-        // Use a vector to collect all taps dynamically
-        std::vector<std::vector<int32_t>> all_taps;
-
-        uint32_t tap_idx = 0;
-        while (true)
+        // Get tap count from the first lane's array
+        // All lanes should have the same number of taps
+        if (!j.contains("0") || !j["0"].is_array() || j["0"].empty())
         {
-            std::vector<int32_t> tap_vec;
+            port_serdes_taps_list.count = 0;
+            port_serdes_taps_list.list = NULL;
+            return;
+        }
 
-            // Iterate through all lanes to get tap_idx'th tap value
-            for (uint32_t i = 0; i < lane_count; ++i)
+        uint32_t tap_count = static_cast<uint32_t>(j["0"].size());
+
+        // Allocate the structure directly
+        port_serdes_taps_list.count = tap_count;
+        port_serdes_taps_list.list = sai_alloc_n_of_ptr_type(tap_count, port_serdes_taps_list.list);
+
+        // For each tap, allocate its lane list
+        for (uint32_t tap_idx = 0; tap_idx < tap_count; ++tap_idx)
+        {
+            port_serdes_taps_list.list[tap_idx].count = lane_count;
+            port_serdes_taps_list.list[tap_idx].list = sai_alloc_n_of_ptr_type(lane_count, port_serdes_taps_list.list[tap_idx].list);
+        }
+
+        // Now fill in the values
+        for (uint32_t tap_idx = 0; tap_idx < tap_count; ++tap_idx)
+        {
+            std::string tap_key = "tap" + std::to_string(tap_idx);
+
+            for (uint32_t lane_idx = 0; lane_idx < lane_count; ++lane_idx)
             {
-                std::string lane_key = std::to_string(i);
-                std::string tap_key = "tap" + std::to_string(tap_idx);
+                std::string lane_key = std::to_string(lane_idx);
 
                 if (j.contains(lane_key) && j[lane_key].is_array() && tap_idx < j[lane_key].size())
                 {
@@ -4658,40 +4674,9 @@ void sai_deserialize_taps_list(
 
                     if (tap_obj.is_object() && tap_obj.contains(tap_key))
                     {
-                        tap_vec.push_back(tap_obj[tap_key].get<int32_t>());
+                        port_serdes_taps_list.list[tap_idx].list[lane_idx] = tap_obj[tap_key].get<int32_t>();
                     }
                 }
-            }
-
-            // If no values were found for this tap, we're done
-            if (tap_vec.empty())
-            {
-                break;
-            }
-
-            // Store this tap's values
-            all_taps.push_back(tap_vec);
-            tap_idx++;
-        }
-
-        // Now allocate the final data structure
-        port_serdes_taps_list.count = static_cast<uint32_t>(all_taps.size());
-        if (port_serdes_taps_list.count == 0)
-        {
-            port_serdes_taps_list.list = NULL;
-            return;
-        }
-
-        port_serdes_taps_list.list = sai_alloc_n_of_ptr_type(port_serdes_taps_list.count, port_serdes_taps_list.list);
-
-        for (uint32_t i = 0; i < all_taps.size(); ++i)
-        {
-            port_serdes_taps_list.list[i].count = static_cast<uint32_t>(all_taps[i].size());
-            port_serdes_taps_list.list[i].list = sai_alloc_n_of_ptr_type(all_taps[i].size(), port_serdes_taps_list.list[i].list);
-
-            for (uint32_t lane_val_idx = 0; lane_val_idx < all_taps[i].size(); ++lane_val_idx)
-            {
-                port_serdes_taps_list.list[i].list[lane_val_idx] = all_taps[i][lane_val_idx];
             }
         }
     }

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -268,6 +268,9 @@ std::string sai_serialize_number_list(
         _In_ bool countOnly,
         _In_ bool hex = false);
 
+std::string sai_serialize_uint32_list_to_json_dict(
+        _In_ const std::string& uint32_list_string);
+
 std::string sai_serialize_attr_id(
         _In_ const sai_attr_metadata_t& meta);
 

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -32,6 +32,8 @@ sai_status_t transfer_attributes(
 
 std::string sai_serialize_port_attr(_In_ const sai_port_attr_t port_attr);
 
+std::string sai_serialize_port_serdes_attr(_In_ const sai_port_serdes_attr_t port_serdes_attr);
+
 std::string sai_serialize_fdb_event(
         _In_ sai_fdb_event_t event);
 
@@ -322,6 +324,10 @@ std::string sai_serialize_port_snr_list(
         _In_ const sai_port_snr_list_t& snr_list,
         _In_ bool countOnly);
 
+std::string sai_serialize_taps_list(
+        _In_ const sai_taps_list_t& port_serdes_taps_list,
+        _In_ bool countOnly);
+
 // serialize notifications
 
 std::string sai_serialize_fdb_event_ntf(
@@ -464,6 +470,10 @@ void sai_deserialize_ipmc_entry_type(
 void sai_deserialize_port_attr(
       _In_ const std::string& s,
       _Out_ sai_port_attr_t& port_attr);
+
+void sai_deserialize_port_serdes_attr(
+      _In_ const std::string& s,
+      _Out_ sai_port_serdes_attr_t& port_serdes_attr);
 
 void sai_deserialize_l2mc_entry_type(
         _In_ const std::string& s,
@@ -780,6 +790,11 @@ void sai_deserialize_stats_st_capability_list(
 void sai_deserialize_port_snr_list(
         _In_ const std::string& s,
         _Out_ sai_port_snr_list_t& snr_list,
+        _In_ bool countOnly);
+
+void sai_deserialize_taps_list(
+        _In_ const std::string& s,
+        _Out_ sai_taps_list_t& port_serdes_taps_list,
         _In_ bool countOnly);
 
 void sai_deserialize_switch_macsec_post_status(

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2539,6 +2539,12 @@ public:
 
                 std::string attr_value = sai_serialize_attr_value(*meta, attrs[i]);
 
+                // Special formatting for RX_VGA
+                if (attrs[i].id == SAI_PORT_SERDES_ATTR_RX_VGA)
+                {
+                    attr_value = sai_serialize_uint32_list_to_json_dict(attr_value);
+                }
+
                 // Use hset to set each field individually to avoid race conditions
                 // with PortPhyAttrContext writing to the same table
                 portPhyAttrTable.hset(port_vid_str, it->second, attr_value, "");

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -25,6 +25,7 @@ using json = nlohmann::json;
 
 static const std::string COUNTER_TYPE_PORT = "Port Counter";
 static const std::string ATTR_TYPE_PORT_PHY_ATTR = "Port Phy Attributes";
+static const std::string ATTR_TYPE_PORT_PHY_SERDES_ATTR = "Port Phy Serdes Attributes";
 static const std::string COUNTER_TYPE_PORT_DEBUG = "Port Debug Counter";
 static const std::string COUNTER_TYPE_QUEUE = "Queue Counter";
 static const std::string COUNTER_TYPE_PG = "Priority Group Counter";
@@ -73,6 +74,7 @@ const std::map<std::string, std::string> FlexCounter::m_plugIn2CounterType = {
 const std::map<std::tuple<sai_object_type_t, std::string>, std::string> FlexCounter::m_objectTypeField2CounterType = {
     {{SAI_OBJECT_TYPE_PORT, PORT_COUNTER_ID_LIST}, COUNTER_TYPE_PORT},
     {{SAI_OBJECT_TYPE_PORT, PORT_PHY_ATTR_ID_LIST}, ATTR_TYPE_PORT_PHY_ATTR},
+    {{SAI_OBJECT_TYPE_PORT_SERDES, PORT_PHY_SERDES_ATTR_ID_LIST}, ATTR_TYPE_PORT_PHY_SERDES_ATTR},
     {{SAI_OBJECT_TYPE_PORT, PORT_DEBUG_COUNTER_ID_LIST}, COUNTER_TYPE_PORT_DEBUG},
     {{SAI_OBJECT_TYPE_QUEUE, QUEUE_COUNTER_ID_LIST}, COUNTER_TYPE_QUEUE},
     {{SAI_OBJECT_TYPE_QUEUE, QUEUE_ATTR_ID_LIST}, ATTR_TYPE_QUEUE},
@@ -1999,8 +2001,8 @@ public:
                 continue;
             }
 
-            std::vector<swss::FieldValueTuple> values;
-            values.reserve(attrIds.size());
+            // Store in PORT_PHY_ATTR table using VID as key
+            std::string vid_str = sai_serialize_object_id(vid);
 
             for (size_t i = 0; i != attrIds.size(); i++)
             {
@@ -2034,12 +2036,10 @@ public:
                     // Standard serialization for SNR and any other attributes
                     attr_value = sai_serialize_attr_value(*meta, attrs[i]);
                 }
-                values.emplace_back(it->second, attr_value);
+                // Use hset to set each field individually to avoid race conditions
+                // with PortSerdesAttrContext writing to the same table
+                portPhyAttrTable.hset(vid_str, it->second, attr_value, "");
             }
-
-            // Store in PORT_PHY_ATTR table using VID as key
-            std::string vid_str = sai_serialize_object_id(vid);
-            portPhyAttrTable.set(vid_str, values, "");
         }
 
         portPhyAttrTable.flush();
@@ -2163,6 +2163,415 @@ const std::unordered_map<sai_port_attr_t, std::string> PortPhyAttrContext::m_att
     {SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK, "pcs_fec_lane_alignment_lock"},
     {SAI_PORT_ATTR_RX_SIGNAL_DETECT, "phy_rx_signal_detect"}
 };
+
+
+
+// Specialized context for PORT_SERDES_ATTR that writes to PORT_PHY_ATTR_TABLE table
+class PortPhySerdesAttrContext : public AttrContext<sai_port_serdes_attr_t, PortPhySerdesAttributeData>
+{
+public:
+    using Base = AttrContext<sai_port_serdes_attr_t, PortPhySerdesAttributeData>;
+
+    typedef CounterIds<sai_port_serdes_attr_t> AttrIdsType;
+
+    PortPhySerdesAttrContext(
+            _In_ const std::string &name,
+            _In_ const std::string &instance,
+            _In_ sai_object_type_t object_type,
+            _In_ sairedis::SaiInterface *vendor_sai,
+            _In_ sai_stats_mode_t &stats_mode,
+            _In_ const std::string &dbCounters):
+        Base(name, instance, object_type, vendor_sai, stats_mode),
+        m_dbCounters(dbCounters)
+    {
+        SWSS_LOG_ENTER();
+    }
+
+    bool getPortRidFromPortSerdesRid(sai_object_id_t port_serdes_rid, sai_object_id_t &port_rid)
+    {
+        sai_attribute_t attr;
+        attr.id = SAI_PORT_SERDES_ATTR_PORT_ID;
+        sai_status_t status = Base::m_vendorSai->get(Base::m_objectType, port_serdes_rid, 1, &attr);
+
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            port_rid = attr.value.oid;
+            return true;
+        }
+
+        SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to get port RID for port serdes RID:0x%" PRIx64 ", status:%d",
+                      port_serdes_rid, status);
+        return false;
+    }
+
+    bool getPortVidFromPortSerdesVid(sai_object_id_t port_serdes_vid, sai_object_id_t &port_vid)
+    {
+        try
+        {
+            swss::DBConnector db(m_dbCounters, 0);
+            swss::Table portSerdesIdToPortIdTable(&db, "COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP");
+
+            std::string port_serdes_vid_str = sai_serialize_object_id(port_serdes_vid);
+            std::string port_vid_str;
+
+            if (portSerdesIdToPortIdTable.hget("", port_serdes_vid_str, port_vid_str))
+            {
+                sai_deserialize_object_id(port_vid_str, port_vid);
+                return true;
+            }
+
+            SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: port_serdes_vid:0x%" PRIx64 " not found in COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP",
+                         port_serdes_vid);
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Exception while querying COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP: %s", e.what());
+        }
+
+        return false;
+    }
+
+    void updatePortSerdesIdToPortIdMap(sai_object_id_t port_serdes_rid, sai_object_id_t port_serdes_vid)
+    {
+        sai_object_id_t port_rid = SAI_NULL_OBJECT_ID;
+        sai_object_id_t port_vid = SAI_NULL_OBJECT_ID;
+
+        if (getPortRidFromPortSerdesRid(port_serdes_rid, port_rid) &&
+            getPortVidFromPortSerdesVid(port_serdes_vid, port_vid))
+        {
+            m_portSerdesIdToPortIdMap[port_serdes_rid] = PortIdInfo(port_rid, port_vid);
+            SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Mapped port_serdes_rid:0x%" PRIx64 " -> port_rid:0x%" PRIx64 ", port_vid:0x%" PRIx64,
+                          port_serdes_rid, port_rid, port_vid);
+        }
+        else
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to map port_serdes_rid:0x%" PRIx64 " - could not retrieve port RID or VID", port_serdes_rid);
+            m_portSerdesIdToPortIdMap.erase(port_serdes_rid);
+        }
+    }
+
+    void updatePortSerdesIdToLaneCountMap(sai_object_id_t port_serdes_rid)
+    {
+        sai_object_id_t port_rid;
+        uint32_t laneCount;
+        sai_attribute_t attr;
+
+        auto it = m_portSerdesIdToPortIdMap.find(port_serdes_rid);
+        if (it == m_portSerdesIdToPortIdMap.end())
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port serdes RID:0x%" PRIx64 " has no associated port rid/vid mapping", port_serdes_rid);
+            return;
+        }
+        port_rid = it->second.port_rid;
+
+        attr.id = SAI_PORT_ATTR_HW_LANE_LIST;
+        attr.value.u32list.count = 0;        // Query with count=0 to get the actual lane count
+        attr.value.u32list.list = nullptr;
+        sai_status_t status = Base::m_vendorSai->get(SAI_OBJECT_TYPE_PORT, port_rid, 1, &attr);
+
+        if (status != SAI_STATUS_BUFFER_OVERFLOW)
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to get hardware lane count for port RID:0x%" PRIx64 ", status:%d",
+                          port_rid, status);
+            return;
+        }
+
+        laneCount = attr.value.u32list.count;
+
+        // Store the lane count in the map
+        m_portSerdesIdToLaneCountMap[port_serdes_rid] = laneCount;
+        SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Stored lane count for port_serdes_rid:0x%" PRIx64 " = %u lanes",
+                      port_serdes_rid, laneCount);
+    }
+
+    void updatePortSerdesTapsCountMap(sai_object_id_t port_serdes_rid)
+    {
+        std::vector<sai_port_serdes_attr_t> countAttrs = {
+            SAI_PORT_SERDES_ATTR_TX_FIR_COUNT
+            // enable the below attrs when implemented.
+            //SAI_PORT_SERDES_ATTR_RX_FFE_COUNT,
+            //SAI_PORT_SERDES_ATTR_RX_DFE_COUNT
+        };
+
+        for (const auto& attrId : countAttrs)
+        {
+            uint32_t count;
+            sai_attribute_t attr;
+            attr.id = attrId;
+
+            sai_status_t status = Base::m_vendorSai->get(
+                Base::m_objectType,
+                port_serdes_rid,
+                1,
+                &attr);
+
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to get port serdes count attr %s for port_serdes RID:0x%" PRIx64 ", status:%d",
+                              sai_serialize_port_serdes_attr(attrId).c_str(), port_serdes_rid, status);
+                continue;
+            }
+
+            count = attr.value.u32;
+
+            m_portSerdesTapsCountMap[port_serdes_rid][attrId] = count;
+            SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Stored %s for port_serdes_rid:0x%" PRIx64 " = %u",
+                          sai_serialize_port_serdes_attr(attrId).c_str(), port_serdes_rid, count);
+        }
+    }
+
+    void initAttrData(
+        sai_object_id_t rid,
+        sai_attribute_t *attr,
+        PortPhySerdesAttributeData* data)
+    {
+        if (!attr || !data)
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Invalid input params : attr : %p, data : %p", attr, data);
+            return;
+        }
+
+        // Look up lane count from m_portSerdesIdToLaneCountMap
+        auto it = m_portSerdesIdToLaneCountMap.find(rid);
+        if (it == m_portSerdesIdToLaneCountMap.end())
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: port_serdes_rid:0x%" PRIx64 " has no lane count information", rid);
+            return;
+        }
+
+        uint32_t laneCount = it->second;
+        SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Found lane count for port_serdes_rid:0x%" PRIx64 " = %u", rid, laneCount);
+
+        switch (attr->id) {
+            case SAI_PORT_SERDES_ATTR_RX_VGA:
+                data->rxVgaData.resize(laneCount);
+                attr->value.u32list.count = laneCount;
+                attr->value.u32list.list = data->rxVgaData.data();
+                break;
+
+            case SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST:
+            {
+                // Find the TX Fir TAPS count from the map
+                auto count_it = m_portSerdesTapsCountMap.find(rid);
+                if (count_it == m_portSerdesTapsCountMap.end())
+                {
+                 SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: port_serdes_rid:0x%" PRIx64 " has no serdes count attribute information", rid);
+                 break;
+                }
+                auto& attrCountMap = count_it->second;
+                auto tap_it = attrCountMap.find(SAI_PORT_SERDES_ATTR_TX_FIR_COUNT);
+                if (tap_it == attrCountMap.end())
+                {
+                    SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: TX_FIR_COUNT not found for port_serdes_rid:0x%" PRIx64, rid);
+                     break;
+                }
+                uint32_t tapCount = tap_it->second;
+
+                // Resize the memory as per the taps and lane count.
+                // Structure: outer dimension = tapCount, inner dimension = laneCount
+                // sai_taps_list_t.count = number of taps
+                // sai_taps_list_t.list[i] = sai_s32_list_t for tap i
+                // sai_s32_list_t.count = number of lanes
+                // sai_s32_list_t.list[j] = value for lane j
+                data->txFirTapsData.resize(tapCount);
+                data->txFirTapsList.resize(tapCount);
+
+                for (uint32_t i = 0; i < tapCount; i++)
+                {
+                    data->txFirTapsData[i].resize(laneCount);
+                    data->txFirTapsList[i].count = laneCount;
+                    data->txFirTapsList[i].list = data->txFirTapsData[i].data();
+                }
+
+                // Set up the top-level attribute pointer
+                attr->value.portserdestaps.count = tapCount;
+                attr->value.portserdestaps.list = data->txFirTapsList.data();
+                break;
+            }
+
+            default:
+                SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: initAttrData: Unsupported attr-id : %d", attr->id);
+                break;
+        }
+    }
+
+    void addObject(
+            _In_ sai_object_id_t vid,
+            _In_ sai_object_id_t rid,
+            _In_ const std::vector<std::string> &idStrings,
+            _In_ const std::string &per_object_stats_mode) override
+    {
+        SWSS_LOG_ENTER();
+
+        SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Adding port serdes object VID 0x%" PRIx64 ", RID 0x%" PRIx64 " with %zu attributes",
+                       vid, rid, idStrings.size());
+
+        std::vector<sai_port_serdes_attr_t> attrIds;
+
+        for (const auto &str : idStrings)
+        {
+            sai_port_serdes_attr_t attr;
+            sai_deserialize_port_serdes_attr(str, attr);
+            attrIds.push_back(attr);
+        }
+
+        auto attr_ids = std::make_shared<AttrIdsType>(rid, attrIds);
+        auto it = Base::m_objectIdsMap.find(vid);
+        if (it != Base::m_objectIdsMap.end())
+        {
+            it->second->counter_ids = attrIds;
+        }
+        else
+        {
+            Base::m_objectIdsMap.emplace(vid, attr_ids);
+        }
+
+        // update member maps
+        updatePortSerdesIdToPortIdMap(rid, vid);
+        updatePortSerdesIdToLaneCountMap(rid);
+        updatePortSerdesTapsCountMap(rid);
+    }
+
+    void removeObject(_In_ sai_object_id_t vid) override
+    {
+        SWSS_LOG_ENTER();
+
+        auto it = Base::m_objectIdsMap.find(vid);
+        if (it != Base::m_objectIdsMap.end())
+        {
+            sai_object_id_t port_serdes_rid = it->second->rid;
+
+            // Clean up m_portSerdesIdToLaneCountMap
+            auto lane_it = m_portSerdesIdToLaneCountMap.find(port_serdes_rid);
+            if (lane_it != m_portSerdesIdToLaneCountMap.end())
+            {
+                SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Removing port_serdes RID:0x%" PRIx64 " from m_portSerdesIdToLaneCountMap", port_serdes_rid);
+                m_portSerdesIdToLaneCountMap.erase(lane_it);
+            }
+
+            // Clean up m_portSerdesIdToPortIdMap
+            auto serdes_it = m_portSerdesIdToPortIdMap.find(port_serdes_rid);
+            if (serdes_it != m_portSerdesIdToPortIdMap.end())
+            {
+                SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Removing port_serdes RID:0x%" PRIx64 " from m_portSerdesIdToPortIdMap", port_serdes_rid);
+                m_portSerdesIdToPortIdMap.erase(serdes_it);
+            }
+
+            // Clean up m_portSerdesTapsCountMap
+            auto count_it = m_portSerdesTapsCountMap.find(port_serdes_rid);
+            if (count_it != m_portSerdesTapsCountMap.end())
+            {
+                SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Removing port_serdes RID:0x%" PRIx64 " from m_portSerdesTapsCountMap", port_serdes_rid);
+                m_portSerdesTapsCountMap.erase(count_it);
+            }
+        }
+
+        // Call base class to remove from m_objectIdsMap
+        Base::removeObject(vid);
+    }
+
+    void collectData(_In_ swss::Table &countersTable) override
+    {
+        SWSS_LOG_ENTER();
+
+        // Collected port phy serdes attrs data will be written to PORT_PHY_ATTR_TABLE (shared with port phy attrs)
+        swss::DBConnector db(m_dbCounters, 0);
+        swss::RedisPipeline pipeline(&db);
+        swss::Table portPhyAttrTable(&pipeline, PORT_PHY_ATTR_TABLE, true);
+
+        for (const auto &kv : Base::m_objectIdsMap)
+        {
+            const auto &vid = kv.first;
+            const auto &rid = kv.second->rid;
+            const auto &attrIds = kv.second->counter_ids;
+
+
+            std::vector<sai_attribute_t> attrs(attrIds.size());
+            PortPhySerdesAttributeData attrData;
+
+            SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Collecting %zu port serdes attributes with VID 0x%" PRIx64 ", RID:0x%" PRIx64,
+                           attrIds.size(), vid, rid);
+
+            for (size_t i = 0; i < attrIds.size(); i++)
+            {
+                attrs[i].id = attrIds[i];
+                initAttrData(rid, &attrs[i], &attrData);
+            }
+
+            sai_status_t status = Base::m_vendorSai->get(
+                    Base::m_objectType,
+                    rid,
+                    static_cast<uint32_t>(attrIds.size()),
+                    attrs.data());
+
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to get port serdes attr for VID 0x%" PRIx64 ", status: %d",
+                        vid, status);
+                continue;
+            }
+
+            // Get port_vid from the map using port_serdes_rid
+            auto port_it = m_portSerdesIdToPortIdMap.find(rid);
+            if (port_it == m_portSerdesIdToPortIdMap.end())
+            {
+                SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: Port serdes VID 0x%" PRIx64 " has no associated port mapping", vid);
+                continue;
+            }
+
+            std::string port_vid_str = sai_serialize_object_id(port_it->second.port_vid);
+
+            for (size_t i = 0; i != attrIds.size(); i++)
+            {
+                auto meta = sai_metadata_get_attr_metadata(Base::m_objectType, attrs[i].id);
+                if (!meta)
+                {
+                    SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to get metadata for port serdes attr");
+                    continue;
+                }
+
+                auto it = m_attrAliases.find(attrIds[i]);
+                if (it == m_attrAliases.end())
+                {
+                    SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Unsupported PORT_SERDES_ATTR: %d", attrIds[i]);
+                    continue;
+                }
+
+                std::string attr_value = sai_serialize_attr_value(*meta, attrs[i]);
+
+                // Use hset to set each field individually to avoid race conditions
+                // with PortPhyAttrContext writing to the same table
+                portPhyAttrTable.hset(port_vid_str, it->second, attr_value, "");
+            }
+        }
+
+        portPhyAttrTable.flush();
+    }
+
+private:
+    // Struct to hold both RID and VID for a port
+    struct PortIdInfo
+    {
+        sai_object_id_t port_rid;
+        sai_object_id_t port_vid;
+
+        PortIdInfo() : port_rid(SAI_NULL_OBJECT_ID), port_vid(SAI_NULL_OBJECT_ID) {}
+        PortIdInfo(sai_object_id_t rid, sai_object_id_t vid) : port_rid(rid), port_vid(vid) {}
+    };
+
+    static const std::unordered_map<sai_port_serdes_attr_t, std::string> m_attrAliases;
+
+    std::string m_dbCounters;
+    std::map<sai_object_id_t, PortIdInfo> m_portSerdesIdToPortIdMap;
+    std::map<sai_object_id_t, uint32_t> m_portSerdesIdToLaneCountMap;
+    std::map<sai_object_id_t, std::map<sai_port_serdes_attr_t, uint32_t>> m_portSerdesTapsCountMap;
+};
+
+const std::unordered_map<sai_port_serdes_attr_t, std::string> PortPhySerdesAttrContext::m_attrAliases = {
+    {SAI_PORT_SERDES_ATTR_RX_VGA, "rx_vga"},
+    {SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST, "tx_fir_taps_list"}
+};
+
 
 class DashMeterCounterContext : public BaseCounterContext
 {
@@ -2915,6 +3324,10 @@ std::shared_ptr<BaseCounterContext> FlexCounter::createCounterContext(
     {
         return std::make_shared<PortPhyAttrContext>(context_name, instance, SAI_OBJECT_TYPE_PORT, m_vendorSai.get(), m_statsMode, m_dbCounters);
     }
+    else if (context_name == ATTR_TYPE_PORT_PHY_SERDES_ATTR)
+    {
+        return std::make_shared<PortPhySerdesAttrContext>(context_name, instance, SAI_OBJECT_TYPE_PORT_SERDES, m_vendorSai.get(), m_statsMode, m_dbCounters);
+    }
     else if (context_name == ATTR_TYPE_QUEUE)
     {
         return std::make_shared<AttrContext<sai_queue_attr_t>>(context_name, instance, SAI_OBJECT_TYPE_QUEUE, m_vendorSai.get(), m_statsMode);
@@ -3259,6 +3672,13 @@ void FlexCounter::removeCounter(
         if (hasCounterContext(COUNTER_TYPE_POLICER))
         {
             getCounterContext(COUNTER_TYPE_POLICER)->removeObject(vid);
+        }
+    }
+    else if (objectType == SAI_OBJECT_TYPE_PORT_SERDES)
+    {
+        if (hasCounterContext(ATTR_TYPE_PORT_PHY_SERDES_ATTR))
+        {
+            getCounterContext(ATTR_TYPE_PORT_PHY_SERDES_ATTR)->removeObject(vid);
         }
     }
     else

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2189,6 +2189,8 @@ public:
 
     bool getPortRidFromPortSerdesRid(sai_object_id_t port_serdes_rid, sai_object_id_t &port_rid)
     {
+        SWSS_LOG_ENTER();
+
         sai_attribute_t attr;
         attr.id = SAI_PORT_SERDES_ATTR_PORT_ID;
         sai_status_t status = Base::m_vendorSai->get(Base::m_objectType, port_serdes_rid, 1, &attr);
@@ -2206,6 +2208,8 @@ public:
 
     bool getPortVidFromPortSerdesVid(sai_object_id_t port_serdes_vid, sai_object_id_t &port_vid)
     {
+        SWSS_LOG_ENTER();
+
         try
         {
             swss::DBConnector db(m_dbCounters, 0);
@@ -2233,6 +2237,8 @@ public:
 
     void updatePortSerdesIdToPortIdMap(sai_object_id_t port_serdes_rid, sai_object_id_t port_serdes_vid)
     {
+        SWSS_LOG_ENTER();
+
         sai_object_id_t port_rid = SAI_NULL_OBJECT_ID;
         sai_object_id_t port_vid = SAI_NULL_OBJECT_ID;
 
@@ -2252,6 +2258,8 @@ public:
 
     void updatePortSerdesIdToLaneCountMap(sai_object_id_t port_serdes_rid)
     {
+        SWSS_LOG_ENTER();
+
         sai_object_id_t port_rid;
         uint32_t laneCount;
         sai_attribute_t attr;
@@ -2286,6 +2294,8 @@ public:
 
     void updatePortSerdesTapsCountMap(sai_object_id_t port_serdes_rid)
     {
+        SWSS_LOG_ENTER();
+
         std::vector<sai_port_serdes_attr_t> countAttrs = {
             SAI_PORT_SERDES_ATTR_TX_FIR_COUNT
             // enable the below attrs when implemented.
@@ -2325,6 +2335,8 @@ public:
         sai_attribute_t *attr,
         PortPhySerdesAttributeData* data)
     {
+        SWSS_LOG_ENTER();
+
         if (!attr || !data)
         {
             SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Invalid input params : attr : %p, data : %p", attr, data);

--- a/syncd/FlexCounter.h
+++ b/syncd/FlexCounter.h
@@ -28,6 +28,16 @@ struct PortPhyAttributeData {
     std::vector<sai_port_snr_values_t> rxSnrData;
 };
 
+// Holds data storage for SAI PORT_SERDES attribute API calls
+struct PortPhySerdesAttributeData {
+    // For SAI_PORT_SERDES_ATTR_RX_VGA
+    std::vector<uint32_t> rxVgaData;
+
+    // For SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST
+    std::vector<std::vector<int32_t>> txFirTapsData;
+    std::vector<sai_s32_list_t> txFirTapsList;
+};
+
 namespace syncd
 {
     class BaseCounterContext

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -225,6 +225,7 @@ HSV
 htonl
 http
 https
+hset
 hw
 hwinfo
 ICV
@@ -315,6 +316,7 @@ params
 performTransition
 pfc
 PHY
+phy
 plaintext
 pn
 PN

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -1777,61 +1777,60 @@ TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_nul
 
 TEST(SaiSerialize, sai_serialize_taps_list)
 {
-    sai_attribute_t attr;
-    memset(&attr, 0, sizeof(attr));
+    // Create test data: 3 taps, each with different number of lane values
+    sai_taps_list_t taps_list;
+    sai_s32_list_t taps[3];
 
-    for (size_t idx = 0 ; idx < sai_metadata_attr_sorted_by_id_name_count; ++idx)
-    {
-        auto meta = sai_metadata_attr_sorted_by_id_name[idx];
-        if(meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_TAPS_LIST)
-        {
-            attr.id = meta->attrid;
+    // Tap 0: 4 lanes with values [10, 20, 30, 40]
+    int32_t tap0_values[] = {10, 20, 30, 40};
+    taps[0].count = 4;
+    taps[0].list = tap0_values;
 
-            // Create test data: 3 taps, each with different number of lane values
-            sai_s32_list_t taps[3];
+    // Tap 1: 2 lanes with values [50, 60]
+    int32_t tap1_values[] = {50, 60};
+    taps[1].count = 2;
+    taps[1].list = tap1_values;
 
-            // Tap 0: 4 lanes with values [10, 20, 30, 40]
-            int32_t tap0_values[] = {10, 20, 30, 40};
-            taps[0].count = 4;
-            taps[0].list = tap0_values;
+    // Tap 2: 4 lanes with values [70, 80, 90, 100]
+    int32_t tap2_values[] = {70, 80, 90, 100};
+    taps[2].count = 4;
+    taps[2].list = tap2_values;
 
-            // Tap 1: 2 lanes with values [50, 60]
-            int32_t tap1_values[] = {50, 60};
-            taps[1].count = 2;
-            taps[1].list = tap1_values;
+    taps_list.count = 3;
+    taps_list.list = taps;
 
-            // Tap 2: 4 lanes with values [70, 80, 90, 100]
-            int32_t tap2_values[] = {70, 80, 90, 100};
-            taps[2].count = 4;
-            taps[2].list = tap2_values;
+    // Test normal serialization
+    auto s = sai_serialize_taps_list(taps_list, false);
 
-            attr.value.portserdestaps.count = 3;
-            attr.value.portserdestaps.list = taps;
+    std::string expected = "{\"0\":[{\"tap0\":10},{\"tap1\":50},{\"tap2\":70}],"
+        "\"1\":[{\"tap0\":20},{\"tap1\":60},{\"tap2\":80}],"
+        "\"2\":[{\"tap0\":30},{\"tap1\":90}],\"3\":[{\"tap0\":40},{\"tap1\":100}]}";
 
-            auto s = sai_serialize_attr_value(*meta, attr, false);
+    EXPECT_EQ(s, expected);
 
-            std::string expected = "[{tap1:10,20,30,40},{tap2:50,60},{tap3:70,80,90,100}]";
-            EXPECT_EQ(s, expected);
+    // Test empty taps list
+    taps_list.count = 0;
+    taps_list.list = NULL;
+    s = sai_serialize_taps_list(taps_list, false);
+    EXPECT_EQ(s, "{}");
 
-            // Test empty taps list
-            attr.value.portserdestaps.count = 0;
-            attr.value.portserdestaps.list = NULL;
-            s = sai_serialize_attr_value(*meta, attr, false);
-            EXPECT_EQ(s, "[]");
-
-            // Test countOnly mode
-            attr.value.portserdestaps.count = 3;
-            attr.value.portserdestaps.list = taps;
-            s = sai_serialize_attr_value(*meta, attr, true);
-            EXPECT_EQ(s, "3");
-        }
-    }
+    // Test countOnly mode
+    taps_list.count = 3;
+    taps_list.list = taps;
+    s = sai_serialize_taps_list(taps_list, true);
+    EXPECT_EQ(s, "3");
 }
 
 TEST(SaiSerialize, sai_deserialize_taps_list)
 {
-    // Test normal case with multiple taps
-    std::string json_str = "[{tap1:10,20,30,40},{tap2:50,60},{tap3:70,80,90,100}]";
+    // Input represents (with sequential tap numbering per lane):
+    // Lane 0: tap0=10, tap1=50, tap2=70 (3 taps)
+    // Lane 1: tap0=20, tap1=60, tap2=80 (3 taps)
+    // Lane 2: tap0=30, tap1=90 (2 taps)
+    // Lane 3: tap0=40, tap1=100 (2 taps)
+    std::string json_str = "{\"0\":[{\"tap0\":10},{\"tap1\":50},{\"tap2\":70}],"
+        "\"1\":[{\"tap0\":20},{\"tap1\":60},{\"tap2\":80}],"
+        "\"2\":[{\"tap0\":30},{\"tap1\":90}],\"3\":[{\"tap0\":40},{\"tap1\":100}]}";
 
     sai_taps_list_t taps_list;
     memset(&taps_list, 0, sizeof(taps_list));
@@ -1841,7 +1840,7 @@ TEST(SaiSerialize, sai_deserialize_taps_list)
     EXPECT_EQ(taps_list.count, 3);
     ASSERT_NE(taps_list.list, nullptr);
 
-    // Verify tap 0: 4 lanes
+    // Verify tap 0 (all lane's tap0 values): 4 lanes [10, 20, 30, 40]
     EXPECT_EQ(taps_list.list[0].count, 4);
     ASSERT_NE(taps_list.list[0].list, nullptr);
     EXPECT_EQ(taps_list.list[0].list[0], 10);
@@ -1849,19 +1848,19 @@ TEST(SaiSerialize, sai_deserialize_taps_list)
     EXPECT_EQ(taps_list.list[0].list[2], 30);
     EXPECT_EQ(taps_list.list[0].list[3], 40);
 
-    // Verify tap 1: 2 lanes
-    EXPECT_EQ(taps_list.list[1].count, 2);
+    // Verify tap 1 (all lane's tap1 values): 4 lanes [50, 60, 90, 100]
+    EXPECT_EQ(taps_list.list[1].count, 4);
     ASSERT_NE(taps_list.list[1].list, nullptr);
     EXPECT_EQ(taps_list.list[1].list[0], 50);
     EXPECT_EQ(taps_list.list[1].list[1], 60);
+    EXPECT_EQ(taps_list.list[1].list[2], 90);
+    EXPECT_EQ(taps_list.list[1].list[3], 100);
 
-    // Verify tap 2: 4 lanes
-    EXPECT_EQ(taps_list.list[2].count, 4);
+    // Verify tap 2 (all lane's tap2 values): 2 lanes [70, 80]
+    EXPECT_EQ(taps_list.list[2].count, 2);
     ASSERT_NE(taps_list.list[2].list, nullptr);
     EXPECT_EQ(taps_list.list[2].list[0], 70);
     EXPECT_EQ(taps_list.list[2].list[1], 80);
-    EXPECT_EQ(taps_list.list[2].list[2], 90);
-    EXPECT_EQ(taps_list.list[2].list[3], 100);
 
     // Clean up
     for (uint32_t i = 0; i < taps_list.count; i++)
@@ -1870,21 +1869,31 @@ TEST(SaiSerialize, sai_deserialize_taps_list)
     }
     delete[] taps_list.list;
 
-    // Test empty list
-    std::string empty_json_str = "[]";
+    // Test empty object
+    std::string empty_json_str = "{}";
     memset(&taps_list, 0, sizeof(taps_list));
     sai_deserialize_taps_list(empty_json_str, taps_list, false);
     EXPECT_EQ(taps_list.count, 0);
     EXPECT_EQ(taps_list.list, nullptr);
 
-    // Test tap with no lane values
-    std::string tap_no_lanes = "[{tap1:}]";
+    // Test single lane.
+    std::string single_lane = "{\"0\":[{\"tap0\":100},{\"tap1\":200},{\"tap2\":300}]}";
     memset(&taps_list, 0, sizeof(taps_list));
-    sai_deserialize_taps_list(tap_no_lanes, taps_list, false);
-    EXPECT_EQ(taps_list.count, 1);
+    sai_deserialize_taps_list(single_lane, taps_list, false);
+    EXPECT_EQ(taps_list.count, 3);
     ASSERT_NE(taps_list.list, nullptr);
-    EXPECT_EQ(taps_list.list[0].count, 0);
-    EXPECT_EQ(taps_list.list[0].list, nullptr);
+    EXPECT_EQ(taps_list.list[0].count, 1);
+    EXPECT_EQ(taps_list.list[0].list[0], 100);
+    EXPECT_EQ(taps_list.list[1].count, 1);
+    EXPECT_EQ(taps_list.list[1].list[0], 200);
+    EXPECT_EQ(taps_list.list[2].count, 1);
+    EXPECT_EQ(taps_list.list[2].list[0], 300);
+
+    // Clean up
+    for (uint32_t i = 0; i < taps_list.count; i++)
+    {
+        delete[] taps_list.list[i].list;
+    }
     delete[] taps_list.list;
 
     // Test countOnly mode

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -1777,22 +1777,19 @@ TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_nul
 
 TEST(SaiSerialize, sai_serialize_taps_list)
 {
-    // Create test data: 3 taps, each with different number of lane values
+    // Create test data
     sai_taps_list_t taps_list;
     sai_s32_list_t taps[3];
 
-    // Tap 0: 4 lanes with values [10, 20, 30, 40]
     int32_t tap0_values[] = {10, 20, 30, 40};
     taps[0].count = 4;
     taps[0].list = tap0_values;
 
-    // Tap 1: 2 lanes with values [50, 60]
-    int32_t tap1_values[] = {50, 60};
-    taps[1].count = 2;
+    int32_t tap1_values[] = {50, 60, 70, 80};
+    taps[1].count = 4;
     taps[1].list = tap1_values;
 
-    // Tap 2: 4 lanes with values [70, 80, 90, 100]
-    int32_t tap2_values[] = {70, 80, 90, 100};
+    int32_t tap2_values[] = {90, 100, 110, 120};
     taps[2].count = 4;
     taps[2].list = tap2_values;
 
@@ -1802,17 +1799,48 @@ TEST(SaiSerialize, sai_serialize_taps_list)
     // Test normal serialization
     auto s = sai_serialize_taps_list(taps_list, false);
 
-    std::string expected = "{\"0\":[{\"tap0\":10},{\"tap1\":50},{\"tap2\":70}],"
-        "\"1\":[{\"tap0\":20},{\"tap1\":60},{\"tap2\":80}],"
-        "\"2\":[{\"tap0\":30},{\"tap1\":90}],\"3\":[{\"tap0\":40},{\"tap1\":100}]}";
+    std::string expected = "{\"0\":[{\"tap0\":10},{\"tap1\":50},{\"tap2\":90}],"
+        "\"1\":[{\"tap0\":20},{\"tap1\":60},{\"tap2\":100}],"
+        "\"2\":[{\"tap0\":30},{\"tap1\":70},{\"tap2\":110}],"
+        "\"3\":[{\"tap0\":40},{\"tap1\":80},{\"tap2\":120}]}";
 
     EXPECT_EQ(s, expected);
 
-    // Test empty taps list
+    // Test empty taps list (count = 0)
     taps_list.count = 0;
     taps_list.list = NULL;
     s = sai_serialize_taps_list(taps_list, false);
     EXPECT_EQ(s, "{}");
+
+    // Test NULL list
+    taps_list.count = 3;
+    taps_list.list = NULL;
+    s = sai_serialize_taps_list(taps_list, false);
+    EXPECT_EQ(s, "{}");
+
+    // Test first tap with NULL list
+    taps_list.count = 3;
+    taps_list.list = taps;
+    taps[0].list = NULL;
+    s = sai_serialize_taps_list(taps_list, false);
+    EXPECT_EQ(s, "{}");
+    taps[0].list = tap0_values; // restore
+
+    // Test first tap with count = 0
+    taps[0].count = 0;
+    s = sai_serialize_taps_list(taps_list, false);
+    EXPECT_EQ(s, "{}");
+    taps[0].count = 4; // restore
+
+    // Test single lane, single tap
+    sai_s32_list_t single_tap;
+    int32_t single_value[] = {42};
+    single_tap.count = 1;
+    single_tap.list = single_value;
+    taps_list.count = 1;
+    taps_list.list = &single_tap;
+    s = sai_serialize_taps_list(taps_list, false);
+    EXPECT_EQ(s, "{\"0\":[{\"tap0\":42}]}");
 
     // Test countOnly mode
     taps_list.count = 3;
@@ -1823,18 +1851,16 @@ TEST(SaiSerialize, sai_serialize_taps_list)
 
 TEST(SaiSerialize, sai_deserialize_taps_list)
 {
-    // Input represents (with sequential tap numbering per lane):
-    // Lane 0: tap0=10, tap1=50, tap2=70 (3 taps)
-    // Lane 1: tap0=20, tap1=60, tap2=80 (3 taps)
-    // Lane 2: tap0=30, tap1=90 (2 taps)
-    // Lane 3: tap0=40, tap1=100 (2 taps)
-    std::string json_str = "{\"0\":[{\"tap0\":10},{\"tap1\":50},{\"tap2\":70}],"
-        "\"1\":[{\"tap0\":20},{\"tap1\":60},{\"tap2\":80}],"
-        "\"2\":[{\"tap0\":30},{\"tap1\":90}],\"3\":[{\"tap0\":40},{\"tap1\":100}]}";
+    // Create test string
+    std::string json_str = "{\"0\":[{\"tap0\":10},{\"tap1\":50},{\"tap2\":90}],"
+        "\"1\":[{\"tap0\":20},{\"tap1\":60},{\"tap2\":100}],"
+        "\"2\":[{\"tap0\":30},{\"tap1\":70},{\"tap2\":110}],"
+        "\"3\":[{\"tap0\":40},{\"tap1\":80},{\"tap2\":120}]}";
 
     sai_taps_list_t taps_list;
     memset(&taps_list, 0, sizeof(taps_list));
 
+    // deserialize string
     sai_deserialize_taps_list(json_str, taps_list, false);
 
     EXPECT_EQ(taps_list.count, 3);
@@ -1848,19 +1874,21 @@ TEST(SaiSerialize, sai_deserialize_taps_list)
     EXPECT_EQ(taps_list.list[0].list[2], 30);
     EXPECT_EQ(taps_list.list[0].list[3], 40);
 
-    // Verify tap 1 (all lane's tap1 values): 4 lanes [50, 60, 90, 100]
+    // Verify tap 1 (all lane's tap1 values): 4 lanes [50, 60, 70, 80]
     EXPECT_EQ(taps_list.list[1].count, 4);
     ASSERT_NE(taps_list.list[1].list, nullptr);
     EXPECT_EQ(taps_list.list[1].list[0], 50);
     EXPECT_EQ(taps_list.list[1].list[1], 60);
-    EXPECT_EQ(taps_list.list[1].list[2], 90);
-    EXPECT_EQ(taps_list.list[1].list[3], 100);
+    EXPECT_EQ(taps_list.list[1].list[2], 70);
+    EXPECT_EQ(taps_list.list[1].list[3], 80);
 
-    // Verify tap 2 (all lane's tap2 values): 2 lanes [70, 80]
-    EXPECT_EQ(taps_list.list[2].count, 2);
+    // Verify tap 2 (all lane's tap2 values): 4 lanes [90, 100, 110, 120]
+    EXPECT_EQ(taps_list.list[2].count, 4);
     ASSERT_NE(taps_list.list[2].list, nullptr);
-    EXPECT_EQ(taps_list.list[2].list[0], 70);
-    EXPECT_EQ(taps_list.list[2].list[1], 80);
+    EXPECT_EQ(taps_list.list[2].list[0], 90);
+    EXPECT_EQ(taps_list.list[2].list[1], 100);
+    EXPECT_EQ(taps_list.list[2].list[2], 110);
+    EXPECT_EQ(taps_list.list[2].list[3], 120);
 
     // Clean up
     for (uint32_t i = 0; i < taps_list.count; i++)
@@ -1876,7 +1904,28 @@ TEST(SaiSerialize, sai_deserialize_taps_list)
     EXPECT_EQ(taps_list.count, 0);
     EXPECT_EQ(taps_list.list, nullptr);
 
-    // Test single lane.
+    // Test missing lane "0"
+    std::string missing_lane0 = "{\"1\":[{\"tap0\":10}]}";
+    memset(&taps_list, 0, sizeof(taps_list));
+    sai_deserialize_taps_list(missing_lane0, taps_list, false);
+    EXPECT_EQ(taps_list.count, 0);
+    EXPECT_EQ(taps_list.list, nullptr);
+
+    // Test lane "0" with empty array
+    std::string empty_array = "{\"0\":[]}";
+    memset(&taps_list, 0, sizeof(taps_list));
+    sai_deserialize_taps_list(empty_array, taps_list, false);
+    EXPECT_EQ(taps_list.count, 0);
+    EXPECT_EQ(taps_list.list, nullptr);
+
+    // Test lane "0" is not an array
+    std::string not_array = "{\"0\":\"invalid\"}";
+    memset(&taps_list, 0, sizeof(taps_list));
+    sai_deserialize_taps_list(not_array, taps_list, false);
+    EXPECT_EQ(taps_list.count, 0);
+    EXPECT_EQ(taps_list.list, nullptr);
+
+    // Test single lane with all taps
     std::string single_lane = "{\"0\":[{\"tap0\":100},{\"tap1\":200},{\"tap2\":300}]}";
     memset(&taps_list, 0, sizeof(taps_list));
     sai_deserialize_taps_list(single_lane, taps_list, false);
@@ -1895,6 +1944,26 @@ TEST(SaiSerialize, sai_deserialize_taps_list)
         delete[] taps_list.list[i].list;
     }
     delete[] taps_list.list;
+
+    // Test single tap, single lane
+    std::string single_single = "{\"0\":[{\"tap0\":42}]}";
+    memset(&taps_list, 0, sizeof(taps_list));
+    sai_deserialize_taps_list(single_single, taps_list, false);
+    EXPECT_EQ(taps_list.count, 1);
+    ASSERT_NE(taps_list.list, nullptr);
+    EXPECT_EQ(taps_list.list[0].count, 1);
+    EXPECT_EQ(taps_list.list[0].list[0], 42);
+
+    // Clean up
+    delete[] taps_list.list[0].list;
+    delete[] taps_list.list;
+
+    // Test invalid JSON (parse error)
+    std::string invalid_json = "{invalid json";
+    memset(&taps_list, 0, sizeof(taps_list));
+    sai_deserialize_taps_list(invalid_json, taps_list, false);
+    EXPECT_EQ(taps_list.count, 0);
+    EXPECT_EQ(taps_list.list, nullptr);
 
     // Test countOnly mode
     std::string count_str = "5";

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -1775,3 +1775,121 @@ TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_nul
     sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
 }
 
+TEST(SaiSerialize, sai_serialize_taps_list)
+{
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+
+    for (size_t idx = 0 ; idx < sai_metadata_attr_sorted_by_id_name_count; ++idx)
+    {
+        auto meta = sai_metadata_attr_sorted_by_id_name[idx];
+        if(meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_TAPS_LIST)
+        {
+            attr.id = meta->attrid;
+
+            // Create test data: 3 taps, each with different number of lane values
+            sai_s32_list_t taps[3];
+
+            // Tap 0: 4 lanes with values [10, 20, 30, 40]
+            int32_t tap0_values[] = {10, 20, 30, 40};
+            taps[0].count = 4;
+            taps[0].list = tap0_values;
+
+            // Tap 1: 2 lanes with values [50, 60]
+            int32_t tap1_values[] = {50, 60};
+            taps[1].count = 2;
+            taps[1].list = tap1_values;
+
+            // Tap 2: 4 lanes with values [70, 80, 90, 100]
+            int32_t tap2_values[] = {70, 80, 90, 100};
+            taps[2].count = 4;
+            taps[2].list = tap2_values;
+
+            attr.value.portserdestaps.count = 3;
+            attr.value.portserdestaps.list = taps;
+
+            auto s = sai_serialize_attr_value(*meta, attr, false);
+
+            std::string expected = "[{tap1:10,20,30,40},{tap2:50,60},{tap3:70,80,90,100}]";
+            EXPECT_EQ(s, expected);
+
+            // Test empty taps list
+            attr.value.portserdestaps.count = 0;
+            attr.value.portserdestaps.list = NULL;
+            s = sai_serialize_attr_value(*meta, attr, false);
+            EXPECT_EQ(s, "[]");
+
+            // Test countOnly mode
+            attr.value.portserdestaps.count = 3;
+            attr.value.portserdestaps.list = taps;
+            s = sai_serialize_attr_value(*meta, attr, true);
+            EXPECT_EQ(s, "3");
+        }
+    }
+}
+
+TEST(SaiSerialize, sai_deserialize_taps_list)
+{
+    // Test normal case with multiple taps
+    std::string json_str = "[{tap1:10,20,30,40},{tap2:50,60},{tap3:70,80,90,100}]";
+
+    sai_taps_list_t taps_list;
+    memset(&taps_list, 0, sizeof(taps_list));
+
+    sai_deserialize_taps_list(json_str, taps_list, false);
+
+    EXPECT_EQ(taps_list.count, 3);
+    ASSERT_NE(taps_list.list, nullptr);
+
+    // Verify tap 0: 4 lanes
+    EXPECT_EQ(taps_list.list[0].count, 4);
+    ASSERT_NE(taps_list.list[0].list, nullptr);
+    EXPECT_EQ(taps_list.list[0].list[0], 10);
+    EXPECT_EQ(taps_list.list[0].list[1], 20);
+    EXPECT_EQ(taps_list.list[0].list[2], 30);
+    EXPECT_EQ(taps_list.list[0].list[3], 40);
+
+    // Verify tap 1: 2 lanes
+    EXPECT_EQ(taps_list.list[1].count, 2);
+    ASSERT_NE(taps_list.list[1].list, nullptr);
+    EXPECT_EQ(taps_list.list[1].list[0], 50);
+    EXPECT_EQ(taps_list.list[1].list[1], 60);
+
+    // Verify tap 2: 4 lanes
+    EXPECT_EQ(taps_list.list[2].count, 4);
+    ASSERT_NE(taps_list.list[2].list, nullptr);
+    EXPECT_EQ(taps_list.list[2].list[0], 70);
+    EXPECT_EQ(taps_list.list[2].list[1], 80);
+    EXPECT_EQ(taps_list.list[2].list[2], 90);
+    EXPECT_EQ(taps_list.list[2].list[3], 100);
+
+    // Clean up
+    for (uint32_t i = 0; i < taps_list.count; i++)
+    {
+        delete[] taps_list.list[i].list;
+    }
+    delete[] taps_list.list;
+
+    // Test empty list
+    std::string empty_json_str = "[]";
+    memset(&taps_list, 0, sizeof(taps_list));
+    sai_deserialize_taps_list(empty_json_str, taps_list, false);
+    EXPECT_EQ(taps_list.count, 0);
+    EXPECT_EQ(taps_list.list, nullptr);
+
+    // Test tap with no lane values
+    std::string tap_no_lanes = "[{tap1:}]";
+    memset(&taps_list, 0, sizeof(taps_list));
+    sai_deserialize_taps_list(tap_no_lanes, taps_list, false);
+    EXPECT_EQ(taps_list.count, 1);
+    ASSERT_NE(taps_list.list, nullptr);
+    EXPECT_EQ(taps_list.list[0].count, 0);
+    EXPECT_EQ(taps_list.list[0].list, nullptr);
+    delete[] taps_list.list;
+
+    // Test countOnly mode
+    std::string count_str = "5";
+    memset(&taps_list, 0, sizeof(taps_list));
+    sai_deserialize_taps_list(count_str, taps_list, true);
+    EXPECT_EQ(taps_list.count, 5);
+}

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -14,6 +14,7 @@ tests_SOURCES = main.cpp \
 				TestConcurrentQueue.cpp \
 				TestFlexCounter.cpp \
 				TestPortPhyAttr.cpp \
+				TestPortPhySerdesAttr.cpp \
 				TestVirtualOidTranslator.cpp \
 				TestNotificationQueue.cpp \
 				TestNotificationProcessor.cpp \

--- a/unittest/syncd/TestPortPhySerdesAttr.cpp
+++ b/unittest/syncd/TestPortPhySerdesAttr.cpp
@@ -1,0 +1,304 @@
+/**
+ * @file TestPortPhySerdesAttr.cpp
+ * @brief Unit tests for PORT_SERDES_ATTR flex counter functionality
+ *
+ * Tests implementation according to UT Plan:
+ * 1. sai_serialize_port_serdes_attr() function
+ * 2. sai_deserialize_port_serdes_attr() function
+ * 3. collectData() with mocked SAI and counters DB validation
+ */
+
+#include "FlexCounter.h"
+#include "sai_serialize.h"
+#include "MockableSaiInterface.h"
+#include "MockHelper.h"
+#include "swss/table.h"
+#include "swss/schema.h"
+#include "syncd/SaiSwitch.h"
+#include <string>
+#include <gtest/gtest.h>
+#include <memory>
+
+using namespace saimeta;
+using namespace sairedis;
+using namespace syncd;
+using namespace std;
+
+static const std::string ATTR_TYPE_PORT_PHY_SERDES_ATTR = "Port Serdes Attributes";
+static const uint32_t TEST_LANE_COUNT = 4;
+static const uint32_t TEST_TAP_COUNT = 6;
+
+template <typename T>
+std::string toOid(T value)
+{
+    SWSS_LOG_ENTER();
+    std::ostringstream ostream;
+    ostream << "oid:0x" << std::hex << value;
+    return ostream.str();
+}
+
+
+class TestPortPhySerdesAttr : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        sai = std::make_shared<MockableSaiInterface>();
+
+        sai->mock_switchIdQuery = [](sai_object_id_t) {
+            return 0x21000000000000;
+        };
+
+        flexCounter = std::make_shared<FlexCounter>("TEST_PORT_SERDES_ATTR", sai, "COUNTERS_DB");
+
+        // Setup test port serdes OID and port OID
+        // PORT_SERDES object type = 87 (0x57), so OID is 0x57000000000001
+        testPortSerdesOid = 0x57000000000001;
+        testPortSerdesRid = 0x57000000000001;
+        testPortOid = 0x1000000000001;
+        testPortRid = 0x1000000000001;
+    }
+
+    void TearDown() override
+    {
+        flexCounter.reset();
+        sai.reset();
+    }
+
+    std::shared_ptr<MockableSaiInterface> sai;
+    std::shared_ptr<FlexCounter> flexCounter;
+    sai_object_id_t testPortSerdesOid;
+    sai_object_id_t testPortSerdesRid;
+    sai_object_id_t testPortOid;
+    sai_object_id_t testPortRid;
+};
+
+TEST_F(TestPortPhySerdesAttr, SerializePortSerdesAttr)
+{
+    sai_port_serdes_attr_t attr = SAI_PORT_SERDES_ATTR_RX_VGA;
+    std::string result = sai_serialize_port_serdes_attr(attr);
+    EXPECT_EQ(result, "SAI_PORT_SERDES_ATTR_RX_VGA");
+
+    attr = SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST;
+    result = sai_serialize_port_serdes_attr(attr);
+    EXPECT_EQ(result, "SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST");
+
+    attr = SAI_PORT_SERDES_ATTR_TX_FIR_COUNT;
+    result = sai_serialize_port_serdes_attr(attr);
+    EXPECT_EQ(result, "SAI_PORT_SERDES_ATTR_TX_FIR_COUNT");
+}
+
+TEST_F(TestPortPhySerdesAttr, DeserializePortSerdesAttr)
+{
+    sai_port_serdes_attr_t attr_out;
+
+    std::string input = "SAI_PORT_SERDES_ATTR_RX_VGA";
+    sai_deserialize_port_serdes_attr(input, attr_out);
+    EXPECT_EQ(attr_out, SAI_PORT_SERDES_ATTR_RX_VGA);
+
+    input = "SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST";
+    sai_deserialize_port_serdes_attr(input, attr_out);
+    EXPECT_EQ(attr_out, SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST);
+
+    input = "SAI_PORT_SERDES_ATTR_TX_FIR_COUNT";
+    sai_deserialize_port_serdes_attr(input, attr_out);
+    EXPECT_EQ(attr_out, SAI_PORT_SERDES_ATTR_TX_FIR_COUNT);
+}
+
+/**
+ * Test collectData() with mocked SAI and COUNTERS_DB validation
+ * This test verifies the complete data collection workflow:
+ * 1. Mock SAI interface returns realistic PORT_SERDES attribute data
+ * 2. FlexCounter collects the data via collectData()
+ * 3. Verify collected data is properly written to COUNTERS_DB with friendly aliases
+ *
+ * This test validates the complete PORT_SERDES_ATTR collection workflow
+ * including RX_VGA and TX_FIR_TAPS_LIST attributes.
+ */
+TEST_F(TestPortPhySerdesAttr, CollectDataAndValidateCountersDB)
+{
+    // Setup mock for PORT_SERDES attributes with realistic data
+    sai->mock_get = [](sai_object_type_t object_type,
+                      sai_object_id_t object_id,
+                      uint32_t attr_count,
+                      sai_attribute_t *attr_list) -> sai_status_t
+    {
+        if (object_type == SAI_OBJECT_TYPE_PORT_SERDES) {
+            for (uint32_t i = 0; i < attr_count; i++) {
+                switch (attr_list[i].id) {
+                    case SAI_PORT_SERDES_ATTR_PORT_ID:
+                        // Return the associated port OID
+                        attr_list[i].value.oid = 0x1000000000001;
+                        break;
+
+                    case SAI_PORT_SERDES_ATTR_TX_FIR_COUNT:
+                        // Return tap count
+                        attr_list[i].value.u32 = TEST_TAP_COUNT;
+                        break;
+
+                    case SAI_PORT_SERDES_ATTR_RX_VGA:
+                        if (attr_list[i].value.u32list.list == nullptr) {
+                            // First call: return count needed
+                            attr_list[i].value.u32list.count = TEST_LANE_COUNT;
+                            return SAI_STATUS_BUFFER_OVERFLOW;
+                        } else {
+                            // Second call: fill actual data
+                            uint32_t count = attr_list[i].value.u32list.count;
+                            for (uint32_t lane = 0; lane < count && lane < TEST_LANE_COUNT; lane++) {
+                                attr_list[i].value.u32list.list[lane] = 177 + lane; // VGA values: 177, 178, 179, 180
+                            }
+                            attr_list[i].value.u32list.count = std::min(count, TEST_LANE_COUNT);
+                        }
+                        break;
+
+                    case SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST:
+                        if (attr_list[i].value.portserdestaps.list == nullptr) {
+                            // First call: return tap count needed
+                            attr_list[i].value.portserdestaps.count = TEST_TAP_COUNT;
+                            return SAI_STATUS_BUFFER_OVERFLOW;
+                        } else {
+                            // Second call: fill actual data
+                            uint32_t tap_count = attr_list[i].value.portserdestaps.count;
+                            for (uint32_t tap_idx = 0; tap_idx < tap_count && tap_idx < TEST_TAP_COUNT; tap_idx++) {
+                                if (attr_list[i].value.portserdestaps.list[tap_idx].list == nullptr) {
+                                    // Query for lane count for this tap
+                                    attr_list[i].value.portserdestaps.list[tap_idx].count = TEST_LANE_COUNT;
+                                } else {
+                                    // Fill lane values for this tap
+                                    uint32_t lane_count = attr_list[i].value.portserdestaps.list[tap_idx].count;
+                                    for (uint32_t lane = 0; lane < lane_count && lane < TEST_LANE_COUNT; lane++) {
+                                        // Generate tap values: tap0: -23,-22,-21,-20, tap1: -13,-12,-11,-10, etc.
+                                        int32_t base_value = -23 + (tap_idx * 10);
+                                        attr_list[i].value.portserdestaps.list[tap_idx].list[lane] = base_value + lane;
+                                    }
+                                    attr_list[i].value.portserdestaps.list[tap_idx].count = std::min(lane_count, TEST_LANE_COUNT);
+                                }
+                            }
+                            attr_list[i].value.portserdestaps.count = std::min(tap_count, TEST_TAP_COUNT);
+                        }
+                        break;
+
+                    default:
+                        return SAI_STATUS_NOT_SUPPORTED;
+                }
+            }
+            return SAI_STATUS_SUCCESS;
+        } else if (object_type == SAI_OBJECT_TYPE_PORT) {
+            for (uint32_t i = 0; i < attr_count; i++) {
+                if (attr_list[i].id == SAI_PORT_ATTR_HW_LANE_LIST) {
+                    if (attr_list[i].value.u32list.list == nullptr) {
+                        // Return lane count
+                        attr_list[i].value.u32list.count = TEST_LANE_COUNT;
+                        return SAI_STATUS_BUFFER_OVERFLOW;
+                    } else {
+                        // Fill lane list
+                        uint32_t count = attr_list[i].value.u32list.count;
+                        for (uint32_t lane = 0; lane < count && lane < TEST_LANE_COUNT; lane++) {
+                            attr_list[i].value.u32list.list[lane] = lane;
+                        }
+                        attr_list[i].value.u32list.count = std::min(count, TEST_LANE_COUNT);
+                        return SAI_STATUS_SUCCESS;
+                    }
+                }
+            }
+        }
+        return SAI_STATUS_INVALID_PARAMETER;
+    };
+
+    // Setup COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP in COUNTERS_DB
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::Table portSerdesIdToPortIdTable(&db, "COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP");
+    portSerdesIdToPortIdTable.hset("", toOid(testPortSerdesOid), toOid(testPortOid));
+
+    vector<swss::FieldValueTuple> portSerdesAttrValues;
+
+    std::string attrIds = "SAI_PORT_SERDES_ATTR_RX_VGA,SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST";
+
+    portSerdesAttrValues.emplace_back(PORT_PHY_SERDES_ATTR_ID_LIST, attrIds);
+
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT_SERDES);
+
+    flexCounter->addCounter(testPortSerdesOid, testPortSerdesRid, portSerdesAttrValues);
+
+    vector<swss::FieldValueTuple> pluginValues;
+    pluginValues.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    pluginValues.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    pluginValues.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    flexCounter->addCounterPlugin(pluginValues);
+
+    usleep(1000 * 1050); // 1.05 seconds to ensure at least one poll cycle
+
+    // Connect to COUNTERS_DB and verify entries in PORT_PHY_ATTR_TABLE
+    swss::RedisPipeline pipeline(&db);
+    swss::Table portPhyAttrTable(&pipeline, PORT_PHY_ATTR_TABLE, false);
+
+    // The key should be the port VID (not port serdes VID)
+    std::string expectedKey = toOid(testPortOid);
+
+    // Validate RX_VGA with friendly alias "rx_vga"
+    std::string rxVgaValue;
+    bool found = portPhyAttrTable.hget(expectedKey, "rx_vga", rxVgaValue);
+    EXPECT_TRUE(found) << "rx_vga not found in COUNTERS_DB PORT_PHY_ATTR_TABLE table";
+
+    // Expected format: "4:177,178,179,180" (count:lane_values)
+    EXPECT_TRUE(rxVgaValue.find("4:") != std::string::npos)
+        << "rx_vga should start with lane count '4:'\nActual: " << rxVgaValue;
+
+    for (uint32_t lane = 0; lane < TEST_LANE_COUNT; lane++) {
+        uint32_t expected_vga = 177 + lane;
+        std::string expected_value = std::to_string(expected_vga);
+
+        EXPECT_TRUE(rxVgaValue.find(expected_value) != std::string::npos)
+            << "Lane " << lane << " VGA should be " << expected_vga
+            << "\nActual full value: " << rxVgaValue;
+    }
+
+    // Validate TX_FIR_TAPS_LIST with friendly alias "tx_fir_taps_list"
+    std::string txFirTapsValue;
+    found = portPhyAttrTable.hget(expectedKey, "tx_fir_taps_list", txFirTapsValue);
+    EXPECT_TRUE(found) << "tx_fir_taps_list not found in COUNTERS_DB PORT_SERDES_ATTR table";
+
+    // Expected format: [{tap1:v1,v2,v3,v4},{tap2:v1,v2,v3,v4},...]
+    EXPECT_TRUE(txFirTapsValue.find("[") != std::string::npos &&
+                txFirTapsValue.find("]") != std::string::npos)
+        << "tx_fir_taps_list should be in array format\nActual: " << txFirTapsValue;
+
+    // Verify tap structure with strict checking
+    for (uint32_t tap_idx = 0; tap_idx < TEST_TAP_COUNT; tap_idx++) {
+        std::ostringstream tap_prefix;
+        tap_prefix << "{tap" << (tap_idx + 1) << ":";
+
+        // Find the tap section
+        size_t tap_start = txFirTapsValue.find(tap_prefix.str());
+        EXPECT_NE(tap_start, std::string::npos)
+            << "Should contain tap " << tap_idx << " with prefix '" << tap_prefix.str() << "'"
+            << "\nActual: " << txFirTapsValue;
+
+        if (tap_start == std::string::npos) continue;
+
+        // Extract content between "tapN:" and "}"
+        size_t content_start = tap_start + tap_prefix.str().length();
+        size_t content_end = txFirTapsValue.find("}", content_start);
+        EXPECT_NE(content_end, std::string::npos)
+            << "Should have closing brace for tap " << tap_idx;
+
+        if (content_end == std::string::npos) continue;
+
+        std::string tap_content = txFirTapsValue.substr(content_start, content_end - content_start);
+
+        // Verify lane values for this specific tap
+        int32_t base_value = -23 + (tap_idx * 10);
+        for (uint32_t lane = 0; lane < TEST_LANE_COUNT; lane++) {
+            int32_t expected_tap_value = base_value + lane;
+            std::string expected_str = std::to_string(expected_tap_value);
+
+            EXPECT_TRUE(tap_content.find(expected_str) != std::string::npos)
+                << "Tap " << tap_idx << " lane " << lane << " should have value " << expected_tap_value
+                << "\nTap content: " << tap_content
+                << "\nFull value: " << txFirTapsValue;
+        }
+    }
+
+    flexCounter->removeCounter(testPortSerdesOid);
+}
+


### PR DESCRIPTION
**What I did**
1 - Added logic to serialize deserialize port_sereds_attr_t ids and sai_taps_list_t.

2 - Added logic to syncd - FlexCounter module to handle changes from table entries of the following type : FLEX_COUNTER_DB :: FLEX_COUNTER_TABLE:PORT_PHY_SERDES_ATTR: -> {'PORT_PHY_SERDES_ATTR_ID_LIST':}
The above is handled by add/remove counters and collectData calls for the custom class PortPhySerdesAttributeContext, wherein, the collectData method writes the collected port phy serdes attribute data to 
COUNTERS_DB :: "PORT_PHY_ATTR:oid:<PORT VID>"

3 - Added unittest cases for SaiSerialization and flexcounter port serdes attribute collection changes.

**Why I did it**
These changes are brought in sonic-sairedis to support the collection of following attributes: 1 - SAI_PORT_SERDES_ATTR_RX_VGA (type : sai_u32_list_t)
2 - SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST (type : sai_taps_list_t ) (both under sai_port_serdes_attr_)

**How I verified it**
Manual testing -
1) Enable phy counterpoll: `$counterpoll phy enable`

2) Verify COUNTERS_DB has PORT_PHY_ATTR table with keys for each applicable port, and its value has port_phy_serdes atttributes poppulated with fresh data, changing at set interval.

```
$ sudo sonic-db-cli COUNTERS_DB keys "*" | grep PHY
PORT_PHY_ATTR:oid:0x1000000000018
PORT_PHY_ATTR:oid:0x100000000001d
PORT_PHY_ATTR:oid:0x1000000000001
...

$ sudo sonic-db-cli COUNTERS_DB HGETALL "PORT_PHY_ATTR:oid:0x1000000000019"
{'rx_vga': '{"0":112,"1":113,"2":114,"3":115}', 'tx_fir_taps_list': '{"0":[{"tap0":-38},{"tap1":-28},{"tap2":-18},{"tap3":-8},{"tap4":2},{"tap5":12}],"1":[{"tap0":-37},{"tap1":-27},{"tap2":-17},{"tap3":-7},{"tap4":3},{"tap5":13}],"2":[{"tap0":-36},{"tap1":-26},{"tap2":-16},{"tap3":-6},{"tap4":4},{"tap5":14}],"3":[{"tap0":-35},{"tap1":-25},{"tap2":-15},{"tap3":-5},{"tap4":5},{"tap5":15}]}'}
$ sudo sonic-db-cli COUNTERS_DB HGETALL "PORT_PHY_ATTR:oid:0x1000000000019"
{'rx_vga': '{"0":157,"1":158,"2":159,"3":160}', 'tx_fir_taps_list': '{"0":[{"tap0":7},{"tap1":17},{"tap2":27},{"tap3":37},{"tap4":47},{"tap5":-43}],"1":[{"tap0":8},{"tap1":18},{"tap2":28},{"tap3":38},{"tap4":48},{"tap5":-42}],"2":[{"tap0":9},{"tap1":19},{"tap2":29},{"tap3":39},{"tap4":49},{"tap5":-41}],"3":[{"tap0":10},{"tap1":20},{"tap2":30},{"tap3":40},{"tap4":-50},{"tap5":-40}]}'}
admin@ld492:~$
```
(Note: These values are randomly generated currently, also PORT_PHY_ATTRIBUTES should also have port phy attributes (along with serdes) in real scenario, in this setup it is disabled)

3) Disable phy counterpoll: `$counterpoll phy disable`, and verify port_phy_serdes data collection is halted.
