### PR TITLE
BROADCOM_LEGACY_SAI_COMPAT: Fix sai_query_stats_st_capability crash on Tomahawk-1 (BCM56960) legacy platforms

### DIFF
--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -146,6 +146,26 @@ sai_status_t VendorSai::apiInitialize(
         return SAI_STATUS_FAILURE;
     }
 
+#ifdef HAVE_SAI_QUERY_STATS_ST_CAPABILITY
+    // BROADCOM_LEGACY_SAI_COMPAT: Allow platforms to disable sai_query_stats_st_capability at runtime
+    // via sai.profile key SAI_STATS_ST_CAPABILITY_SUPPORTED=0.
+    // Needed for legacy ASICs (e.g. Tomahawk-1/BCM56960) where the SAI function
+    // pointer is non-null but the internal ST platform driver is uninitialized,
+    // causing a SIGSEGV in brcm_sai_st_pd_ctr_cap_list_get.
+    if (m_globalApis.query_stats_st_capability != nullptr &&
+        m_service_method_table.profile_get_value != nullptr)
+    {
+        const char *stCapVal = m_service_method_table.profile_get_value(
+                0, "SAI_STATS_ST_CAPABILITY_SUPPORTED");
+        if (stCapVal != nullptr && std::string(stCapVal) == "0")
+        {
+            SWSS_LOG_NOTICE("SAI_STATS_ST_CAPABILITY_SUPPORTED=0 in sai.profile,"
+                            " disabling query_stats_st_capability for this platform");
+            m_globalApis.query_stats_st_capability = nullptr;
+        }
+    }
+#endif
+
     m_apiInitialized = true;
 
     return status;

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -493,3 +493,4 @@ SNR
 tparam
 ICMP
 UDP
+SIGSEGV

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -1807,3 +1807,33 @@ TEST_F(VendorSaiTest, bulk_eni_trusted_vni_entry)
     EXPECT_EQ(SAI_STATUS_NOT_SUPPORTED,
             m_vsai->bulkSet(0, e, nullptr, SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR, nullptr));
 }
+
+// BROADCOM_LEGACY_SAI_COMPAT tests ------------------------------------------------------------------------------------
+
+static const char* profile_get_value_no_st_capability(
+        _In_ sai_switch_profile_id_t profile_id,
+        _In_ const char* variable)
+{
+    SWSS_LOG_ENTER();
+
+    if (variable == NULL)
+        return NULL;
+
+    if (std::string(variable) == "SAI_STATS_ST_CAPABILITY_SUPPORTED")
+        return "0";
+
+    return nullptr;
+}
+
+static sai_service_method_table_t test_services_no_st_capability = {
+    profile_get_value_no_st_capability,
+    profile_get_next_value
+};
+
+TEST(VendorSai, statsStCapabilityProfileKeyProcessed)
+{
+    // BROADCOM_LEGACY_SAI_COMPAT: SAI_STATS_ST_CAPABILITY_SUPPORTED=0 in sai.profile
+    // should be processed during apiInitialize without breaking initialization
+    VendorSai sai;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.apiInitialize(0, &test_services_no_st_capability));
+}


### PR DESCRIPTION
## Problem

On Arista 7060cx (BCM56960_B1 / Tomahawk-1, `broadcom-legacy` platform), syncd crashes at startup with a SIGSEGV inside `brcm_sai_st_pd_ctr_cap_list_get+0x10`.

**Root cause:** The SONiC build always uses XGS SAI headers for all Broadcom syncd builds ([buildimage issue #23387](https://github.com/sonic-net/sonic-buildimage/issues/23387)). After commit `4f1d7d99` restored `sai_query_stats_st_capability` to `AC_CHECK_FUNCS`, the symbol is detected against XGS SAI 13.2.1+ → `HAVE_SAI_QUERY_STATS_ST_CAPABILITY=1` is defined → syncd calls the function at runtime. On TH1, the streaming telemetry platform driver (`p_pdapi_st`) is uninitialized → NULL vtable dereference at offset +0x10 → SIGSEGV.

Crash confirmed via GDB core dump: crash address `0x8ab6120` = `brcm_sai_st_pd_ctr_cap_list_get+0x10` in libsai.so.

## Fix

Add a runtime guard in `VendorSai::apiInitialize()` that reads `SAI_STATS_ST_CAPABILITY_SUPPORTED` from `sai.profile`. If set to `0`, the `query_stats_st_capability` function pointer is nulled before it can be called. This replaces the previous blunt compile-time `AH_TEMPLATE` workaround (commit `4a96de71`) with a proper per-platform runtime opt-out, and also restores `sai_query_stats_st_capability` to `AC_CHECK_FUNCS` in `configure.ac`.

XGS platforms (TH2/TH3/TH4/TH5) are unaffected — they do not set this key so the API remains enabled.

All changes are tagged with the comment marker `BROADCOM_LEGACY_SAI_COMPAT` for future searchability.

## Changes

- `configure.ac`: Restore `sai_query_stats_st_capability` to `AC_CHECK_FUNCS`; remove `AH_TEMPLATE` workaround; add `BROADCOM_LEGACY_SAI_COMPAT` comment
- `syncd/VendorSai.cpp`: In `apiInitialize()`, read `SAI_STATS_ST_CAPABILITY_SUPPORTED` from `sai.profile` and null `m_globalApis.query_stats_st_capability` if set to `0`

## Testing

- Arista 7060cx (BCM56960_B1, broadcom-legacy): `SAI_STATS_ST_CAPABILITY_SUPPORTED=0` in `sai.profile` → syncd starts without crash ✅
- Crash on images without this fix confirmed via GDB analysis of `/var/core/syncd.*.core.gz`

## Related

- Fixes regression introduced by commit `4f1d7d99`
- Companion `sai.profile` key change: sonic-net/sonic-buildimage (TBD)
- See also: `BROADCOM_LEGACY_SAI_COMPAT` Issue 2 — `sai_get_stats_ext` for switch objects