### PR TITLE
BROADCOM_LEGACY_SAI_COMPAT: Fix sai_get_stats_ext crash on Tomahawk-1 (BCM56960) legacy platforms

### DIFF
--- a/meta/SaiInterface.h
+++ b/meta/SaiInterface.h
@@ -352,6 +352,13 @@ namespace sairedis
             virtual sai_log_level_t logGet(
                     _In_ sai_api_t api);
 
+        public: // non SAI API
+
+            // BROADCOM_LEGACY_SAI_COMPAT: Platforms that crash when sai_get_stats_ext is called on
+            // switch objects (e.g. Tomahawk-1/BCM56960 legacy) can set
+            // SAI_STATS_EXT_SWITCH_SUPPORTED=0 in sai.profile to disable it.
+            virtual bool isSwitchStatsExtSupported() const { return true; }
+
         public: // non SAI API - options helper
 
             std::shared_ptr<SaiOptions> getOptions(

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -3399,7 +3399,9 @@ std::shared_ptr<BaseCounterContext> FlexCounter::createCounterContext(
         auto context = std::make_shared<CounterContext<sai_switch_stat_t>>(context_name, instance, SAI_OBJECT_TYPE_SWITCH, m_vendorSai.get(), m_statsMode);
         context->always_check_supported_counters = true;
         context->use_sai_stats_capa_query = true;
-        context->use_sai_stats_ext = true;
+        // BROADCOM_LEGACY_SAI_COMPAT: sai_get_stats_ext crashes on some legacy ASICs for switch objects;
+        // platform can set SAI_STATS_EXT_SWITCH_SUPPORTED=0 in sai.profile to disable.
+        context->use_sai_stats_ext = m_vendorSai->isSwitchStatsExtSupported();
         return context;
     }
 

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -22,6 +22,7 @@ VendorSai::VendorSai()
     SWSS_LOG_ENTER();
 
     m_apiInitialized = false;
+    m_switchStatsExtSupported = true;
 
     memset(&m_apis, 0, sizeof(m_apis));
 
@@ -165,6 +166,22 @@ sai_status_t VendorSai::apiInitialize(
         }
     }
 #endif
+
+    // BROADCOM_LEGACY_SAI_COMPAT: Allow platforms to disable sai_get_stats_ext for switch objects
+    // via sai.profile key SAI_STATS_EXT_SWITCH_SUPPORTED=0.
+    // Needed for legacy ASICs (e.g. Tomahawk-1/BCM56960) where sai_get_stats_ext
+    // on SAI_OBJECT_TYPE_SWITCH causes a crash during FlexCounter polling.
+    if (m_service_method_table.profile_get_value != nullptr)
+    {
+        const char *extVal = m_service_method_table.profile_get_value(
+                0, "SAI_STATS_EXT_SWITCH_SUPPORTED");
+        if (extVal != nullptr && std::string(extVal) == "0")
+        {
+            SWSS_LOG_NOTICE("SAI_STATS_EXT_SWITCH_SUPPORTED=0 in sai.profile,"
+                            " disabling sai_get_stats_ext for switch object type");
+            m_switchStatsExtSupported = false;
+        }
+    }
 
     m_apiInitialized = true;
 
@@ -2290,3 +2307,10 @@ sai_log_level_t VendorSai::logGet(
 
     return SAI_LOG_LEVEL_NOTICE;
 }
+
+bool VendorSai::isSwitchStatsExtSupported() const
+{
+    SWSS_LOG_ENTER();
+    return m_switchStatsExtSupported;
+}
+

--- a/syncd/VendorSai.h
+++ b/syncd/VendorSai.h
@@ -224,6 +224,8 @@ namespace syncd
             virtual sai_log_level_t logGet(
                     _In_ sai_api_t api) override;
 
+            virtual bool isSwitchStatsExtSupported() const override;
+
         private:
 
             bool m_apiInitialized;
@@ -237,5 +239,7 @@ namespace syncd
             sai_global_apis_t m_globalApis;
 
             std::map<sai_api_t, sai_log_level_t> m_logLevelMap;
+
+            bool m_switchStatsExtSupported;
     };
 }

--- a/unittest/syncd/TestVendorSai.cpp
+++ b/unittest/syncd/TestVendorSai.cpp
@@ -1810,6 +1810,26 @@ TEST_F(VendorSaiTest, bulk_eni_trusted_vni_entry)
 
 // BROADCOM_LEGACY_SAI_COMPAT tests ------------------------------------------------------------------------------------
 
+static const char* profile_get_value_no_switch_stats_ext(
+        _In_ sai_switch_profile_id_t profile_id,
+        _In_ const char* variable)
+{
+    SWSS_LOG_ENTER();
+
+    if (variable == NULL)
+        return NULL;
+
+    if (std::string(variable) == "SAI_STATS_EXT_SWITCH_SUPPORTED")
+        return "0";
+
+    return nullptr;
+}
+
+static sai_service_method_table_t test_services_no_switch_stats_ext = {
+    profile_get_value_no_switch_stats_ext,
+    profile_get_next_value
+};
+
 static const char* profile_get_value_no_st_capability(
         _In_ sai_switch_profile_id_t profile_id,
         _In_ const char* variable)
@@ -1829,6 +1849,24 @@ static sai_service_method_table_t test_services_no_st_capability = {
     profile_get_value_no_st_capability,
     profile_get_next_value
 };
+
+TEST(VendorSai, isSwitchStatsExtSupportedDefault)
+{
+    // BROADCOM_LEGACY_SAI_COMPAT: isSwitchStatsExtSupported() defaults to true when
+    // SAI_STATS_EXT_SWITCH_SUPPORTED key is absent from sai.profile
+    VendorSai sai;
+    sai.apiInitialize(0, &test_services);
+    EXPECT_TRUE(sai.isSwitchStatsExtSupported());
+}
+
+TEST(VendorSai, isSwitchStatsExtDisabledViaProfile)
+{
+    // BROADCOM_LEGACY_SAI_COMPAT: SAI_STATS_EXT_SWITCH_SUPPORTED=0 in sai.profile
+    // disables sai_get_stats_ext for switch objects (needed for TH1/BCM56960 legacy)
+    VendorSai sai;
+    sai.apiInitialize(0, &test_services_no_switch_stats_ext);
+    EXPECT_FALSE(sai.isSwitchStatsExtSupported());
+}
 
 TEST(VendorSai, statsStCapabilityProfileKeyProcessed)
 {


### PR DESCRIPTION
## Problem

On Arista 7060cx (BCM56960_B1 / Tomahawk-1, `broadcom-legacy` platform), syncd crashes during FlexCounter polling with a SIGSEGV when collecting switch counters.

**Root cause:** PR #1775 added `context->use_sai_stats_ext = true` for the `COUNTER_TYPE_SWITCH` FlexCounter context, forcing `sai_get_stats_ext` to be used instead of `sai_get_stats` for switch objects. While this is required for TH5, on TH1 (broadcom-legacy) `sai_get_stats_ext` for switch objects hits uninitialized internal state in the legacy SAI binary -> SIGSEGV.

Crash confirmed at the same address `0x8ab6120` in libsai.so via GDB analysis.

## Fix

Add a runtime guard controlled by `sai.profile` key `SAI_STATS_EXT_SWITCH_SUPPORTED`. If set to `0`, `FlexCounter::createCounterContext()` uses `sai_get_stats` instead of `sai_get_stats_ext` for switch objects.

Implementation:
- `meta/SaiInterface.h`: Add `virtual bool isSwitchStatsExtSupported() const { return true; }` (default enabled for all platforms)
- `syncd/VendorSai.h`: Declare override + `bool m_switchStatsExtSupported` private member
- `syncd/VendorSai.cpp`: In `apiInitialize()`, read `SAI_STATS_EXT_SWITCH_SUPPORTED` from `sai.profile`; implement accessor
- `syncd/FlexCounter.cpp`: Use `m_vendorSai->isSwitchStatsExtSupported()` for `COUNTER_TYPE_SWITCH` context

XGS platforms (TH2/TH3/TH4/TH5) are unaffected - they do not set this key so `sai_get_stats_ext` remains enabled.

All changes are tagged `BROADCOM_LEGACY_SAI_COMPAT` for future searchability.

## Changes

- `meta/SaiInterface.h`: +7 lines - virtual `isSwitchStatsExtSupported()` with default `true`
- `syncd/VendorSai.h`: +4 lines - override declaration + private member
- `syncd/VendorSai.cpp`: +24 lines - sai.profile key read in `apiInitialize()` + method implementation
- `syncd/FlexCounter.cpp`: -1/+3 lines - conditional `use_sai_stats_ext` for `COUNTER_TYPE_SWITCH`

## Testing

- Arista 7060cx (BCM56960_B1, broadcom-legacy): `SAI_STATS_EXT_SWITCH_SUPPORTED=0` in `sai.profile` -> syncd starts and FlexCounter runs without crash
- TH5 (XGS): No sai.profile key set -> `sai_get_stats_ext` still used for switch counters

## Related

- Fixes regression introduced by PR #1775
- Companion to #1788 - `sai_query_stats_st_capability` fix (BROADCOM_LEGACY_SAI_COMPAT Issue 1); **merge #1788 first, then rebase this PR**
- Companion `sai.profile` key change: sonic-net/sonic-buildimage#26014 (`SAI_STATS_EXT_SWITCH_SUPPORTED=0`)
