### PR TITLE
[Link Event Damping] Add SelectablesTracker for timer management

### DIFF
--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -46,6 +46,7 @@ libSyncd_a_SOURCES = \
 				SaiObj.cpp \
 				SaiSwitch.cpp \
 				SaiSwitchInterface.cpp \
+				SelectablesTracker.cpp \
 				ServiceMethodTable.cpp \
 				SingleReiniter.cpp \
 				SwitchNotifications.cpp \

--- a/syncd/SelectablesTracker.cpp
+++ b/syncd/SelectablesTracker.cpp
@@ -1,0 +1,106 @@
+#include "SelectablesTracker.h"
+
+#include "swss/logger.h"
+
+using namespace syncd;
+
+bool SelectablesTracker::addSelectableToTracker(
+        _In_ swss::Selectable *selectable,
+        _In_ std::shared_ptr<SelectableEventHandler> eventHandler)
+{
+    SWSS_LOG_ENTER();
+
+    if (selectable == nullptr)
+    {
+        SWSS_LOG_ERROR("Invalid Selectable:Selectable is NULL.");
+
+        return false;
+    }
+
+    if (eventHandler == nullptr)
+    {
+        SWSS_LOG_ERROR("Event handler for Selectable with fd: %d is NULL.",
+                selectable->getFd());
+
+        return false;
+    }
+
+    int fd = selectable->getFd();
+
+    if (m_selectableFdToEventHandlerMap.count(fd) != 0)
+    {
+        SWSS_LOG_ERROR("Selectable with fd %d is already in use.", fd);
+
+        return false;
+    }
+
+    SWSS_LOG_INFO("Adding the Selectable with fd: %d.", fd);
+    m_selectableFdToEventHandlerMap[fd] = eventHandler;
+
+    return true;
+}
+
+bool SelectablesTracker::removeSelectableFromTracker(
+        _In_ swss::Selectable *selectable)
+{
+    SWSS_LOG_ENTER();
+
+    if (selectable == nullptr)
+    {
+        SWSS_LOG_ERROR("Invalid Selectable:Selectable is NULL.");
+
+        return false;
+    }
+
+    int fd = selectable->getFd();
+
+    SWSS_LOG_INFO("Removing the Selectable with fd: %d.", fd);
+
+    if (m_selectableFdToEventHandlerMap.erase(fd) == 0)
+    {
+        SWSS_LOG_ERROR("Selectable with fd %d is not present in the map!", fd);
+
+        return false;
+    }
+
+    return true;
+}
+
+bool SelectablesTracker::selectableIsTracked(
+        _In_ swss::Selectable *selectable)
+{
+    SWSS_LOG_ENTER();
+
+    if ((selectable == nullptr) ||
+        (m_selectableFdToEventHandlerMap.count(selectable->getFd()) == 0))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+std::shared_ptr<SelectableEventHandler> SelectablesTracker::getEventHandlerForSelectable(
+        _In_ swss::Selectable *selectable)
+{
+    SWSS_LOG_ENTER();
+
+    if (selectable == nullptr)
+    {
+        SWSS_LOG_ERROR("Invalid Selectable:Selectable is NULL.");
+
+        return nullptr;
+    }
+
+    int fd = selectable->getFd();
+    auto it = m_selectableFdToEventHandlerMap.find(fd);
+
+    if (it == m_selectableFdToEventHandlerMap.end())
+    {
+        SWSS_LOG_ERROR("Selectable with fd %d is not present in the map!", fd);
+
+        return nullptr;
+    }
+
+    return it->second;
+}

--- a/syncd/SelectablesTracker.cpp
+++ b/syncd/SelectablesTracker.cpp
@@ -10,6 +10,8 @@ bool SelectablesTracker::addSelectableToTracker(
 {
     SWSS_LOG_ENTER();
 
+    std::lock_guard<std::mutex> lock(m_mutex);
+
     if (selectable == nullptr)
     {
         SWSS_LOG_ERROR("Invalid Selectable:Selectable is NULL.");
@@ -45,6 +47,8 @@ bool SelectablesTracker::removeSelectableFromTracker(
 {
     SWSS_LOG_ENTER();
 
+    std::lock_guard<std::mutex> lock(m_mutex);
+
     if (selectable == nullptr)
     {
         SWSS_LOG_ERROR("Invalid Selectable:Selectable is NULL.");
@@ -67,9 +71,11 @@ bool SelectablesTracker::removeSelectableFromTracker(
 }
 
 bool SelectablesTracker::selectableIsTracked(
-        _In_ swss::Selectable *selectable)
+        _In_ swss::Selectable *selectable) const
 {
     SWSS_LOG_ENTER();
+
+    std::lock_guard<std::mutex> lock(m_mutex);
 
     if ((selectable == nullptr) ||
         (m_selectableFdToEventHandlerMap.count(selectable->getFd()) == 0))
@@ -81,9 +87,11 @@ bool SelectablesTracker::selectableIsTracked(
 }
 
 std::shared_ptr<SelectableEventHandler> SelectablesTracker::getEventHandlerForSelectable(
-        _In_ swss::Selectable *selectable)
+        _In_ swss::Selectable *selectable) const
 {
     SWSS_LOG_ENTER();
+
+    std::lock_guard<std::mutex> lock(m_mutex);
 
     if (selectable == nullptr)
     {

--- a/syncd/SelectablesTracker.h
+++ b/syncd/SelectablesTracker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 #include "SelectableEventHandler.h"
@@ -39,16 +40,18 @@ namespace syncd
 
             // Checks if Selectable is present in the tracker map.
             virtual bool selectableIsTracked(
-                    _In_ swss::Selectable *selectable);
+                    _In_ swss::Selectable *selectable) const;
 
             // Gets the EventHandler for a Selectable.
             virtual std::shared_ptr<SelectableEventHandler> getEventHandlerForSelectable(
-                    _In_ swss::Selectable *selectable);
+                    _In_ swss::Selectable *selectable) const;
 
         private:
 
             using SelectableFdToEventHandlerMap =
                     std::unordered_map<int, std::shared_ptr<SelectableEventHandler>>;
+
+            mutable std::mutex m_mutex;
 
             SelectableFdToEventHandlerMap m_selectableFdToEventHandlerMap;
     };

--- a/syncd/SelectablesTracker.h
+++ b/syncd/SelectablesTracker.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "SelectableEventHandler.h"
+#include "swss/sal.h"
+#include "swss/selectable.h"
+#include "swss/selectabletimer.h"
+
+namespace syncd
+{
+    // This class keeps track of Selectable being used by an entity and their
+    // corresponding EventHandler objects.
+    class SelectablesTracker
+    {
+        private:
+
+            // Not copyable or movable.
+            SelectablesTracker(const SelectablesTracker &) = delete;
+            SelectablesTracker(SelectablesTracker &&) = delete;
+            SelectablesTracker &operator=(const SelectablesTracker &) = delete;
+            SelectablesTracker &operator=(SelectablesTracker &&) = delete;
+
+        public:
+
+            SelectablesTracker() = default;
+
+            virtual ~SelectablesTracker() = default;
+
+            // Adds the mapping of Selectable and its corresponding EventHandler object.
+            virtual bool addSelectableToTracker(
+                    _In_ swss::Selectable *selectable,
+                    _In_ std::shared_ptr<SelectableEventHandler> eventHandler);
+
+            // Removes a Selectable from the map.
+            virtual bool removeSelectableFromTracker(
+                    _In_ swss::Selectable *selectable);
+
+            // Checks if Selectable is present in the tracker map.
+            virtual bool selectableIsTracked(
+                    _In_ swss::Selectable *selectable);
+
+            // Gets the EventHandler for a Selectable.
+            virtual std::shared_ptr<SelectableEventHandler> getEventHandlerForSelectable(
+                    _In_ swss::Selectable *selectable);
+
+        private:
+
+            using SelectableFdToEventHandlerMap =
+                    std::unordered_map<int, std::shared_ptr<SelectableEventHandler>>;
+
+            SelectableFdToEventHandlerMap m_selectableFdToEventHandlerMap;
+    };
+
+}  // namespace syncd

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -153,6 +153,7 @@ config
 const
 CONST
 consts
+copyable
 counterName
 countOnly
 cout

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -21,6 +21,7 @@ tests_SOURCES = main.cpp \
 				TestNotificationHandler.cpp \
 				TestMdioIpcServer.cpp \
 				TestPortStateChangeHandler.cpp \
+				TestSelectablesTracker.cpp \
 				TestWorkaround.cpp \
 				TestSyncd.cpp \
 				TestVendorSai.cpp \

--- a/unittest/syncd/MockSelectablesTracker.h
+++ b/unittest/syncd/MockSelectablesTracker.h
@@ -21,5 +21,11 @@ namespace syncd
 
                MOCK_METHOD1(removeSelectableFromTracker,
                               bool(swss::Selectable *selectable));
+
+               MOCK_CONST_METHOD1(selectableIsTracked,
+                              bool(swss::Selectable *selectable));
+
+               MOCK_CONST_METHOD1(getEventHandlerForSelectable,
+                              std::shared_ptr<SelectableEventHandler>(swss::Selectable *selectable));
      };
 }  // namespace syncd

--- a/unittest/syncd/MockSelectablesTracker.h
+++ b/unittest/syncd/MockSelectablesTracker.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <memory>
+
+#include "SelectablesTracker.h"
+#include "gmock/gmock.h"
+
+namespace syncd
+{
+
+     class MockSelectablesTracker : public SelectablesTracker
+     {
+          public:
+
+               MockSelectablesTracker() : SelectablesTracker() {}
+
+               ~MockSelectablesTracker() override {}
+
+               MOCK_METHOD2(addSelectableToTracker, bool(swss::Selectable *selectable,
+                              std::shared_ptr<SelectableEventHandler> eventHandler));
+
+               MOCK_METHOD1(removeSelectableFromTracker,
+                              bool(swss::Selectable *selectable));
+     };
+}  // namespace syncd

--- a/unittest/syncd/TestSelectablesTracker.cpp
+++ b/unittest/syncd/TestSelectablesTracker.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "SelectablesTracker.h"
+
+using namespace syncd;
+
+class SelectableEventHandlerTestHelper : public SelectableEventHandler
+{
+    public:
+
+        SelectableEventHandlerTestHelper() {}
+        ~SelectableEventHandlerTestHelper() {}
+
+        void handleSelectableEvent() {}
+};
+
+class SelectablesTrackerTest : public ::testing::Test
+{
+    public:
+
+        SelectablesTrackerTest() {}
+
+        SelectablesTracker m_selectablesTracker_;
+};
+
+TEST_F(SelectablesTrackerTest, AddSelectableFailsIfSelectableNull)
+{
+    auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
+
+    EXPECT_FALSE(m_selectablesTracker_.addSelectableToTracker(
+            /*selectable=*/nullptr, eventHandler));
+}
+
+TEST_F(SelectablesTrackerTest, AddSelectableFailsIfEventHandlerNull)
+{
+    swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+
+    EXPECT_FALSE(m_selectablesTracker_.addSelectableToTracker(
+            (swss::Selectable *)&timer, /*eventHandler=*/nullptr));
+}
+
+TEST_F(SelectablesTrackerTest, AddSelectableSucceeds)
+{
+      swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+      auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
+
+      EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+              (swss::Selectable *)&timer, eventHandler));
+}
+
+TEST_F(SelectablesTrackerTest, AddSelectableFailsIfSelectableExists)
+{
+    // Add a selectable timer to tracker.
+    swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+    auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
+
+    EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+            (swss::Selectable *)&timer, eventHandler));
+
+    // Adding the same selectable timer to tracker should fail.
+    auto eventHandler2 = std::make_shared<SelectableEventHandlerTestHelper>();
+    EXPECT_FALSE(m_selectablesTracker_.addSelectableToTracker(
+            (swss::Selectable *)&timer, eventHandler2));
+}
+
+TEST_F(SelectablesTrackerTest, RemoveSelectableFailsIfSelectableNull)
+{
+    EXPECT_FALSE(
+            m_selectablesTracker_.removeSelectableFromTracker(/*selectable=*/nullptr));
+}
+
+TEST_F(SelectablesTrackerTest, RemoveSelectableFailsIfSelectableNotExist)
+{
+    swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+
+    EXPECT_FALSE(m_selectablesTracker_.removeSelectableFromTracker(
+            (swss::Selectable *)&timer));
+}
+
+TEST_F(SelectablesTrackerTest, RemoveSelectableSucceeds)
+{
+    // Add a selectable timer.
+    swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+    auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
+
+    EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+            (swss::Selectable *)&timer, eventHandler));
+
+    // Remove the selectable timer just added in tracker.
+    EXPECT_TRUE(m_selectablesTracker_.removeSelectableFromTracker(
+            (swss::Selectable *)&timer));
+
+    // Removing the selectable timer again should fail.
+    EXPECT_FALSE(m_selectablesTracker_.removeSelectableFromTracker(
+            (swss::Selectable *)&timer));
+}
+
+TEST_F(SelectablesTrackerTest, NullptrSelectableIsNotTracked)
+{
+    EXPECT_FALSE(
+            m_selectablesTracker_.selectableIsTracked(/*selectable=*/nullptr));
+}
+
+TEST_F(SelectablesTrackerTest, SelectableIsNotTracked)
+{
+    swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+    EXPECT_FALSE(
+            m_selectablesTracker_.selectableIsTracked((swss::Selectable *)&timer));
+}
+
+TEST_F(SelectablesTrackerTest, SelectableIsTracked)
+{
+    // Add the Selectable in the tracker.
+    swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+    auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
+
+    EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+            (swss::Selectable *)&timer, eventHandler));
+
+    // Verify the Selectable in the tracker.
+    EXPECT_TRUE(
+        m_selectablesTracker_.selectableIsTracked((swss::Selectable *)&timer));
+
+    // Remove the Selectable from tracker.
+    EXPECT_TRUE(m_selectablesTracker_.removeSelectableFromTracker(
+        (swss::Selectable *)&timer));
+
+    // Check the Selectable in tracker again, this time it should fail.
+    EXPECT_FALSE(
+        m_selectablesTracker_.selectableIsTracked((swss::Selectable *)&timer));
+}
+
+TEST_F(SelectablesTrackerTest, GetEventHandlerFailsIfSelectableNull)
+{
+    EXPECT_EQ(
+            m_selectablesTracker_.getEventHandlerForSelectable(/*selectable=*/nullptr),
+            nullptr);
+}
+
+TEST_F(SelectablesTrackerTest, GetEventHandlerFailsIfSelectableNotExist)
+{
+    swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+    EXPECT_EQ(m_selectablesTracker_.getEventHandlerForSelectable(
+                  (swss::Selectable *)&timer),
+              nullptr);
+}
+
+TEST_F(SelectablesTrackerTest, GetEventHandlerSucceeds)
+{
+    // Add a selectable timer.
+    swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
+    auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
+
+    EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+            (swss::Selectable *)&timer, eventHandler));
+
+    // Get the event handler for the selectable timer.
+    EXPECT_EQ(m_selectablesTracker_.getEventHandlerForSelectable(
+                  (swss::Selectable *)&timer),
+              eventHandler);
+}

--- a/unittest/syncd/TestSelectablesTracker.cpp
+++ b/unittest/syncd/TestSelectablesTracker.cpp
@@ -22,14 +22,28 @@ class SelectablesTrackerTest : public ::testing::Test
 
         SelectablesTrackerTest() {}
 
-        SelectablesTracker m_selectablesTracker_;
+    protected:
+
+        void SetUp() override
+        {
+            m_selectablesTracker_ = std::make_unique<SelectablesTracker>();
+        }
+
+        void TearDown() override
+        {
+            // Destroy the tracker before stack-allocated timers go out of
+            // scope to avoid use-after-free on dangling Selectable pointers.
+            m_selectablesTracker_.reset();
+        }
+
+        std::unique_ptr<SelectablesTracker> m_selectablesTracker_;
 };
 
 TEST_F(SelectablesTrackerTest, AddSelectableFailsIfSelectableNull)
 {
     auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
 
-    EXPECT_FALSE(m_selectablesTracker_.addSelectableToTracker(
+    EXPECT_FALSE(m_selectablesTracker_->addSelectableToTracker(
             /*selectable=*/nullptr, eventHandler));
 }
 
@@ -37,7 +51,7 @@ TEST_F(SelectablesTrackerTest, AddSelectableFailsIfEventHandlerNull)
 {
     swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
 
-    EXPECT_FALSE(m_selectablesTracker_.addSelectableToTracker(
+    EXPECT_FALSE(m_selectablesTracker_->addSelectableToTracker(
             (swss::Selectable *)&timer, /*eventHandler=*/nullptr));
 }
 
@@ -46,7 +60,7 @@ TEST_F(SelectablesTrackerTest, AddSelectableSucceeds)
       swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
       auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
 
-      EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+      EXPECT_TRUE(m_selectablesTracker_->addSelectableToTracker(
               (swss::Selectable *)&timer, eventHandler));
 }
 
@@ -56,26 +70,26 @@ TEST_F(SelectablesTrackerTest, AddSelectableFailsIfSelectableExists)
     swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
     auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
 
-    EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+    EXPECT_TRUE(m_selectablesTracker_->addSelectableToTracker(
             (swss::Selectable *)&timer, eventHandler));
 
     // Adding the same selectable timer to tracker should fail.
     auto eventHandler2 = std::make_shared<SelectableEventHandlerTestHelper>();
-    EXPECT_FALSE(m_selectablesTracker_.addSelectableToTracker(
+    EXPECT_FALSE(m_selectablesTracker_->addSelectableToTracker(
             (swss::Selectable *)&timer, eventHandler2));
 }
 
 TEST_F(SelectablesTrackerTest, RemoveSelectableFailsIfSelectableNull)
 {
     EXPECT_FALSE(
-            m_selectablesTracker_.removeSelectableFromTracker(/*selectable=*/nullptr));
+            m_selectablesTracker_->removeSelectableFromTracker(/*selectable=*/nullptr));
 }
 
 TEST_F(SelectablesTrackerTest, RemoveSelectableFailsIfSelectableNotExist)
 {
     swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
 
-    EXPECT_FALSE(m_selectablesTracker_.removeSelectableFromTracker(
+    EXPECT_FALSE(m_selectablesTracker_->removeSelectableFromTracker(
             (swss::Selectable *)&timer));
 }
 
@@ -85,29 +99,29 @@ TEST_F(SelectablesTrackerTest, RemoveSelectableSucceeds)
     swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
     auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
 
-    EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+    EXPECT_TRUE(m_selectablesTracker_->addSelectableToTracker(
             (swss::Selectable *)&timer, eventHandler));
 
     // Remove the selectable timer just added in tracker.
-    EXPECT_TRUE(m_selectablesTracker_.removeSelectableFromTracker(
+    EXPECT_TRUE(m_selectablesTracker_->removeSelectableFromTracker(
             (swss::Selectable *)&timer));
 
     // Removing the selectable timer again should fail.
-    EXPECT_FALSE(m_selectablesTracker_.removeSelectableFromTracker(
+    EXPECT_FALSE(m_selectablesTracker_->removeSelectableFromTracker(
             (swss::Selectable *)&timer));
 }
 
 TEST_F(SelectablesTrackerTest, NullptrSelectableIsNotTracked)
 {
     EXPECT_FALSE(
-            m_selectablesTracker_.selectableIsTracked(/*selectable=*/nullptr));
+            m_selectablesTracker_->selectableIsTracked(/*selectable=*/nullptr));
 }
 
 TEST_F(SelectablesTrackerTest, SelectableIsNotTracked)
 {
     swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
     EXPECT_FALSE(
-            m_selectablesTracker_.selectableIsTracked((swss::Selectable *)&timer));
+            m_selectablesTracker_->selectableIsTracked((swss::Selectable *)&timer));
 }
 
 TEST_F(SelectablesTrackerTest, SelectableIsTracked)
@@ -116,33 +130,33 @@ TEST_F(SelectablesTrackerTest, SelectableIsTracked)
     swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
     auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
 
-    EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+    EXPECT_TRUE(m_selectablesTracker_->addSelectableToTracker(
             (swss::Selectable *)&timer, eventHandler));
 
     // Verify the Selectable in the tracker.
     EXPECT_TRUE(
-        m_selectablesTracker_.selectableIsTracked((swss::Selectable *)&timer));
+        m_selectablesTracker_->selectableIsTracked((swss::Selectable *)&timer));
 
     // Remove the Selectable from tracker.
-    EXPECT_TRUE(m_selectablesTracker_.removeSelectableFromTracker(
+    EXPECT_TRUE(m_selectablesTracker_->removeSelectableFromTracker(
         (swss::Selectable *)&timer));
 
     // Check the Selectable in tracker again, this time it should fail.
     EXPECT_FALSE(
-        m_selectablesTracker_.selectableIsTracked((swss::Selectable *)&timer));
+        m_selectablesTracker_->selectableIsTracked((swss::Selectable *)&timer));
 }
 
 TEST_F(SelectablesTrackerTest, GetEventHandlerFailsIfSelectableNull)
 {
     EXPECT_EQ(
-            m_selectablesTracker_.getEventHandlerForSelectable(/*selectable=*/nullptr),
+            m_selectablesTracker_->getEventHandlerForSelectable(/*selectable=*/nullptr),
             nullptr);
 }
 
 TEST_F(SelectablesTrackerTest, GetEventHandlerFailsIfSelectableNotExist)
 {
     swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
-    EXPECT_EQ(m_selectablesTracker_.getEventHandlerForSelectable(
+    EXPECT_EQ(m_selectablesTracker_->getEventHandlerForSelectable(
                   (swss::Selectable *)&timer),
               nullptr);
 }
@@ -153,11 +167,11 @@ TEST_F(SelectablesTrackerTest, GetEventHandlerSucceeds)
     swss::SelectableTimer timer(/*interval=*/{.tv_sec = 10, .tv_nsec = 20});
     auto eventHandler = std::make_shared<SelectableEventHandlerTestHelper>();
 
-    EXPECT_TRUE(m_selectablesTracker_.addSelectableToTracker(
+    EXPECT_TRUE(m_selectablesTracker_->addSelectableToTracker(
             (swss::Selectable *)&timer, eventHandler));
 
     // Get the event handler for the selectable timer.
-    EXPECT_EQ(m_selectablesTracker_.getEventHandlerForSelectable(
+    EXPECT_EQ(m_selectablesTracker_->getEventHandlerForSelectable(
                   (swss::Selectable *)&timer),
               eventHandler);
 }


### PR DESCRIPTION
## Summary

Supersedes #1323 by @Ashish1805. Adds the `SelectablesTracker` class for tracking selectable timers used by the link event damper in syncd.

This is part of the Link Event Damping feature ([HLD: sonic-net/SONiC#1071](https://github.com/sonic-net/SONiC/pull/1071)).

**All review feedback from #1323 has been addressed:**
- Moved class members to `private` (@kcudnik)
- Replaced raw pointers with `shared_ptr` for memory safety (@kcudnik)
- Fixed code ordering -- null checks before `getFd()` call (@Junchao-Mellanox)
- Added empty line before `if()` blocks (@kcudnik)
- CodeQL `constexpr` fix already present on master

**Changes:**
- `syncd/SelectablesTracker.h` -- Header with private members, shared_ptr interface
- `syncd/SelectablesTracker.cpp` -- Implementation with proper null checking order
- `unittest/syncd/TestSelectablesTracker.cpp` -- 11 unit test cases
- `unittest/syncd/MockSelectablesTracker.h` -- Mock class in separate file
- Build integration in both `syncd/Makefile.am` and `unittest/syncd/Makefile.am`

**Dependency chain:** This PR is a prerequisite for the per-port link event damper (#1334) and the libsai RedisInterface (#1331).

## Test plan
- [ ] 11 new unit tests covering add/remove/get operations, null handling, duplicate detection
- [ ] Existing syncd unit tests pass (no regressions)
- [ ] Azure Pipelines CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Ashish Singh <ashish.singh@google.com>