### PR TITLE
Reduce port snoop notification log level from NOTICE to INFO

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -6841,7 +6841,7 @@ void Meta::meta_sai_on_port_host_tx_ready_change(
 
     if (!m_oids.objectReferenceExists(port_id))
     {
-        SWSS_LOG_NOTICE("port_id new object spotted %s not present in local DB (snoop!)",
+        SWSS_LOG_INFO("port_id new object spotted %s not present in local DB (snoop!)",
                 sai_serialize_object_id(port_id).c_str());
 
         sai_object_meta_key_t host_tx_ready_key = { .objecttype = ot, .objectkey = { .key = { .object_id = port_id } } };
@@ -6985,7 +6985,7 @@ void Meta::meta_sai_on_port_state_change_single(
 
     if (valid && !m_oids.objectReferenceExists(data.port_id))
     {
-        SWSS_LOG_NOTICE("data.port_id new object spotted %s not present in local DB (snoop!)",
+        SWSS_LOG_INFO("data.port_id new object spotted %s not present in local DB (snoop!)",
                 sai_serialize_object_id(data.port_id).c_str());
 
         sai_object_meta_key_t key = { .objecttype = ot, .objectkey = { .key = { .object_id = data.port_id } } };

--- a/unittest/meta/Makefile.am
+++ b/unittest/meta/Makefile.am
@@ -20,6 +20,7 @@ tests_SOURCES = \
 				TestNotificationFactory.cpp \
 				TestNotificationFdbEvent.cpp \
 				TestNotificationNatEvent.cpp \
+				TestNotificationPortHostTxReadyEvent.cpp \
 				TestNotificationPortStateChange.cpp \
 				TestNotificationQueuePfcDeadlock.cpp \
 				TestNotificationSwitchShutdownRequest.cpp \

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -2157,3 +2157,82 @@ TEST(Meta, meta_validation_uint64_range_list)
     // Remove exercises meta_generic_validation_post_remove (UINT64_RANGE_LIST path)
     EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(SAI_OBJECT_TYPE_TAM_INT, tam_int_id));
 }
+
+TEST(Meta, meta_sai_on_port_state_change_snoop)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchId = 0;
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, &attr));
+
+    // Port OID not in local DB — hits the snoop path (SWSS_LOG_INFO)
+    sai_port_oper_status_notification_t data;
+    data.port_id = 0x100000000001a; // encodes as SAI_OBJECT_TYPE_PORT
+    data.port_state = SAI_PORT_OPER_STATUS_UP;
+
+    m.meta_sai_on_port_state_change(1, &data);
+
+    // SAI_NULL_OBJECT_ID — hits the invalid type error path
+    data.port_id = SAI_NULL_OBJECT_ID;
+    m.meta_sai_on_port_state_change(1, &data);
+
+    // Port that IS in the DB — should NOT hit the snoop path
+    sai_object_id_t portId = create_port(m, switchId);
+    data.port_id = portId;
+    data.port_state = SAI_PORT_OPER_STATUS_UP;
+    m.meta_sai_on_port_state_change(1, &data);
+
+    // count > 0 with NULL data pointer — hits the NULL guard
+    m.meta_sai_on_port_state_change(1, nullptr);
+
+    // count == 0 — no-op
+    m.meta_sai_on_port_state_change(0, nullptr);
+}
+
+TEST(Meta, meta_sai_on_port_host_tx_ready_change_snoop)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchId = 0;
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, &attr));
+
+    // Port OID not in local DB — hits the snoop path (SWSS_LOG_INFO)
+    m.meta_sai_on_port_host_tx_ready_change(
+            0x100000000001a, // encodes as SAI_OBJECT_TYPE_PORT, not in local DB
+            switchId,
+            SAI_PORT_HOST_TX_READY_STATUS_READY);
+
+    // SAI_NULL_OBJECT_ID — hits the unexpected type error path
+    m.meta_sai_on_port_host_tx_ready_change(
+            SAI_NULL_OBJECT_ID,
+            switchId,
+            SAI_PORT_HOST_TX_READY_STATUS_READY);
+
+    // Invalid enum value — early return, drops notification
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+    m.meta_sai_on_port_host_tx_ready_change(
+            0x100000000001a,
+            switchId,
+            (sai_port_host_tx_ready_status_t)9999);
+#pragma GCC diagnostic pop
+
+    // Port that IS in the DB — should NOT hit the snoop path
+    sai_object_id_t portId = create_port(m, switchId);
+    m.meta_sai_on_port_host_tx_ready_change(
+            portId,
+            switchId,
+            SAI_PORT_HOST_TX_READY_STATUS_NOT_READY);
+}

--- a/unittest/meta/TestNotificationPortHostTxReadyEvent.cpp
+++ b/unittest/meta/TestNotificationPortHostTxReadyEvent.cpp
@@ -17,40 +17,36 @@ static std::string fullnull = "[]";
 
 TEST(NotificationPortHostTxReadyEvent, ctr)
 {
-    NotificationPortHostTxReadyEvent n(s);
+    NotificationPortHostTxReady n(s);
 }
 
 TEST(NotificationPortHostTxReadyEvent, getSwitchId)
 {
-    NotificationPortHostTxReadyEvent n(s);
+    NotificationPortHostTxReady n(s);
 
     EXPECT_EQ(n.getSwitchId(), 0x2100000000);
 
-    NotificationSwitchStateChange n2(null);
+    NotificationPortHostTxReady n2(null);
 
     EXPECT_EQ(n2.getSwitchId(), 0);
 }
 
 TEST(NotificationPortHostTxReadyEvent, getAnyObjectId)
 {
-    NotificationPortHostTxReadyEvent n(s);
+    NotificationPortHostTxReady n(s);
 
     EXPECT_EQ(n.getAnyObjectId(), 0x100000000001a);
 
-    NotificationPortHostTxReadyEvent n2(null);
+    NotificationPortHostTxReady n2(null);
 
     EXPECT_EQ(n2.getAnyObjectId(), 0);
 
-    NotificationPortHostTxReadyEvent n3(fullnull);
-
-    EXPECT_EQ(n3.getSwitchId(), 0);
-
-    EXPECT_EQ(n3.getAnyObjectId(), 0);
+    EXPECT_THROW(NotificationPortHostTxReady n3(fullnull), std::exception);
 }
 
 TEST(NotificationPortHostTxReadyEvent, processMetadata)
 {
-    NotificationPortHostTxReadyEvent n(s);
+    NotificationPortHostTxReady n(s);
 
     auto sai = std::make_shared<MetaTestSaiInterface>();
     auto meta = std::make_shared<Meta>(sai);
@@ -68,11 +64,11 @@ static void on_port_host_tx_ready_change_notification(
 
 TEST(NotificationPortHostTxReadyEvent, executeCallback)
 {
-    NotificationPortHostTxReadyEvent n(s);
+    NotificationPortHostTxReady n(s);
 
     sai_switch_notifications_t ntfs;
 
-    ntfs.on_port_host_tx_ready_change = &on_port_host_tx_ready_change_notification;
+    ntfs.on_port_host_tx_ready = &on_port_host_tx_ready_change_notification;
 
     n.executeCallback(ntfs);
 }


### PR DESCRIPTION
## Description
Reduces the log level of port snoop notifications in the SAI meta layer from `NOTICE` to `INFO`.

### Why
SAI 14.1 corrected the link scan callback sequence (was broken in 13.2.1). Now SAI correctly sends port state change notifications (link down) immediately after switch create, before orchagent has finished creating/discovering ports. The meta layer's snoop mechanism handles this correctly by auto-discovering the ports, but logs at `NOTICE` level for each one.

On chassis platforms (BCM DNX) with 100+ front panel and fabric ports, this produces excessive syslog noise at boot:
```
```

### What changed
- `meta_sai_on_port_state_change_single()`: `SWSS_LOG_NOTICE` → `SWSS_LOG_INFO`
- `meta_sai_on_port_host_tx_ready_change()`: `SWSS_LOG_NOTICE` → `SWSS_LOG_INFO`

The snoop mechanism continues to work identically — only the log level changes. Messages remain available at INFO level for debugging.

### Precedent
The existing `post get` snoop at line 5630 already uses `META_LOG_INFO` for the same pattern.

Fixes: sonic-net/sonic-buildimage#24871