### PR TITLE
Fix use-after-free in VPP message handler registration

### DIFF
--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -519,7 +519,9 @@ vl_msg_api_set_handlers (int id, const char *name, void *handler, void *cleanup,
     c->fromjson = fromjson;
     c->calc_size = calc_size;
     vl_msg_api_config (c);
-    free(name_copy);
+    /* Do not free name_copy: vl_msg_api_config stores the pointer in
+       m->name and in the msg_id_by_name hash table. Freeing it causes
+       use-after-free when the hash does strcmp on existing keys. */
 }
 
 static bool vl_api_to_vpp_ip_addr(vl_api_address_t *vpp_addr, vpp_ip_addr_t *ipaddr)


### PR DESCRIPTION
vl_msg_api_set_handlers() calls strdup(name) and passes the pointer to vl_msg_api_config() which stores it directly in m->name and as a hash key in msg_id_by_name (via hash_set_mem). Freeing name_copy after this call leaves dangling pointers that cause use-after-free when the hash does strcmp on existing keys during subsequent handler registrations.

