### PR TITLE
Fix spurious ERROR log on router interface creation

### DIFF
--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1902,10 +1902,10 @@ sai_status_t SwitchVpp::createRouterif(
 
     if (m_switchConfig->m_useTapDevice == true)
     {
-        sai_attribute_t tattr;
+        auto sid = sai_serialize_object_id(object_id);
+        auto &objectHash = m_objectHash.at(SAI_OBJECT_TYPE_ROUTER_INTERFACE);
 
-        tattr.id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
-        if (get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, object_id, 1, &tattr) == SAI_STATUS_ITEM_NOT_FOUND)
+        if (objectHash.find(sid) == objectHash.end())
         {
             vpp_create_router_interface(attr_count, attr_list);
         } else {


### PR DESCRIPTION
Replace get() with direct m_objectHash lookup in createRouterif() to avoid false ERROR log when creating a new router interface. The get() call was only used to check existence (return value never read), but it unconditionally logs ERROR for missing objects.

This pattern (m_objectHash.at(type).find(sid)) is already used in set_internal() and remove_internal().