### PR TITLE
Increase syncd watchdog timeout to 60s for VPP

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -504,6 +504,10 @@ vpp_api_check()
 config_syncd_vpp()
 {
     CMD_ARGS+=" -l -p $HWSKU_DIR/sai_vpp.profile"
+    # VPP processes bulk route entries synchronously (one VPP API call per route).
+    # A bulkset of ~1000 routes can take ~50 seconds, exceeding the default 30s
+    # watchdog. Increase to 60s to avoid false watchdog ERR logs.
+    CMD_ARGS+=" -w 60000000"
     vpp_api_check "/run/vpp/api.sock"
     source /etc/sonic/vpp/syncd_vpp_env
     export NO_LINUX_NL


### PR DESCRIPTION
VPP processes route entries synchronously via individual API calls (ip_route_add_del). During BGP reconvergence, bulk route programming can exceed the default 30s watchdog timeout, causing false ERR logs.

Set to 60s for now to allow tests to pass. This may need further tuning based on topology size and route scale.