### PR TITLE
[Mellanox] Activate phcsync gate to prevent clock sync during warm reboot

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -401,7 +401,7 @@ config_syncd_mlnx()
 
     # As long as sonic does not support PTP which can be enabled/disabled, Nvidia platforms enables
     # phcsync for all systems. If HW does not support it, it will do nothing.
-    supervisorctl start phcsync
+    supervisorctl start phcsync-gate
 
     if [ -f "$HWSKU_DIR/context_config.json" ]; then
         CMD_ARGS+=" -x $HWSKU_DIR/context_config.json -g 0"


### PR DESCRIPTION
Activate phcsync_warm_reboot_gate.py when syncd starts instead of invoking phcsync.sh directly.

This PR is related to:
https://github.com/sonic-net/sonic-buildimage/pull/26332
https://github.com/sonic-net/sonic-swss-common/pull/1161

Together, these PRs introduce an event-driven mechanism that starts and stops phcsync.sh during a warm reboot.

Order of merge:
1. https://github.com/sonic-net/sonic-swss-common/pull/1161
2. https://github.com/sonic-net/sonic-buildimage/pull/26332
3. https://github.com/sonic-net/sonic-sairedis/pull/1810