### PR TITLE
vslib: add enum capability for HFTel TAM transport and bind-point

### DIFF
--- a/unittest/vslib/TestSwitchStateBase.cpp
+++ b/unittest/vslib/TestSwitchStateBase.cpp
@@ -270,6 +270,48 @@ TEST_F(SwitchStateBaseTest, bufferProfilePacketAdmissionFailActionCapabilitiesGe
     ASSERT_EQ(paSet1, paSet2);
 }
 
+TEST_F(SwitchStateBaseTest, tamTransportTypeCapabilitiesGet)
+{
+    sai_s32_list_t data = { .count = 0, .list = nullptr };
+
+    auto status = m_ss->queryAttrEnumValuesCapability(
+        m_swid, SAI_OBJECT_TYPE_TAM_TRANSPORT, SAI_TAM_TRANSPORT_ATTR_TRANSPORT_TYPE, &data
+    );
+    ASSERT_EQ(status, SAI_STATUS_BUFFER_OVERFLOW);
+    ASSERT_EQ(data.count, 1U);
+
+    std::vector<sai_int32_t> values(data.count);
+    data.list = values.data();
+
+    status = m_ss->queryAttrEnumValuesCapability(
+        m_swid, SAI_OBJECT_TYPE_TAM_TRANSPORT, SAI_TAM_TRANSPORT_ATTR_TRANSPORT_TYPE, &data
+    );
+    ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+    ASSERT_EQ(data.count, 1U);
+    ASSERT_EQ(static_cast<sai_tam_transport_type_t>(values[0]), SAI_TAM_TRANSPORT_TYPE_NONE);
+}
+
+TEST_F(SwitchStateBaseTest, tamBindPointTypeCapabilitiesGet)
+{
+    sai_s32_list_t data = { .count = 0, .list = nullptr };
+
+    auto status = m_ss->queryAttrEnumValuesCapability(
+        m_swid, SAI_OBJECT_TYPE_TAM, SAI_TAM_ATTR_TAM_BIND_POINT_TYPE_LIST, &data
+    );
+    ASSERT_EQ(status, SAI_STATUS_BUFFER_OVERFLOW);
+    ASSERT_EQ(data.count, 1U);
+
+    std::vector<sai_int32_t> values(data.count);
+    data.list = values.data();
+
+    status = m_ss->queryAttrEnumValuesCapability(
+        m_swid, SAI_OBJECT_TYPE_TAM, SAI_TAM_ATTR_TAM_BIND_POINT_TYPE_LIST, &data
+    );
+    ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+    ASSERT_EQ(data.count, 1U);
+    ASSERT_EQ(static_cast<sai_tam_bind_point_type_t>(values[0]), SAI_TAM_BIND_POINT_TYPE_SWITCH);
+}
+
 TEST_F(SwitchStateBaseTest, switchQoSMaxNumOfTrafficClasses)
 {
     ASSERT_EQ(m_ss->set_maximum_number_of_traffic_classes(), SAI_STATUS_SUCCESS);

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -4281,6 +4281,46 @@ sai_status_t SwitchStateBase::queryBufferProfilePacketAdmissionFailActionCapabil
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchStateBase::queryTamTransportTypeCapability(
+                   _Inout_ sai_s32_list_t *enum_values_capability)
+{
+    SWSS_LOG_ENTER();
+
+    /* SAI_TAM_TRANSPORT_TYPE_NONE. */
+    constexpr uint32_t value_count = 1;
+
+    if (enum_values_capability->count < value_count)
+    {
+        enum_values_capability->count = value_count;
+        return SAI_STATUS_BUFFER_OVERFLOW;
+    }
+
+    enum_values_capability->count = value_count;
+    enum_values_capability->list[0] = SAI_TAM_TRANSPORT_TYPE_NONE;
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchStateBase::queryTamBindPointTypeCapability(
+                   _Inout_ sai_s32_list_t *enum_values_capability)
+{
+    SWSS_LOG_ENTER();
+
+    /* SAI_TAM_BIND_POINT_TYPE_SWITCH. */
+    constexpr uint32_t value_count = 1;
+
+    if (enum_values_capability->count < value_count)
+    {
+        enum_values_capability->count = value_count;
+        return SAI_STATUS_BUFFER_OVERFLOW;
+    }
+
+    enum_values_capability->count = value_count;
+    enum_values_capability->list[0] = SAI_TAM_BIND_POINT_TYPE_SWITCH;
+
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t SwitchStateBase::queryAttrEnumValuesCapability(
                               _In_ sai_object_id_t switch_id,
                               _In_ sai_object_type_t object_type,
@@ -4323,6 +4363,14 @@ sai_status_t SwitchStateBase::queryAttrEnumValuesCapability(
     else if (object_type == SAI_OBJECT_TYPE_BUFFER_PROFILE && attr_id == SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION)
     {
         return queryBufferProfilePacketAdmissionFailActionCapability(enum_values_capability);
+    }
+    else if (object_type == SAI_OBJECT_TYPE_TAM_TRANSPORT && attr_id == SAI_TAM_TRANSPORT_ATTR_TRANSPORT_TYPE)
+    {
+        return queryTamTransportTypeCapability(enum_values_capability);
+    }
+    else if (object_type == SAI_OBJECT_TYPE_TAM && attr_id == SAI_TAM_ATTR_TAM_BIND_POINT_TYPE_LIST)
+    {
+        return queryTamBindPointTypeCapability(enum_values_capability);
     }
 
     return SAI_STATUS_NOT_SUPPORTED;

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -779,6 +779,12 @@ namespace saivs
             virtual sai_status_t queryBufferProfilePacketAdmissionFailActionCapability(
                                       _Inout_ sai_s32_list_t *enum_values_capability);
 
+            virtual sai_status_t queryTamTransportTypeCapability(
+                                      _Inout_ sai_s32_list_t *enum_values_capability);
+
+            virtual sai_status_t queryTamBindPointTypeCapability(
+                                      _Inout_ sai_s32_list_t *enum_values_capability);
+
             virtual sai_status_t queryPortAutonegFecOverrideSupportCapability(
                                       _Out_ sai_attr_capability_t *attr_capability);
 


### PR DESCRIPTION
**Why**
PR https://github.com/sonic-net/sonic-swss/pull/4367 updates HFTel capability detection logic. Tests under the PR are failing due to missing enum capability for HFTel TAM transport and bind-point attributes.

**How**
Expose sai_query_attribute_enum_values_capability support in the virtual switch for SAI_TAM_TRANSPORT_ATTR_TRANSPORT_TYPE and SAI_TAM_ATTR_TAM_BIND_POINT_TYPE_LIST so orchagent HFTel capability checks pass under DVS. Report only the values required by HFTel: SAI_TAM_TRANSPORT_TYPE_NONE and SAI_TAM_BIND_POINT_TYPE_SWITCH.

Add queryTamTransportTypeCapability and queryTamBindPointTypeCapability, following the same pattern as queryBufferProfilePacketAdmissionFailActionCapability.



**UT **
```
test_hft.py::TestHFT::test_simple_hft_one_counter PASSED [  7%]
test_hft.py::TestHFT::test_hft_multiple_counters PASSED [ 14%]
test_hft.py::TestHFT::test_hft_delete_group_and_rejoin PASSED [ 21%]
test_hft.py::TestHFT::test_hft_profile_status_disabled PASSED   [ 28%]
test_hft.py::TestHFT::test_hft_custom_polling_interval PASSED  [ 35%]
test_hft.py::TestHFT::test_hft_stream_state_sync_to_state_db PASSED [ 42%]
test_hft.py::TestHFT::test_hft_empty_fields_with_disabled_status PASSED [ 50%]
test_hft.py::TestHFT::test_hft_missing_fields_with_disabled_status PASSED [ 57%]
test_hft.py::TestHFT::test_hft_buffer_queue_group PASSED [ 64%]
test_hft.py::TestHFT::test_hft_multiple_groups PASSED [ 71%]
test_hft.py::TestHFT::test_hft_invalid_counters_no_orchagent_restart PASSED [ 78%]
test_hft.py::TestHFT::test_hft_empty_group_name_no_orchagent_restart PASSED  [ 85%]
test_hft.py::TestHFT::test_hft_empty_default_config_cleanup PASSED [ 92%]
test_hft.py::test_nonflaky_dummy PASSED [100%]
```