### PR TITLE
[test] Fix flaky FlexCounter.bulkChunksize under AddressSanitizer

### DIFF
--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -6,6 +6,7 @@
 #include "VidManager.h"
 #include "NumberOidIndexGenerator.h"
 #include <string>
+#include <atomic>
 #include <chrono>
 #include <fstream>
 #include <gtest/gtest.h>
@@ -235,7 +236,8 @@ void testAddRemoveCounter(
         bool bulkChunkSizeAfterPort = true,
         const std::string pluginName = "",
         bool immediatelyRemoveBulkChunkSizePerCounter = false,
-        bool forceSingleCreate = false)
+        bool forceSingleCreate = false,
+        std::function<void()> onChunkConfigApplied = nullptr)
 {
     SWSS_LOG_ENTER();
 
@@ -297,6 +299,10 @@ void testAddRemoveCounter(
             bulkChunkSizeValues.clear();
             bulkChunkSizeValues.emplace_back(BULK_CHUNK_SIZE_PER_PREFIX_FIELD, "");
             fc.addCounterPlugin(bulkChunkSizeValues);
+        }
+        if (onChunkConfigApplied)
+        {
+            onChunkConfigApplied();
         }
     }
 
@@ -1376,6 +1382,15 @@ TEST(FlexCounter, bulkCounter)
 TEST(FlexCounter, bulkChunksize)
 {
     /*
+     * Atomic flag to synchronize the test thread and the FlexCounter worker
+     * thread. Under AddressSanitizer the worker may poll before the test
+     * finishes setting up chunk-size configuration. The mock treats any
+     * post-init poll that arrives before this flag is set as an extra
+     * initialization call (no chunk-size assertions).
+     */
+    std::atomic<bool> chunkConfigReady{false};
+
+    /*
      * Test logic
      * 1. Generate counter values and store them whenever the bulk get stat is called after initialization
      * 2. Convert stored counter values to string when the verify function is called
@@ -1551,6 +1566,33 @@ TEST(FlexCounter, bulkChunksize)
             return SAI_STATUS_SUCCESS;
         }
 
+        /*
+         * Guard against race: the FlexCounter worker thread may poll after
+         * initialCheckCount is consumed but before chunk-size configuration
+         * has been applied by the test thread. This is especially likely
+         * under AddressSanitizer where the test thread runs 2-5x slower.
+         * Treat such calls as extra initialization — populate counters
+         * without asserting chunk sizes.
+         */
+        if (!chunkConfigReady.load(std::memory_order_acquire))
+        {
+            for (uint32_t i = 0; i < object_count; i++)
+            {
+                object_status[i] = SAI_STATUS_SUCCESS;
+                auto &counterMap = counterValuesMap[object_keys[i].key.object_id];
+                for (uint32_t j = 0; j < number_of_counters; j++)
+                {
+                    const auto &searchRef = counterMap.find(counter_ids[j]);
+                    if (searchRef == counterMap.end())
+                    {
+                        counterMap[counter_ids[j]] = ++counterSeed;
+                    }
+                    counters[i * number_of_counters + j] = counterMap[counter_ids[j]];
+                }
+            }
+            return SAI_STATUS_SUCCESS;
+        }
+
         EXPECT_TRUE(!forceSingleCall);
 
         for (uint32_t i = 0; i < object_count; i++)
@@ -1633,7 +1675,12 @@ TEST(FlexCounter, bulkChunksize)
         allObjectIds.erase(key);
     };
 
+    auto setChunkReady = [&]() {
+        chunkConfigReady.store(true, std::memory_order_release);
+    };
+
     // create ports first and then set bulk chunk size + per counter bulk chunk size
+    chunkConfigReady = false;
     initialCheckCount = 6;
     testAddRemoveCounter(
         6,
@@ -1646,10 +1693,17 @@ TEST(FlexCounter, bulkChunksize)
         STATS_MODE_READ,
         false,
         "3",
-        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2");
+        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
+        true,
+        "",
+        false,
+        false,
+        setChunkReady);
     EXPECT_TRUE(allObjectIds.empty());
 
     // set bulk chunk size + per counter bulk chunk size first and then create ports
+    // bulkChunkSizeAfterPort=false: config applied before ports, no race
+    chunkConfigReady = true;
     initialCheckCount = 6;
     testAddRemoveCounter(
         6,
@@ -1672,6 +1726,7 @@ TEST(FlexCounter, bulkChunksize)
     // Remove per counter bulk chunk size after initializing it
     // This is to cover the scenario of removing per counter bulk chunk size filed
     // All counters share a unified bulk chunk size
+    chunkConfigReady = false;
     unifiedBulkChunkSize = 3;
     initialCheckCount = 6;
     testAddRemoveCounter(
@@ -1688,11 +1743,14 @@ TEST(FlexCounter, bulkChunksize)
         "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
         true,
         "",
-        true);
+        true,
+        false,
+        setChunkReady);
     EXPECT_TRUE(allObjectIds.empty());
     unifiedBulkChunkSize = 0;
 
     // add ports counters in bulk mode first and then set bulk chunk size + per counter bulk chunk size
+    chunkConfigReady = false;
     initialCheckCount = 3;
     testAddRemoveCounter(
         6,
@@ -1705,10 +1763,17 @@ TEST(FlexCounter, bulkChunksize)
         STATS_MODE_READ,
         true,
         "3",
-        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2");
+        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
+        true,
+        "",
+        false,
+        false,
+        setChunkReady);
     EXPECT_TRUE(allObjectIds.empty());
 
     // set bulk chunk size + per counter bulk chunk size first and then add ports counters in bulk mode
+    // bulkChunkSizeAfterPort=false: config applied before ports, no race
+    chunkConfigReady = true;
     initialCheckCount = 3;
     testAddRemoveCounter(
         6,
@@ -1728,6 +1793,7 @@ TEST(FlexCounter, bulkChunksize)
 
     // add ports counters in bulk mode with some bulk-unsupported counters first and then set bulk chunk size + per counter bulk chunk size
     // all counters will be polled using single call in runtime
+    chunkConfigReady = true;
     forceSingleCall = true;
     initialCheckCount = 1; // check bulk for all counter IDs altogether
     initialCheckCount += 6; // for bulk unsupported counter prefix, check bulk again for each objects
@@ -1750,6 +1816,7 @@ TEST(FlexCounter, bulkChunksize)
     EXPECT_TRUE(allObjectIds.empty());
     forceSingleCall = false;
 
+    chunkConfigReady = true;
     forceSingleCall = true;
     noBulkCapabilityOnly = true;
     initialCheckCount = 0; // check bulk for all counter IDs altogether
@@ -1778,6 +1845,8 @@ TEST(FlexCounter, bulkChunksize)
     // set bulk chunk size + per counter bulk chunk size first and then add ports counters in bulk mode with some bulk-unsupported counters
     // All bulk-unsupported counters are polled using single call and all the rest counters are polled using bulk call
     // For each OID, it will be in both m_bulkContexts and m_objectIdsMap
+    // bulkChunkSizeAfterPort=false: config applied before ports, no race
+    chunkConfigReady = true;
     initialCheckCount = 3; // check bulk for 3 prefixes
     initialCheckCount += 6; // for bulk unsupported counter prefix, check bulk again for each objects
     testAddRemoveCounter(
@@ -1799,6 +1868,8 @@ TEST(FlexCounter, bulkChunksize)
     // set bulk chunk size + per counter bulk chunk size first and then add ports counters in bulk mode with some bulk-unsupported counters
     // All bulk-unsupported counters are polled using single call and all the rest counters are polled using bulk call
     // For each OID, it will be in both m_bulkContexts and m_objectIdsMap
+    // bulkChunkSizeAfterPort=false: config applied before ports, no race
+    chunkConfigReady = true;
     initialCheckCount = 3; // check bulk for 3 prefixes
     initialCheckCount += 6; // for bulk unsupported counter prefix, check bulk again for each objects
     partialSupportingBulkObjectFactor = 2;


### PR DESCRIPTION
## Description

Fix the `FlexCounter.bulkChunksize` unit test that fails intermittently under AddressSanitizer (Asan) builds.

### Root Cause

Under Asan, the test thread runs 2-5x slower while the FlexCounter worker thread polls at its normal 1000ms interval. This creates a race condition:

1. Test creates FlexCounter with `status=enable` and `poll_interval=1000`
2. Test adds 6 port counters one by one
3. FlexCounter worker starts polling — but under Asan, only 1 port may be registered
4. Test sets `BULK_CHUNK_SIZE=3` — but the worker already consumed `initialCheckCount`

Result: `mock_bulkGetStats` receives `object_count=1` when expecting `3`, causing:
```
TestFlexCounter.cpp:1581: Failure
Expected equality of these values:
  object_count
    Which is: 1
  3
```

This failure is 100% reproducible on the BuildAsan CI pipeline.

### Fix

Added an `std::atomic<bool> chunkConfigReady` flag to synchronize the test thread and FlexCounter worker:

- **In `mock_bulkGetStats`**: after the `initialCheckCount` guard, if `chunkConfigReady` is false, treat the call as an extra initialization poll — populate counters but skip chunk-size assertions
- **In `testAddRemoveCounter`**: added an optional `onChunkConfigApplied` callback parameter that fires after chunk config is applied to the FlexCounter
- **Per test case**: flag is reset to `false` before calls where `bulkChunkSizeAfterPort=true` (config applied after ports → race possible), and pre-set to `true` for `bulkChunkSizeAfterPort=false` or `forceSingleCall=true` cases (no race)

This eliminates the timing dependency entirely — no sleeps, no increased timeouts, just explicit synchronization via atomic flag.

### Testing

- Verified the fix compiles and the test logic is correct
- The previous fix approach (PR #1766, poll-wait) solved the normal build flakiness but didn't handle the Asan case where overhead is much larger
