### PR TITLE
Enable async ASIC_DB writes for Southbound-ZMQ

### DIFF
--- a/syncd/CommandLineOptions.cpp
+++ b/syncd/CommandLineOptions.cpp
@@ -20,6 +20,7 @@ CommandLineOptions::CommandLineOptions()
     m_enableUnittests = false;
     m_enableConsistencyCheck = false;
     m_enableSyncMode = false;
+    m_enableAsyncRec = false;
     m_enableSaiBulkSupport = false;
 
     m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
@@ -63,6 +64,7 @@ std::string CommandLineOptions::getCommandLineString() const
     ss << " EnableUnittests=" << (m_enableUnittests ? "YES" : "NO");
     ss << " EnableConsistencyCheck=" << (m_enableConsistencyCheck ? "YES" : "NO");
     ss << " EnableSyncMode=" << (m_enableSyncMode ? "YES" : "NO");
+    ss << " EnableAsyncRec=" << (m_enableAsyncRec ? "YES" : "NO");
     ss << " RedisCommunicationMode=" << sai_serialize_redis_communication_mode(m_redisCommunicationMode);
     ss << " EnableSaiBulkSuport=" << (m_enableSaiBulkSupport ? "YES" : "NO");
     ss << " StartType=" << startTypeToString(m_startType);

--- a/syncd/CommandLineOptions.h
+++ b/syncd/CommandLineOptions.h
@@ -77,6 +77,14 @@ namespace syncd
 
             bool m_enableSyncMode;
 
+            /**
+             * When set to true, ASIC_DB writes are performed asynchronously on a
+             * background thread (via ZmqRedisClient) instead of synchronously on
+             * the processing thread. Only effective when ZMQ southbound is active
+             * on a non-virtual, non-DPU switch. Driven by SYSTEM_DEFAULTS|async_rec.
+             */
+            bool m_enableAsyncRec;
+
             bool m_enableSaiBulkSupport;
 
             sai_redis_communication_mode_t m_redisCommunicationMode;

--- a/syncd/CommandLineOptionsParser.cpp
+++ b/syncd/CommandLineOptionsParser.cpp
@@ -18,7 +18,10 @@ std::shared_ptr<CommandLineOptions> CommandLineOptionsParser::parseCommandLine(
 
     auto options = std::make_shared<CommandLineOptions>();
 
-    optind = 1;
+    // glibc getopt keeps global scanner state across calls. parseCommandLine may be
+    // invoked more than once within a single process, so reset with optind=0 to force
+    // full re-initialization and keep one parse from leaking state into the next.
+    optind = 0;
 
     bool initTimeSpanSeen = false;
 

--- a/syncd/CommandLineOptionsParser.cpp
+++ b/syncd/CommandLineOptionsParser.cpp
@@ -23,9 +23,9 @@ std::shared_ptr<CommandLineOptions> CommandLineOptionsParser::parseCommandLine(
     bool initTimeSpanSeen = false;
 
 #ifdef SAITHRIFT
-    const char* const optstring = "dp:t:g:x:b:B:aw:W:uSUCsz:lrm:h";
+    const char* const optstring = "dp:t:g:x:b:B:aw:W:uSUCsz:lRrm:h";
 #else
-    const char* const optstring = "dp:t:g:x:b:B:aw:W:uSUCsz:lh";
+    const char* const optstring = "dp:t:g:x:b:B:aw:W:uSUCsz:lRh";
 #endif // SAITHRIFT
 
     while (true)
@@ -42,6 +42,7 @@ std::shared_ptr<CommandLineOptions> CommandLineOptionsParser::parseCommandLine(
             { "syncMode",                no_argument,       0, 's' },
             { "redisCommunicationMode",  required_argument, 0, 'z' },
             { "enableSaiBulkSupport",    no_argument,       0, 'l' },
+            { "asyncRec",                no_argument,       0, 'R' },
             { "globalContext",           required_argument, 0, 'g' },
             { "contextContig",           required_argument, 0, 'x' },
             { "breakConfig",             required_argument, 0, 'b' },
@@ -115,6 +116,10 @@ std::shared_ptr<CommandLineOptions> CommandLineOptionsParser::parseCommandLine(
                 options->m_enableSaiBulkSupport = true;
                 break;
 
+            case 'R':
+                options->m_enableAsyncRec = true;
+                break;
+
             case 'g':
                 options->m_globalContext = (uint32_t)std::stoul(optarg);
                 break;
@@ -182,9 +187,9 @@ void CommandLineOptionsParser::printUsage()
     SWSS_LOG_ENTER();
 
 #ifdef SAITHRIFT
-    std::cout << "Usage: syncd [-d] [-p profile] [-t type] [-u] [-S] [-U] [-C] [-s] [-z mode] [-l] [-g idx] [-x contextConfig] [-b breakConfig] [-B supportingBulkCounters] [-r] [-m portmap] [-h]" << std::endl;
+    std::cout << "Usage: syncd [-d] [-p profile] [-t type] [-u] [-S] [-U] [-C] [-s] [-z mode] [-l] [-R] [-g idx] [-x contextConfig] [-b breakConfig] [-B supportingBulkCounters] [-r] [-m portmap] [-h]" << std::endl;
 #else
-    std::cout << "Usage: syncd [-d] [-p profile] [-t type] [-u] [-S] [-U] [-C] [-s] [-z mode] [-l] [-g idx] [-x contextConfig] [-b breakConfig] [-B supportingBulkCounters] [-h]" << std::endl;
+    std::cout << "Usage: syncd [-d] [-p profile] [-t type] [-u] [-S] [-U] [-C] [-s] [-z mode] [-l] [-R] [-g idx] [-x contextConfig] [-b breakConfig] [-B supportingBulkCounters] [-h]" << std::endl;
 #endif // SAITHRIFT
 
     std::cout << "    -d --diag" << std::endl;
@@ -207,6 +212,8 @@ void CommandLineOptionsParser::printUsage()
     std::cout << "        Redis communication mode (redis_async|redis_sync|zmq_sync), default: redis_async" << std::endl;
     std::cout << "    -l --enableBulk" << std::endl;
     std::cout << "        Enable SAI Bulk support" << std::endl;
+    std::cout << "    -R --asyncRec" << std::endl;
+    std::cout << "        Enable asynchronous ASIC_DB writes (only effective with ZMQ southbound)" << std::endl;
     std::cout << "    -g --globalContext" << std::endl;
     std::cout << "        Global context index to load from context config file" << std::endl;
     std::cout << "    -x --contextConfig" << std::endl;

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -59,6 +59,7 @@ libSyncd_a_SOURCES = \
 				WatchdogScope.cpp \
 				Workaround.cpp \
 				ZeroMQNotificationProducer.cpp \
+				ZmqRedisClient.cpp \
 				syncd_main.cpp
 
 libSyncd_a_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -60,6 +60,7 @@ libSyncd_a_SOURCES = \
 				WatchdogScope.cpp \
 				Workaround.cpp \
 				ZeroMQNotificationProducer.cpp \
+				ZmqRedisClient.cpp \
 				syncd_main.cpp
 
 libSyncd_a_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)

--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -33,8 +33,6 @@ RedisClient::RedisClient(
 RedisClient::~RedisClient()
 {
     SWSS_LOG_ENTER();
-
-    // empty
 }
 
 bool RedisClient::isRedisEnabled() const
@@ -508,9 +506,9 @@ void RedisClient::removeAsicObject(
 {
     SWSS_LOG_ENTER();
 
-    std::string key = (ASIC_STATE_TABLE ":") + sai_serialize_object_meta_key(metaKey);
-
-    m_dbAsic->del(key);
+    std::string key = sai_serialize_object_meta_key(metaKey);
+    std::string fullKey = (ASIC_STATE_TABLE ":") + key;
+    m_dbAsic->del(fullKey);
 }
 
 void RedisClient::removeTempAsicObject(
@@ -533,7 +531,7 @@ void RedisClient::removeAsicObjects(
     // we need to rewrite keys to add table prefix
     for (const auto& key: keys)
     {
-         prefixKeys.push_back((ASIC_STATE_TABLE ":") + key);
+            prefixKeys.push_back((ASIC_STATE_TABLE ":") + key);
     }
 
     m_dbAsic->del(prefixKeys);
@@ -562,9 +560,9 @@ void RedisClient::setAsicObject(
 {
     SWSS_LOG_ENTER();
 
-    std::string key = (ASIC_STATE_TABLE ":") + sai_serialize_object_meta_key(metaKey);
-
-    m_dbAsic->hset(key, attr, value);
+    std::string key = sai_serialize_object_meta_key(metaKey);
+    std::string fullKey = (ASIC_STATE_TABLE ":") + key;
+    m_dbAsic->hset(fullKey, attr, value);
 }
 
 void RedisClient::setTempAsicObject(

--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -33,6 +33,8 @@ RedisClient::RedisClient(
 RedisClient::~RedisClient()
 {
     SWSS_LOG_ENTER();
+
+    // empty
 }
 
 bool RedisClient::isRedisEnabled() const
@@ -506,9 +508,9 @@ void RedisClient::removeAsicObject(
 {
     SWSS_LOG_ENTER();
 
-    std::string key = sai_serialize_object_meta_key(metaKey);
-    std::string fullKey = (ASIC_STATE_TABLE ":") + key;
-    m_dbAsic->del(fullKey);
+    std::string key = (ASIC_STATE_TABLE ":") + sai_serialize_object_meta_key(metaKey);
+
+    m_dbAsic->del(key);
 }
 
 void RedisClient::removeTempAsicObject(
@@ -531,7 +533,7 @@ void RedisClient::removeAsicObjects(
     // we need to rewrite keys to add table prefix
     for (const auto& key: keys)
     {
-            prefixKeys.push_back((ASIC_STATE_TABLE ":") + key);
+         prefixKeys.push_back((ASIC_STATE_TABLE ":") + key);
     }
 
     m_dbAsic->del(prefixKeys);
@@ -560,9 +562,9 @@ void RedisClient::setAsicObject(
 {
     SWSS_LOG_ENTER();
 
-    std::string key = sai_serialize_object_meta_key(metaKey);
-    std::string fullKey = (ASIC_STATE_TABLE ":") + key;
-    m_dbAsic->hset(fullKey, attr, value);
+    std::string key = (ASIC_STATE_TABLE ":") + sai_serialize_object_meta_key(metaKey);
+
+    m_dbAsic->hset(key, attr, value);
 }
 
 void RedisClient::setTempAsicObject(

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -6,6 +6,7 @@
 #include "HardReiniter.h"
 #include "RedisClient.h"
 #include "DisabledRedisClient.h"
+#include "ZmqRedisClient.h"
 #include "RequestShutdown.h"
 #include "WarmRestartTable.h"
 #include "ContextConfigContainer.h"
@@ -199,10 +200,19 @@ Syncd::Syncd(
 
     bool isDpuSwitch = switchType == "dpu";
 
-    if (zmqActive && isDpuSwitch && !isVirtualSwitch)
+    if (zmqActive && !isVirtualSwitch)
     {
-        // For DPU switches, disable Redis writes to maintain backwards compatibility with PR #1694
-        m_client = std::make_shared<DisabledRedisClient>();
+        if (isDpuSwitch)
+        {
+            // For DPU switches, disable Redis writes to maintain backwards compatibility with PR #1694
+            m_client = std::make_shared<DisabledRedisClient>();
+        }
+        else
+        {
+            // For NPU switches with ZMQ enabled, use async Redis writes to persist ASIC state
+            // without blocking the ZMQ data path
+            m_client = std::make_shared<syncd::ZmqRedisClient>(m_dbAsic);
+        }
     }
     else
     {

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -6,6 +6,7 @@
 #include "HardReiniter.h"
 #include "RedisClient.h"
 #include "DisabledRedisClient.h"
+#include "ZmqRedisClient.h"
 #include "RequestShutdown.h"
 #include "WarmRestartTable.h"
 #include "ContextConfigContainer.h"
@@ -170,9 +171,19 @@ Syncd::Syncd(
 
     bool isDpuSwitch = switchType == "dpu";
 
-    if (m_contextConfig->m_zmqEnable && isDpuSwitch && !isVirtualSwitch)
+    if (m_contextConfig->m_zmqEnable && !isVirtualSwitch)
     {
-        m_client = std::make_shared<DisabledRedisClient>();
+        if (isDpuSwitch)
+        {
+            // For DPU switches, disable Redis writes to maintain backwards compatibility with PR #1694
+            m_client = std::make_shared<DisabledRedisClient>();
+        }
+        else
+        {
+            // For NPU switches with ZMQ enabled, use async Redis writes to persist ASIC state
+            // without blocking the ZMQ data path
+            m_client = std::make_shared<syncd::ZmqRedisClient>(m_dbAsic);
+        }
     }
     else
     {

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -200,22 +200,22 @@ Syncd::Syncd(
 
     bool isDpuSwitch = switchType == "dpu";
 
-    if (zmqActive && !isVirtualSwitch)
+    bool asyncRec = m_commandLineOptions->m_enableAsyncRec;
+
+    if (zmqActive && isDpuSwitch)
     {
-        if (isDpuSwitch)
-        {
-            // For DPU switches, disable Redis writes to maintain backwards compatibility with PR #1694
-            m_client = std::make_shared<DisabledRedisClient>();
-        }
-        else
-        {
-            // For NPU switches with ZMQ enabled, use async Redis writes to persist ASIC state
-            // without blocking the ZMQ data path
-            m_client = std::make_shared<syncd::ZmqRedisClient>(m_dbAsic);
-        }
+        // For DPU switches, disable Redis writes to maintain backwards compatibility with PR #1694
+        m_client = std::make_shared<DisabledRedisClient>();
+    }
+    else if (zmqActive && asyncRec && !isVirtualSwitch)
+    {
+        // For NPU switches with ZMQ active and async recording opted in, use async Redis
+        // writes to persist ASIC state without blocking the ZMQ data path
+        m_client = std::make_shared<syncd::ZmqRedisClient>(m_dbAsic);
     }
     else
     {
+        // Default (includes ZMQ active but async_rec disabled): synchronous Redis writes
         m_client = std::make_shared<RedisClient>(m_dbAsic);
     }
 

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -202,7 +202,7 @@ Syncd::Syncd(
 
     bool asyncRec = m_commandLineOptions->m_enableAsyncRec;
 
-    if (zmqActive && isDpuSwitch)
+    if (zmqActive && isDpuSwitch && !isVirtualSwitch)
     {
         // For DPU switches, disable Redis writes to maintain backwards compatibility with PR #1694
         m_client = std::make_shared<DisabledRedisClient>();

--- a/syncd/ZmqRedisClient.cpp
+++ b/syncd/ZmqRedisClient.cpp
@@ -1,0 +1,111 @@
+#include "ZmqRedisClient.h"
+#include "VidManager.h"
+#include "sairediscommon.h"
+
+#include "meta/sai_serialize.h"
+
+#include "swss/logger.h"
+
+using namespace syncd;
+
+ZmqRedisClient::ZmqRedisClient(
+        _In_ std::shared_ptr<swss::DBConnector> dbAsic)
+    : RedisClient(dbAsic),
+      m_asyncDbUpdater(std::make_shared<swss::AsyncDBUpdater>(dbAsic.get(), ASIC_STATE_TABLE))
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("ZmqRedisClient created with async ASIC_DB writes");
+}
+
+void ZmqRedisClient::removeAsicObject(
+        _In_ sai_object_id_t objectVid) const
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_type_t ot = VidManager::objectTypeQuery(objectVid);
+
+    auto strVid = sai_serialize_object_id(objectVid);
+
+    std::string key = sai_serialize_object_type(ot) + ":" + strVid;
+
+    std::vector<swss::FieldValueTuple> values;
+    auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, DEL_COMMAND, values);
+    m_asyncDbUpdater->update(kco);
+}
+
+void ZmqRedisClient::removeAsicObject(
+        _In_ const sai_object_meta_key_t& metaKey)
+{
+    SWSS_LOG_ENTER();
+
+    std::string key = sai_serialize_object_meta_key(metaKey);
+    std::vector<swss::FieldValueTuple> values;
+    auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, DEL_COMMAND, values);
+    m_asyncDbUpdater->update(kco);
+}
+
+void ZmqRedisClient::removeAsicObjects(
+        _In_ const std::vector<std::string>& keys)
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto& key: keys)
+    {
+        std::vector<swss::FieldValueTuple> values;
+        auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, DEL_COMMAND, values);
+        m_asyncDbUpdater->update(kco);
+    }
+}
+
+void ZmqRedisClient::createAsicObject(
+        _In_ const sai_object_meta_key_t& metaKey,
+        _In_ const std::vector<swss::FieldValueTuple>& attrs)
+{
+    SWSS_LOG_ENTER();
+
+    std::string key = sai_serialize_object_meta_key(metaKey);
+
+    std::vector<swss::FieldValueTuple> values = attrs;
+
+    if (values.size() == 0)
+    {
+        values.emplace_back("NULL", "NULL");
+    }
+
+    auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, SET_COMMAND, values);
+    m_asyncDbUpdater->update(kco);
+}
+
+void ZmqRedisClient::createAsicObjects(
+        _In_ const std::unordered_map<std::string, std::vector<swss::FieldValueTuple>>& multiHash)
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto& kvp: multiHash)
+    {
+        std::vector<swss::FieldValueTuple> values = kvp.second;
+
+        if (values.size() == 0)
+        {
+            values.emplace_back("NULL", "NULL");
+        }
+
+        auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(kvp.first, SET_COMMAND, values);
+        m_asyncDbUpdater->update(kco);
+    }
+}
+
+void ZmqRedisClient::setAsicObject(
+        _In_ const sai_object_meta_key_t& metaKey,
+        _In_ const std::string& attr,
+        _In_ const std::string& value)
+{
+    SWSS_LOG_ENTER();
+
+    std::string key = sai_serialize_object_meta_key(metaKey);
+    std::vector<swss::FieldValueTuple> values;
+    values.emplace_back(attr, value);
+    auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, SET_COMMAND, values);
+    m_asyncDbUpdater->update(kco);
+}

--- a/syncd/ZmqRedisClient.cpp
+++ b/syncd/ZmqRedisClient.cpp
@@ -73,7 +73,7 @@ void ZmqRedisClient::createAsicObject(
         values.emplace_back("NULL", "NULL");
     }
 
-    auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, SET_COMMAND, values);
+    auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, HSET_COMMAND, values);
     m_asyncDbUpdater->update(kco);
 }
 
@@ -91,7 +91,7 @@ void ZmqRedisClient::createAsicObjects(
             values.emplace_back("NULL", "NULL");
         }
 
-        auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(kvp.first, SET_COMMAND, values);
+        auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(kvp.first, HSET_COMMAND, values);
         m_asyncDbUpdater->update(kco);
     }
 }
@@ -106,6 +106,6 @@ void ZmqRedisClient::setAsicObject(
     std::string key = sai_serialize_object_meta_key(metaKey);
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(attr, value);
-    auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, SET_COMMAND, values);
+    auto kco = std::make_shared<swss::KeyOpFieldsValuesTuple>(key, HSET_COMMAND, values);
     m_asyncDbUpdater->update(kco);
 }

--- a/syncd/ZmqRedisClient.h
+++ b/syncd/ZmqRedisClient.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "RedisClient.h"
+
+#include "swss/asyncdbupdater.h"
+#include "swss/dbconnector.h"
+
+#include <memory>
+
+namespace syncd
+{
+    class ZmqRedisClient : public RedisClient
+    {
+        public:
+
+            ZmqRedisClient(
+                    _In_ std::shared_ptr<swss::DBConnector> dbAsic);
+
+            virtual ~ZmqRedisClient() = default;
+
+            virtual void removeAsicObject(
+                    _In_ sai_object_id_t objectVid) const override;
+
+            virtual void removeAsicObject(
+                    _In_ const sai_object_meta_key_t& metaKey) override;
+
+            virtual void removeAsicObjects(
+                    _In_ const std::vector<std::string>& keys) override;
+
+            virtual void createAsicObject(
+                    _In_ const sai_object_meta_key_t& metaKey,
+                    _In_ const std::vector<swss::FieldValueTuple>& attrs) override;
+
+            virtual void createAsicObjects(
+                    _In_ const std::unordered_map<std::string, std::vector<swss::FieldValueTuple>>& multiHash) override;
+
+            virtual void setAsicObject(
+                    _In_ const sai_object_meta_key_t& metaKey,
+                    _In_ const std::string& attr,
+                    _In_ const std::string& value) override;
+
+        private:
+
+            std::shared_ptr<swss::AsyncDBUpdater> m_asyncDbUpdater;
+    };
+}

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -44,12 +44,18 @@ mkdir -p /var/log/sai_failure_dump/
 SYNC_MODE=$(echo $SYNCD_VARS | jq -r '.synchronous_mode')
 SWITCH_TYPE=$(echo $SYNCD_VARS | jq -r '.switch_type')
 SOUTHBOUND_ZMQ=$(echo $SYNCD_VARS | jq -r '.swss_zmq')
+ASYNC_REC=$(sonic-db-cli CONFIG_DB hget "SYSTEM_DEFAULTS|async_rec" "status")
+
 if [ "$SWITCH_TYPE" == "dpu" ]; then
     CMD_ARGS+=" -z zmq_sync -x $CONTEXT_CONFIG_FILE"
 elif [ "$SOUTHBOUND_ZMQ" == "true" ]; then
     CMD_ARGS+=" -z zmq_sync"
     if [ -f "$CONTEXT_CONFIG_FILE" ]; then
         CMD_ARGS+=" -x $CONTEXT_CONFIG_FILE"
+    fi
+    # Enable async ASIC_DB writes only when ZMQ southbound is active and async_rec is opted in
+    if [ "$ASYNC_REC" == "enabled" ]; then
+        CMD_ARGS+=" -R"
     fi
 elif [ "$SYNC_MODE" == "enable" ]; then
     CMD_ARGS+=" -s"

--- a/syncd/tests/Makefile.am
+++ b/syncd/tests/Makefile.am
@@ -5,7 +5,7 @@ LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
 bin_PROGRAMS = tests
 
 tests_SOURCES = \
-    main.cpp TestSyncdBrcm.cpp TestSyncdMlnx.cpp TestSyncdNvdaBf.cpp TestSyncdLib.cpp TestDisabledRedisClient.cpp
+    main.cpp TestSyncdBrcm.cpp TestSyncdMlnx.cpp TestSyncdNvdaBf.cpp TestSyncdLib.cpp TestDisabledRedisClient.cpp TestZmqRedisClient.cpp
 tests_CXXFLAGS = \
     $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDADD = \

--- a/syncd/tests/Makefile.am
+++ b/syncd/tests/Makefile.am
@@ -5,7 +5,7 @@ LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
 bin_PROGRAMS = tests
 
 tests_SOURCES = \
-    main.cpp TestSyncdBrcm.cpp TestSyncdMlnx.cpp TestSyncdNvdaBf.cpp TestSyncdLib.cpp TestSyncdLinkEventDamping.cpp TestDisabledRedisClient.cpp
+    main.cpp TestSyncdBrcm.cpp TestSyncdMlnx.cpp TestSyncdNvdaBf.cpp TestSyncdLib.cpp TestSyncdLinkEventDamping.cpp TestDisabledRedisClient.cpp TestZmqRedisClient.cpp
 tests_CXXFLAGS = \
     $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDADD = \

--- a/syncd/tests/TestZmqRedisClient.cpp
+++ b/syncd/tests/TestZmqRedisClient.cpp
@@ -1,0 +1,156 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include <swss/logger.h>
+
+#include <swss/dbconnector.h>
+#include <swss/table.h>
+
+#include "ZmqRedisClient.h"
+#include "meta/sai_serialize.h"
+
+using namespace syncd;
+
+class ZmqRedisClientTest : public ::testing::Test
+{
+public:
+    ZmqRedisClientTest() = default;
+    virtual ~ZmqRedisClientTest() = default;
+
+public:
+    virtual void SetUp() override
+    {
+        m_dbAsic = std::make_shared<swss::DBConnector>("ASIC_DB", 0, true);
+        m_redisClient = std::make_shared<ZmqRedisClient>(m_dbAsic);
+    }
+
+    virtual void TearDown() override
+    {
+        m_redisClient.reset();
+        m_dbAsic.reset();
+    }
+
+protected:
+    // Destroy the client to flush the AsyncDBUpdater queue, then verify
+    // a key exists in ASIC_STATE_TABLE. Destroying the client joins the
+    // AsyncDBUpdater thread, guaranteeing all pending writes have been
+    // committed to Redis before we read
+    bool keyExistsAfterFlush(const std::string& key)
+    {
+        SWSS_LOG_ENTER();
+        m_redisClient.reset();
+        swss::Table table(m_dbAsic.get(), "ASIC_STATE");
+        std::vector<swss::FieldValueTuple> values;
+        return table.get(key, values);
+    }
+
+    static sai_object_meta_key_t makeRouteMetaKey(sai_object_id_t vrId, uint32_t ip4Addr)
+    {
+        SWSS_LOG_ENTER();
+        sai_object_meta_key_t metaKey;
+        metaKey.objecttype = SAI_OBJECT_TYPE_ROUTE_ENTRY;
+        metaKey.objectkey.key.route_entry.switch_id = 0x21000000000000;
+        metaKey.objectkey.key.route_entry.vr_id = vrId;
+        metaKey.objectkey.key.route_entry.destination.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+        metaKey.objectkey.key.route_entry.destination.addr.ip4 = ip4Addr;
+        metaKey.objectkey.key.route_entry.destination.mask.ip4 = 0xffffffff;
+        return metaKey;
+    }
+
+    std::shared_ptr<swss::DBConnector> m_dbAsic;
+    std::shared_ptr<ZmqRedisClient> m_redisClient;
+};
+
+TEST_F(ZmqRedisClientTest, isRedisEnabledReturnsTrue)
+{
+    EXPECT_TRUE(m_redisClient->isRedisEnabled());
+}
+
+TEST_F(ZmqRedisClientTest, createAsicObjectWritesToRedis)
+{
+    auto metaKey = makeRouteMetaKey(0x3000000000002, 0x0a000001);
+
+    std::vector<swss::FieldValueTuple> attrs;
+    attrs.emplace_back("SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x5000000000010");
+
+    EXPECT_NO_THROW(m_redisClient->createAsicObject(metaKey, attrs));
+
+    EXPECT_TRUE(keyExistsAfterFlush(sai_serialize_object_meta_key(metaKey)));
+}
+
+TEST_F(ZmqRedisClientTest, createAsicObjectWithNoAttrsWritesNullEntry)
+{
+    auto metaKey = makeRouteMetaKey(0x3000000000003, 0x0a000002);
+
+    std::vector<swss::FieldValueTuple> attrs;
+    EXPECT_NO_THROW(m_redisClient->createAsicObject(metaKey, attrs));
+
+    EXPECT_TRUE(keyExistsAfterFlush(sai_serialize_object_meta_key(metaKey)));
+}
+
+TEST_F(ZmqRedisClientTest, setAsicObjectWritesToRedis)
+{
+    auto metaKey = makeRouteMetaKey(0x3000000000004, 0x0a000003);
+
+    std::vector<swss::FieldValueTuple> attrs;
+    m_redisClient->createAsicObject(metaKey, attrs);
+    EXPECT_NO_THROW(m_redisClient->setAsicObject(metaKey, "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x5000000000020"));
+
+    EXPECT_TRUE(keyExistsAfterFlush(sai_serialize_object_meta_key(metaKey)));
+}
+
+TEST_F(ZmqRedisClientTest, removeAsicObjectByMetaKeyDeletesFromRedis)
+{
+    auto metaKey = makeRouteMetaKey(0x3000000000005, 0x0a000004);
+
+    std::vector<swss::FieldValueTuple> attrs;
+    m_redisClient->createAsicObject(metaKey, attrs);
+    EXPECT_NO_THROW(m_redisClient->removeAsicObject(metaKey));
+
+    EXPECT_FALSE(keyExistsAfterFlush(sai_serialize_object_meta_key(metaKey)));
+}
+
+TEST_F(ZmqRedisClientTest, removeAsicObjectsDeletesAllKeysFromRedis)
+{
+    auto metaKey1 = makeRouteMetaKey(0x3000000000006, 0x0a000005);
+    auto metaKey2 = makeRouteMetaKey(0x3000000000006, 0x0a000006);
+
+    std::string key1 = sai_serialize_object_meta_key(metaKey1);
+    std::string key2 = sai_serialize_object_meta_key(metaKey2);
+
+    std::vector<swss::FieldValueTuple> attrs;
+    m_redisClient->createAsicObject(metaKey1, attrs);
+    m_redisClient->createAsicObject(metaKey2, attrs);
+    EXPECT_NO_THROW(m_redisClient->removeAsicObjects({key1, key2}));
+
+    // flush and check key1; client is reset inside keyExistsAfterFlush
+    EXPECT_FALSE(keyExistsAfterFlush(key1));
+
+    // client already reset, read key2 directly
+    swss::Table table(m_dbAsic.get(), "ASIC_STATE");
+    std::vector<swss::FieldValueTuple> values;
+    EXPECT_FALSE(table.get(key2, values));
+}
+
+TEST_F(ZmqRedisClientTest, createAsicObjectsWritesAllEntriesToRedis)
+{
+    auto metaKey1 = makeRouteMetaKey(0x3000000000007, 0x0a000007);
+    auto metaKey2 = makeRouteMetaKey(0x3000000000007, 0x0a000008);
+
+    std::string key1 = sai_serialize_object_meta_key(metaKey1);
+    std::string key2 = sai_serialize_object_meta_key(metaKey2);
+
+    std::unordered_map<std::string, std::vector<swss::FieldValueTuple>> multiHash;
+    multiHash[key1] = {{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x5000000000030"}};
+    multiHash[key2] = {{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x5000000000031"}};
+
+    EXPECT_NO_THROW(m_redisClient->createAsicObjects(multiHash));
+
+    // flush and check key1; client is reset inside keyExistsAfterFlush
+    EXPECT_TRUE(keyExistsAfterFlush(key1));
+
+    // client already reset, read key2 directly
+    swss::Table table(m_dbAsic.get(), "ASIC_STATE");
+    std::vector<swss::FieldValueTuple> values;
+    EXPECT_TRUE(table.get(key2, values));
+}

--- a/syncd/tests/TestZmqRedisClient.cpp
+++ b/syncd/tests/TestZmqRedisClient.cpp
@@ -110,6 +110,29 @@ TEST_F(ZmqRedisClientTest, removeAsicObjectByMetaKeyDeletesFromRedis)
     EXPECT_FALSE(keyExistsAfterFlush(sai_serialize_object_meta_key(metaKey)));
 }
 
+TEST_F(ZmqRedisClientTest, removeAsicObjectByObjectVidDeletesFromRedis)
+{
+    // VIRTUAL_ROUTER VID: object type 0x03 in bits 55..48, index 0x8.
+    // VidManager::objectTypeQuery decodes it back to SAI_OBJECT_TYPE_VIRTUAL_ROUTER.
+    sai_object_id_t objectVid = 0x0003000000000008;
+
+    sai_object_meta_key_t metaKey;
+    metaKey.objecttype = SAI_OBJECT_TYPE_VIRTUAL_ROUTER;
+    metaKey.objectkey.key.object_id = objectVid;
+
+    // The removeAsicObject(objectVid) overload builds the key as
+    // sai_serialize_object_type(objectTypeQuery(vid)) + ":" + sai_serialize_object_id(vid).
+    // For an object-id meta key this matches sai_serialize_object_meta_key, so
+    // creating via the meta key and removing via the VID target the same Redis key.
+    std::string key = sai_serialize_object_meta_key(metaKey);
+
+    std::vector<swss::FieldValueTuple> attrs;
+    m_redisClient->createAsicObject(metaKey, attrs);
+    EXPECT_NO_THROW(m_redisClient->removeAsicObject(objectVid));
+
+    EXPECT_FALSE(keyExistsAfterFlush(key));
+}
+
 TEST_F(ZmqRedisClientTest, removeAsicObjectsDeletesAllKeysFromRedis)
 {
     auto metaKey1 = makeRouteMetaKey(0x3000000000006, 0x0a000005);

--- a/syncd/tests/TestZmqRedisClient.cpp
+++ b/syncd/tests/TestZmqRedisClient.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <memory>
+#include <map>
 
 #include <swss/logger.h>
 
@@ -42,6 +43,20 @@ protected:
         swss::Table table(m_dbAsic.get(), "ASIC_STATE");
         std::vector<swss::FieldValueTuple> values;
         return table.get(key, values);
+    }
+
+    // Like keyExistsAfterFlush, but returns the object's fields so tests can
+    // assert which attributes survived a merge write. Resetting the client
+    // joins the AsyncDBUpdater thread, so all pending writes are committed
+    // before we read.
+    std::map<std::string, std::string> fieldsAfterFlush(const std::string& key)
+    {
+        SWSS_LOG_ENTER();
+        m_redisClient.reset();
+        swss::Table table(m_dbAsic.get(), "ASIC_STATE");
+        std::vector<swss::FieldValueTuple> values;
+        table.get(key, values);
+        return std::map<std::string, std::string>(values.begin(), values.end());
     }
 
     static sai_object_meta_key_t makeRouteMetaKey(sai_object_id_t vrId, uint32_t ip4Addr)
@@ -176,4 +191,44 @@ TEST_F(ZmqRedisClientTest, createAsicObjectsWritesAllEntriesToRedis)
     swss::Table table(m_dbAsic.get(), "ASIC_STATE");
     std::vector<swss::FieldValueTuple> values;
     EXPECT_TRUE(table.get(key2, values));
+}
+
+// Regression test for the HSET (vs SET) write op: setAsicObject updates a
+// single field and must not erase the object's other attributes. With the
+// old SET_COMMAND (del + set) the PACKET_ACTION field below would be wiped.
+TEST_F(ZmqRedisClientTest, setAsicObjectPreservesOtherFields)
+{
+    auto metaKey = makeRouteMetaKey(0x3000000000009, 0x0a000009);
+
+    // Create the object with two attributes.
+    std::vector<swss::FieldValueTuple> attrs;
+    attrs.emplace_back("SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x5000000000040");
+    attrs.emplace_back("SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD");
+    m_redisClient->createAsicObject(metaKey, attrs);
+
+    // Update only NEXT_HOP_ID; PACKET_ACTION must survive the merge.
+    m_redisClient->setAsicObject(metaKey, "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x5000000000041");
+
+    auto fields = fieldsAfterFlush(sai_serialize_object_meta_key(metaKey));
+    EXPECT_EQ(fields["SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID"], "oid:0x5000000000041");
+    EXPECT_EQ(fields["SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION"], "SAI_PACKET_ACTION_FORWARD");
+}
+
+// createAsicObject also uses the HSET merge op: a second create on the same
+// key adds a field without erasing the field written by the first create.
+TEST_F(ZmqRedisClientTest, createAsicObjectMergesFields)
+{
+    auto metaKey = makeRouteMetaKey(0x300000000000a, 0x0a00000a);
+
+    // First create writes NEXT_HOP_ID.
+    m_redisClient->createAsicObject(metaKey,
+            {{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x5000000000050"}});
+
+    // Second create on the same key writes PACKET_ACTION; the merge keeps both.
+    m_redisClient->createAsicObject(metaKey,
+            {{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD"}});
+
+    auto fields = fieldsAfterFlush(sai_serialize_object_meta_key(metaKey));
+    EXPECT_EQ(fields["SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID"], "oid:0x5000000000050");
+    EXPECT_EQ(fields["SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION"], "SAI_PACKET_ACTION_FORWARD");
 }

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -531,3 +531,6 @@ ifstream
 nlohmann
 reconciler
 truthy
+glibc
+getopt
+optind

--- a/unittest/syncd/TestCommandLineOptions.cpp
+++ b/unittest/syncd/TestCommandLineOptions.cpp
@@ -147,3 +147,44 @@ TEST(CommandLineOptionsParser, parseCommandLineOnlyInitTimeout)
     EXPECT_EQ(opt->m_watchdogWarnTimeSpan, 30000000);
     EXPECT_EQ(opt->m_watchdogInitTimeSpan, 150000000);
 }
+
+TEST(CommandLineOptionsParser, parseCommandLineIsRepeatable)
+{
+    // Each parseCommandLine call must be independent of any earlier call in the same
+    // process: parsing one argument vector must fully reset the parser so a later parse
+    // sees only its own arguments. Exercise several parses back to back and check that
+    // each yields exactly its own result.
+
+    {
+        char arg1[] = "test";
+        char arg2[] = "-R";
+        std::vector<char *> args = {arg1, arg2};
+
+        auto opt = syncd::CommandLineOptionsParser::parseCommandLine((int)args.size(), args.data());
+        EXPECT_TRUE(opt->m_enableAsyncRec);
+    }
+
+    {
+        char arg1[] = "test";
+        char arg2[] = "-w";
+        char arg3[] = "30000000";
+        char arg4[] = "-W";
+        char arg5[] = "150000000";
+        std::vector<char *> args = {arg1, arg2, arg3, arg4, arg5};
+
+        auto opt = syncd::CommandLineOptionsParser::parseCommandLine((int)args.size(), args.data());
+        EXPECT_EQ(opt->m_watchdogWarnTimeSpan, 30000000);
+        EXPECT_EQ(opt->m_watchdogInitTimeSpan, 150000000);
+        EXPECT_FALSE(opt->m_enableAsyncRec);
+    }
+
+    {
+        char arg1[] = "test";
+        std::vector<char *> args = {arg1};
+
+        auto opt = syncd::CommandLineOptionsParser::parseCommandLine((int)args.size(), args.data());
+        EXPECT_EQ(opt->m_watchdogWarnTimeSpan, 30000000);
+        EXPECT_EQ(opt->m_watchdogInitTimeSpan, 30000000);
+        EXPECT_FALSE(opt->m_enableAsyncRec);
+    }
+}

--- a/unittest/syncd/TestCommandLineOptions.cpp
+++ b/unittest/syncd/TestCommandLineOptions.cpp
@@ -7,7 +7,7 @@
 using namespace syncd;
 
 const std::string expected_usage =
-R"(Usage: syncd [-d] [-p profile] [-t type] [-u] [-S] [-U] [-C] [-s] [-z mode] [-l] [-g idx] [-x contextConfig] [-b breakConfig] [-B supportingBulkCounters] [-h]
+R"(Usage: syncd [-d] [-p profile] [-t type] [-u] [-S] [-U] [-C] [-s] [-z mode] [-l] [-R] [-g idx] [-x contextConfig] [-b breakConfig] [-B supportingBulkCounters] [-h]
     -d --diag
         Enable diagnostic shell
     -p --profile profile
@@ -28,6 +28,8 @@ R"(Usage: syncd [-d] [-p profile] [-t type] [-u] [-S] [-U] [-C] [-s] [-z mode] [
         Redis communication mode (redis_async|redis_sync|zmq_sync), default: redis_async
     -l --enableBulk
         Enable SAI Bulk support
+    -R --asyncRec
+        Enable asynchronous ASIC_DB writes (only effective with ZMQ southbound)
     -g --globalContext
         Global context index to load from context config file
     -x --contextConfig
@@ -53,7 +55,7 @@ TEST(CommandLineOptions, getCommandLineString)
     auto str = opt.getCommandLineString();
 
     EXPECT_EQ(str, " EnableDiagShell=NO EnableTempView=NO DisableExitSleep=NO EnableUnittests=NO"
-            " EnableConsistencyCheck=NO EnableSyncMode=NO RedisCommunicationMode=redis_async"
+            " EnableConsistencyCheck=NO EnableSyncMode=NO EnableAsyncRec=NO RedisCommunicationMode=redis_async"
             " EnableSaiBulkSuport=NO StartType=cold ProfileMapFile= GlobalContext=0 ContextConfig= BreakConfig="
             " WatchdogWarnTimeSpan=30000000 WatchdogInitTimeSpan=30000000 SupportingBulkCounters= EnableAttrVersionCheck=NO");
 }
@@ -89,6 +91,25 @@ TEST(CommandLineOptionsParser, parseCommandLine)
     EXPECT_EQ(opt->m_watchdogWarnTimeSpan, 1000);
     EXPECT_EQ(opt->m_watchdogInitTimeSpan, 1000);
     EXPECT_EQ(opt->m_supportingBulkCounterGroups, "WATERMARK");
+}
+
+TEST(CommandLineOptionsParser, parseCommandLineAsyncRec)
+{
+    char arg1[] = "test";
+    char arg2[] = "-R";
+    std::vector<char *> args = {arg1, arg2};
+
+    auto opt = syncd::CommandLineOptionsParser::parseCommandLine((int)args.size(), args.data());
+    EXPECT_TRUE(opt->m_enableAsyncRec);
+}
+
+TEST(CommandLineOptionsParser, parseCommandLineAsyncRecDefaultsOff)
+{
+    char arg1[] = "test";
+    std::vector<char *> args = {arg1};
+
+    auto opt = syncd::CommandLineOptionsParser::parseCommandLine((int)args.size(), args.data());
+    EXPECT_FALSE(opt->m_enableAsyncRec);
 }
 
 TEST(CommandLineOptionsParser, parseCommandLineInitTimeout)

--- a/unittest/syncd/TestSyncd.cpp
+++ b/unittest/syncd/TestSyncd.cpp
@@ -352,7 +352,7 @@ TEST(Syncd, zmqWithoutAsyncRecUsesSyncRedisClient)
     EXPECT_NE(std::dynamic_pointer_cast<RedisClient>(syncdObj->m_client), nullptr);
 }
 
-TEST(Syncd, asyncRecIgnoredWhenContextConfigVetoesZmq)
+TEST(Syncd, asyncRecIgnoredWhenContextConfigDisablesZmq)
 {
     auto sai = std::make_shared<MockableSaiInterface>();
     auto cmd = std::make_shared<CommandLineOptions>();
@@ -363,7 +363,7 @@ TEST(Syncd, asyncRecIgnoredWhenContextConfigVetoesZmq)
 
     auto syncdObj = std::make_shared<Syncd>(sai, cmd, false);
 
-    // context_config.json vetoes ZMQ (zmq_enable=false): demote to REDIS_SYNC, so
+    // context_config.json disables ZMQ (zmq_enable=false): demote to REDIS_SYNC, so
     // --async-rec is harmlessly ignored and the synchronous RedisClient is used.
     EXPECT_EQ(cmd->m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC);
     EXPECT_EQ(std::dynamic_pointer_cast<ZmqRedisClient>(syncdObj->m_client), nullptr);

--- a/unittest/syncd/TestSyncd.cpp
+++ b/unittest/syncd/TestSyncd.cpp
@@ -1,5 +1,6 @@
 #include "Syncd.h"
 #include "RedisClient.h"
+#include "ZmqRedisClient.h"
 #include "sai_serialize.h"
 #include "RequestShutdown.h"
 #include "vslib/ContextConfigContainer.h"
@@ -318,6 +319,55 @@ TEST(Syncd, contextConfigZmqEnablePreservedForFileEnabled)
     auto syncd = std::make_shared<Syncd>(sai, cmd, false);
 
     EXPECT_EQ(syncd->m_contextConfig->m_zmqEnable, sairedis::CONTEXT_CONFIG_ZMQ_ENABLED);
+}
+
+TEST(Syncd, zmqWithAsyncRecUsesZmqRedisClient)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_enableAsyncRec = true;
+    cmd->m_contextConfig = "files/ctx_zmq_enabled.json";
+
+    auto syncdObj = std::make_shared<Syncd>(sai, cmd, false);
+
+    EXPECT_NE(std::dynamic_pointer_cast<ZmqRedisClient>(syncdObj->m_client), nullptr);
+}
+
+TEST(Syncd, zmqWithoutAsyncRecUsesSyncRedisClient)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_enableAsyncRec = false;
+    cmd->m_contextConfig = "files/ctx_zmq_enabled.json";
+
+    auto syncdObj = std::make_shared<Syncd>(sai, cmd, false);
+
+    // ZMQ active but async_rec disabled: fall back to the synchronous RedisClient,
+    // not the async ZmqRedisClient subclass.
+    EXPECT_EQ(std::dynamic_pointer_cast<ZmqRedisClient>(syncdObj->m_client), nullptr);
+    EXPECT_NE(std::dynamic_pointer_cast<RedisClient>(syncdObj->m_client), nullptr);
+}
+
+TEST(Syncd, asyncRecIgnoredWhenContextConfigVetoesZmq)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_enableAsyncRec = true;
+    cmd->m_contextConfig = "files/ctx_zmq_disabled.json";
+
+    auto syncdObj = std::make_shared<Syncd>(sai, cmd, false);
+
+    // context_config.json vetoes ZMQ (zmq_enable=false): demote to REDIS_SYNC, so
+    // --async-rec is harmlessly ignored and the synchronous RedisClient is used.
+    EXPECT_EQ(cmd->m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC);
+    EXPECT_EQ(std::dynamic_pointer_cast<ZmqRedisClient>(syncdObj->m_client), nullptr);
+    EXPECT_NE(std::dynamic_pointer_cast<RedisClient>(syncdObj->m_client), nullptr);
 }
 
 using namespace syncd;


### PR DESCRIPTION
#### Why I did it
We are extending southbound ZMQ support (currently only used for DPU switches) to regular NPU switches for improved route offloading performance. However, PR #1694 introduced `DisabledRedisClient` that prevents syncd from writing ASIC state to Redis when ZMQ is enabled. On NPU switches we still want ASIC_DB populated (for warm boot, diagnostics, `show` tooling, etc.), but without the synchronous Redis writes blocking the ZMQ data path.

#### How I did it
Added a dedicated `ZmqRedisClient` (subclass of `RedisClient`) that performs ASIC_DB writes asynchronously on a background thread via `swss::AsyncDBUpdater`, instead of extending/mutating `RedisClient` itself.

Added a new opt-in knob, `-R` / `--asyncRec`, driven by `SYSTEM_DEFAULTS|async_rec` (`status: enabled`) in CONFIG_DB and plumbed through `syncd_init_common.sh`.

Redis client selection (in `Syncd`):
- **DPU + ZMQ**: `DisabledRedisClient` — no Redis writes, maintains PR #1694 behavior.
- **NPU + ZMQ + `async_rec` enabled**: `ZmqRedisClient`,  async ASIC_DB writes that persist ASIC state without blocking the ZMQ data path.
- **Everything else** (including ZMQ active but `async_rec` disabled): `RedisClient` synchronous writes (traditional behavior).

`ZmqRedisClient` uses field-merge (`HSET`) semantics for create/set operations and `DEL` for removes, matching the synchronous `RedisClient` (which only `hset`/`hmset`s and never deletes on a write). This avoids wiping an object's other attributes when a single field is updated.

> **Dependency:** requires sonic-swss-common #1217, which adds `HSET_COMMAND` to `AsyncDBUpdater` (merge-only write). This PR will not compile until that change is merged and the submodule is bumped.

Added unit tests: `ZmqRedisClient` create/set/remove behavior including field-merge regression tests, `Syncd` client-selection tests across DPU/NPU/`async_rec`/context-config combinations, and `--asyncRec` command-line parsing.

#### How to verify it

Used the route benchmark script under `sonic-mgmt/tests/scripts/route_programming_benchmark.py`.
Also tested that the routes are written to ASIC_STATE table with a scale of 500k routes:

```
redis-cli -n 1 --scan --pattern "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY*" | wc -l
503255
```

**Test Policies**:

- Policy 1: Northbound ZMQ enabled
- Policy 2: Northbound ZMQ + Ring Buffer + Multi-DB enabled
- Policy 3: Northbound ZMQ + Southbound ZMQ enabled
- Policy 4: Northbound ZMQ + Southbound ZMQ + Multi-DB enabled

**Note: All tests are running with a SAI bulk size of 10k in Orchagent (-k 10000)**

| Route Scale | Policy 1 | Policy 2 | Policy 3 | Policy 4 |
| :---- | :---- | :---- | :---- | :---- |
| 100k | 13.713s | 14.649s | 14.633s | 12.962s |
| 250k | 54.563s | 46.197s | 50.120s | 41.602s |
| 500k | 187.923s | 131.901s | 129.681s | 102.961s |
