### PR TITLE
[ci] fix test stages timeout issue

### DIFF
--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -72,6 +72,7 @@ function build_and_install_kmodule()
     mv .config .config.bk
     cp /boot/config-$(uname -r) .config
     grep NET_TEAM .config.bk >> .config
+    make olddefconfig
     make VERSION=$VERSION PATCHLEVEL=$PATCHLEVEL SUBLEVEL=$SUBLEVEL EXTRAVERSION=-${EXTRAVERSION} LOCALVERSION=-${LOCALVERSION} modules_prepare
     cp /usr/src/linux-headers-$(uname -r)/Module.symvers .
     make -j$(nproc) M=drivers/net/team


### PR DESCRIPTION
Test stages timeout because of waiting for interactive input
This change makes kernel module config generation non-interactive in CI