### PR TITLE
[syncd] Add config_db.json fallback for saithrift

### DIFF
--- a/syncd/PortMapParser.cpp
+++ b/syncd/PortMapParser.cpp
@@ -2,12 +2,26 @@
 
 #include "swss/logger.h"
 
+#include <nlohmann/json.hpp>
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
 #include <cstring>
 
 using namespace syncd;
+
+static bool hasJsonExtension(const std::string& filename)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string ext = ".json";
+
+    if (filename.size() < ext.size())
+        return false;
+
+    return filename.compare(filename.size() - ext.size(), ext.size(), ext) == 0;
+}
 
 // TODO: introduce common config format for SONiC
 std::shared_ptr<PortMap> PortMapParser::parsePortMap(
@@ -22,6 +36,11 @@ std::shared_ptr<PortMap> PortMapParser::parsePortMap(
         SWSS_LOG_NOTICE("no port map file, returning empty port map");
 
         return portMap;
+    }
+
+    if (hasJsonExtension(portMapFile))
+    {
+        return parsePortMapFromJson(portMapFile);
     }
 
     std::ifstream portmap(portMapFile);
@@ -61,6 +80,78 @@ std::shared_ptr<PortMap> PortMapParser::parsePortMap(
     }
 
     SWSS_LOG_NOTICE("returning port map with %zu entries", portMap->size());
+
+    return portMap;
+}
+
+std::shared_ptr<PortMap> PortMapParser::parsePortMapFromJson(
+        _In_ const std::string& jsonFile)
+{
+    SWSS_LOG_ENTER();
+
+    auto portMap = std::make_shared<PortMap>();
+
+    std::ifstream ifs(jsonFile);
+
+    if (!ifs.is_open())
+    {
+        std::cerr << "failed to open JSON port map file:" << jsonFile.c_str() << " : " << strerror(errno) << std::endl;
+        SWSS_LOG_ERROR("failed to open JSON port map file: %s: errno: %s", jsonFile.c_str(), strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    nlohmann::json j;
+
+    try
+    {
+        ifs >> j;
+    }
+    catch (const nlohmann::json::parse_error& e)
+    {
+        SWSS_LOG_ERROR("failed to parse JSON file %s: %s", jsonFile.c_str(), e.what());
+        exit(EXIT_FAILURE);
+    }
+
+    if (!j.contains("PORT") || !j["PORT"].is_object())
+    {
+        SWSS_LOG_ERROR("JSON file %s does not contain a valid PORT table", jsonFile.c_str());
+        exit(EXIT_FAILURE);
+    }
+
+    for (const auto& item : j["PORT"].items())
+    {
+        const auto& portName = item.key();
+        const auto& portData = item.value();
+
+        if (!portData.contains("lanes") || !portData["lanes"].is_string())
+        {
+            SWSS_LOG_WARN("skipping port %s: missing or invalid lanes field", portName.c_str());
+            continue;
+        }
+
+        std::string lanes = portData["lanes"].get<std::string>();
+
+        std::istringstream iss(lanes);
+        std::string lane_str;
+        std::set<int> lane_set;
+
+        while (getline(iss, lane_str, ','))
+        {
+            try
+            {
+                lane_set.insert(stoi(lane_str));
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_ERROR("invalid lane value '%s' for port %s: %s", lane_str.c_str(), portName.c_str(), e.what());
+                exit(EXIT_FAILURE);
+            }
+        }
+
+        portMap->insert(lane_set, portName);
+    }
+
+    SWSS_LOG_NOTICE("returning port map from JSON with %zu entries", portMap->size());
 
     return portMap;
 }

--- a/syncd/PortMapParser.h
+++ b/syncd/PortMapParser.h
@@ -17,5 +17,10 @@ namespace syncd
 
             static std::shared_ptr<PortMap> parsePortMap(
                     _In_ const std::string& portMapFile);
+
+        private:
+
+            static std::shared_ptr<PortMap> parsePortMapFromJson(
+                    _In_ const std::string& jsonFile);
     };
 }

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -690,7 +690,15 @@ config_syncd()
     set_start_type
 
     if [ ${ENABLE_SAITHRIFT} == 1 ]; then
-        CMD_ARGS+=" -r -m $HWSKU_DIR/port_config.ini"
+        CMD_ARGS+=" -r"
+        if [ -f $HWSKU_DIR/port_config.ini ]; then
+            CMD_ARGS+=" -m $HWSKU_DIR/port_config.ini"
+        elif [ -f /etc/sonic/config_db.json ]; then
+            CMD_ARGS+=" -m /etc/sonic/config_db.json"
+        else
+            echo "Error: No port_config.ini or config_db.json found for port map"
+            exit 1
+        fi
     fi
 
     [ -r $PLATFORM_DIR/syncd.conf ] && . $PLATFORM_DIR/syncd.conf

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -23,6 +23,7 @@ tests_SOURCES = main.cpp \
 				TestMdioIpcServer.cpp \
 				TestPortStateChangeHandler.cpp \
 				TestWorkaround.cpp \
+				TestPortMapParser.cpp \
 				TestSyncd.cpp \
 				TestVendorSai.cpp \
 				TestFlowDump.cpp

--- a/unittest/syncd/TestPortMapParser.cpp
+++ b/unittest/syncd/TestPortMapParser.cpp
@@ -1,0 +1,327 @@
+#include "PortMapParser.h"
+
+#include "swss/logger.h"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <cstdio>
+
+using namespace syncd;
+
+static void writeTestFile(const std::string& path, const std::string& content)
+{
+    SWSS_LOG_ENTER();
+
+    std::ofstream ofs(path);
+    ofs << content;
+    ofs.close();
+}
+
+TEST(PortMapParser, parsePortMapEmptyFile)
+{
+    auto portMap = PortMapParser::parsePortMap("");
+
+    EXPECT_EQ(portMap->size(), 0);
+}
+
+TEST(PortMapParser, parsePortMapIniFormat)
+{
+    std::string path = "test_port_config.ini";
+
+    writeTestFile(path,
+            "# comment line\n"
+            "; another comment\n"
+            "Ethernet0 0,1,2,3 Ethernet0\n"
+            "Ethernet4 4,5,6,7 Ethernet4\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 2);
+
+    auto raw = portMap->getRawPortMap();
+
+    std::set<int> lanes0 = {0, 1, 2, 3};
+    std::set<int> lanes4 = {4, 5, 6, 7};
+
+    EXPECT_EQ(raw.at(lanes0), "Ethernet0");
+    EXPECT_EQ(raw.at(lanes4), "Ethernet4");
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonValid)
+{
+    std::string path = "test_config_db.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"PORT\": {\n"
+            "        \"Ethernet0\": {\n"
+            "            \"lanes\": \"0,1,2,3\",\n"
+            "            \"speed\": \"100000\"\n"
+            "        },\n"
+            "        \"Ethernet4\": {\n"
+            "            \"lanes\": \"4,5,6,7\",\n"
+            "            \"speed\": \"100000\"\n"
+            "        }\n"
+            "    }\n"
+            "}\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 2);
+
+    auto raw = portMap->getRawPortMap();
+
+    std::set<int> lanes0 = {0, 1, 2, 3};
+    std::set<int> lanes4 = {4, 5, 6, 7};
+
+    EXPECT_EQ(raw.at(lanes0), "Ethernet0");
+    EXPECT_EQ(raw.at(lanes4), "Ethernet4");
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonSingleLane)
+{
+    std::string path = "test_single_lane.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"PORT\": {\n"
+            "        \"Ethernet0\": {\n"
+            "            \"lanes\": \"25\"\n"
+            "        }\n"
+            "    }\n"
+            "}\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 1);
+
+    auto raw = portMap->getRawPortMap();
+
+    std::set<int> lanes = {25};
+
+    EXPECT_EQ(raw.at(lanes), "Ethernet0");
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonSkipsMissingLanes)
+{
+    std::string path = "test_missing_lanes.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"PORT\": {\n"
+            "        \"Ethernet0\": {\n"
+            "            \"lanes\": \"0,1,2,3\"\n"
+            "        },\n"
+            "        \"Ethernet4\": {\n"
+            "            \"speed\": \"100000\"\n"
+            "        },\n"
+            "        \"Ethernet8\": {\n"
+            "            \"lanes\": \"8,9,10,11\"\n"
+            "        }\n"
+            "    }\n"
+            "}\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 2);
+
+    auto raw = portMap->getRawPortMap();
+
+    std::set<int> lanes0 = {0, 1, 2, 3};
+    std::set<int> lanes8 = {8, 9, 10, 11};
+
+    EXPECT_EQ(raw.count(lanes0), 1);
+    EXPECT_EQ(raw.count(lanes8), 1);
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonSkipsNonStringLanes)
+{
+    std::string path = "test_nonstring_lanes.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"PORT\": {\n"
+            "        \"Ethernet0\": {\n"
+            "            \"lanes\": 12345\n"
+            "        },\n"
+            "        \"Ethernet4\": {\n"
+            "            \"lanes\": \"4,5,6,7\"\n"
+            "        }\n"
+            "    }\n"
+            "}\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 1);
+
+    auto raw = portMap->getRawPortMap();
+
+    std::set<int> lanes4 = {4, 5, 6, 7};
+
+    EXPECT_EQ(raw.at(lanes4), "Ethernet4");
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonEmptyPortTable)
+{
+    std::string path = "test_empty_port.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"PORT\": {}\n"
+            "}\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 0);
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonFileNotFound)
+{
+    EXPECT_EXIT(
+            PortMapParser::parsePortMap("nonexistent_file.json"),
+            ::testing::ExitedWithCode(EXIT_FAILURE),
+            "");
+}
+
+TEST(PortMapParser, parsePortMapJsonInvalidJson)
+{
+    std::string path = "test_invalid.json";
+
+    writeTestFile(path, "{ this is not valid json }");
+
+    EXPECT_EXIT(
+            PortMapParser::parsePortMap(path),
+            ::testing::ExitedWithCode(EXIT_FAILURE),
+            "");
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonMissingPortKey)
+{
+    std::string path = "test_no_port_key.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"DEVICE_METADATA\": {}\n"
+            "}\n");
+
+    EXPECT_EXIT(
+            PortMapParser::parsePortMap(path),
+            ::testing::ExitedWithCode(EXIT_FAILURE),
+            "");
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonPortNotObject)
+{
+    std::string path = "test_port_not_obj.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"PORT\": \"not_an_object\"\n"
+            "}\n");
+
+    EXPECT_EXIT(
+            PortMapParser::parsePortMap(path),
+            ::testing::ExitedWithCode(EXIT_FAILURE),
+            "");
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapIniFileNotFound)
+{
+    EXPECT_EXIT(
+            PortMapParser::parsePortMap("nonexistent_file.ini"),
+            ::testing::ExitedWithCode(EXIT_FAILURE),
+            "");
+}
+
+TEST(PortMapParser, parsePortMapJsonMultiplePorts)
+{
+    std::string path = "test_many_ports.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"PORT\": {\n"
+            "        \"Ethernet0\": { \"lanes\": \"0,1,2,3\" },\n"
+            "        \"Ethernet4\": { \"lanes\": \"4,5,6,7\" },\n"
+            "        \"Ethernet8\": { \"lanes\": \"8,9,10,11\" },\n"
+            "        \"Ethernet12\": { \"lanes\": \"12,13,14,15\" }\n"
+            "    }\n"
+            "}\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 4);
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapJsonExtraFieldsIgnored)
+{
+    std::string path = "test_extra_fields.json";
+
+    writeTestFile(path,
+            "{\n"
+            "    \"DEVICE_METADATA\": { \"localhost\": {} },\n"
+            "    \"PORT\": {\n"
+            "        \"Ethernet0\": {\n"
+            "            \"admin_status\": \"up\",\n"
+            "            \"alias\": \"fortyGigE0/0\",\n"
+            "            \"index\": \"0\",\n"
+            "            \"lanes\": \"0,1,2,3\",\n"
+            "            \"mtu\": \"9100\",\n"
+            "            \"speed\": \"40000\"\n"
+            "        }\n"
+            "    },\n"
+            "    \"VLAN\": {}\n"
+            "}\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 1);
+
+    auto raw = portMap->getRawPortMap();
+
+    std::set<int> lanes0 = {0, 1, 2, 3};
+
+    EXPECT_EQ(raw.at(lanes0), "Ethernet0");
+
+    std::remove(path.c_str());
+}
+
+TEST(PortMapParser, parsePortMapNonJsonExtension)
+{
+    std::string path = "test_portmap.txt";
+
+    writeTestFile(path,
+            "Ethernet0 0,1 Ethernet0\n");
+
+    auto portMap = PortMapParser::parsePortMap(path);
+
+    EXPECT_EQ(portMap->size(), 1);
+
+    auto raw = portMap->getRawPortMap();
+
+    std::set<int> lanes0 = {0, 1};
+
+    EXPECT_EQ(raw.at(lanes0), "Ethernet0");
+
+    std::remove(path.c_str());
+}


### PR DESCRIPTION
#### Why I did it

Some HWSKUs use `hwsku.json` instead of `port_config.ini` to define port configurations. 
When saithrift is enabled, syncd currently hardcodes the port map path to `$HWSKU_DIR/port_config.ini`, which causes failures on platforms that don't ship a `port_config.ini`. 
This is part of the broader effort to clean up port_config.ini dependencies (see [sonic-buildimage#24494](https://github.com/sonic-net/sonic-buildimage/issues/24494)).

#### How I did it

- Updated `syncd_init_common.sh` to use to `/etc/sonic/config_db.json` when `port_config.ini` is absent and saithrift is enabled.
- Extended PortMapParser to parse the PORT table from JSON files to build the lane-to-port map.
- Added unit tests for the new JSON parsing path.

#### How to verify it

Remove `port_config.ini` and run the sonic-mgmt QoS tests (`sonic-mgmt/tests/qos/`).