### PR TITLE
vpp: Return NOT_SUPPORTED to queryStatsStCapability

### DIFF
--- a/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
+++ b/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
@@ -225,6 +225,13 @@ TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsCapability)
                 m_swid,
                 SAI_OBJECT_TYPE_PORT,
                 &stats_capability));
+
+    /* Invalid switch id */
+    EXPECT_EQ(SAI_STATUS_FAILURE,
+            m_vssai->queryStatsCapability(
+                SAI_NULL_OBJECT_ID,
+                SAI_OBJECT_TYPE_SWITCH,
+                &stats_capability));
 }
 
 TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsStCapability)
@@ -289,6 +296,13 @@ TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsStCapability)
                   SAI_OBJECT_TYPE_PORT,
                   &stats_capability));
     EXPECT_EQ(stats_capability.list[0].minimal_polling_interval, static_cast<uint64_t>(1e6 * 100));
+
+    /* Invalid switch id */
+    EXPECT_EQ(SAI_STATUS_FAILURE,
+              m_vssai->queryStatsStCapability(
+                  SAI_NULL_OBJECT_ID,
+                  SAI_OBJECT_TYPE_SWITCH,
+                  &stats_capability));
 }
 
 TEST_F(VirtualSwitchSaiInterfaceTest, switchHostifTrapCapabilityGet)

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -4689,11 +4689,19 @@ sai_status_t SwitchStateBase::queryStatsStCapability(
     {
         for (uint32_t i = 0; i < stats_capability.count; i++)
         {
+            stats_st_capability->count = stats_capability.count;
             stats_st_capability->list[i].capability.stat_enum = stats_capability.list[i].stat_enum;
             stats_st_capability->list[i].capability.stat_modes = stats_capability.list[i].stat_modes;
             stats_st_capability->list[i].minimal_polling_interval = static_cast<uint64_t>(1e6 * 100);
             ; // 100ms
         }
+    }
+    else if (status == SAI_STATUS_BUFFER_OVERFLOW)
+    {
+        stats_st_capability->count = stats_capability.count;
+        SWSS_LOG_WARN("Buffer overflow for object type %s, count: %u",
+                      sai_serialize_object_type(objectType).c_str(),
+                      stats_st_capability->count);
     }
     else
     {

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -1062,41 +1062,19 @@ sai_status_t VirtualSwitchSaiInterface::queryStatsStCapability(
 {
     SWSS_LOG_ENTER();
 
-    sai_stat_capability_list_t stats_capability;
-    std::vector<sai_stat_capability_t> stats_list(stats_st_capability->count);
-    stats_capability.count = stats_st_capability->count;
-    stats_capability.list = stats_list.data();
+    if (m_switchStateMap.find(switchId) == m_switchStateMap.end())
+    {
+        SWSS_LOG_ERROR("failed to find switch %s in switch state map", sai_serialize_object_id(switchId).c_str());
 
-    sai_status_t status = queryStatsCapability(
+        return SAI_STATUS_FAILURE;
+    }
+
+    auto ss = m_switchStateMap.at(switchId);
+
+    return ss->queryStatsStCapability(
         switchId,
         objectType,
-        &stats_capability);
-
-    if (status == SAI_STATUS_SUCCESS)
-    {
-        stats_st_capability->count = stats_capability.count;
-        for (uint32_t i = 0; i < stats_capability.count; i++)
-        {
-            stats_st_capability->list[i].capability.stat_enum = stats_capability.list[i].stat_enum;
-            stats_st_capability->list[i].capability.stat_modes = stats_capability.list[i].stat_modes;
-            stats_st_capability->list[i].minimal_polling_interval = static_cast<uint64_t>(1e6 * 100); // 100ms
-        }
-    }
-    else if (status == SAI_STATUS_BUFFER_OVERFLOW)
-    {
-        stats_st_capability->count = stats_capability.count;
-        SWSS_LOG_WARN("Buffer overflow for object type %s, count: %u",
-                      sai_serialize_object_type(objectType).c_str(),
-                      stats_st_capability->count);
-    }
-    else
-    {
-        SWSS_LOG_WARN("Failed to query stats capability for object type %s, status: %s",
-                      sai_serialize_object_type(objectType).c_str(),
-                      sai_serialize_status(status).c_str());
-    }
-
-    return status;
+        stats_st_capability);
 }
 
 sai_status_t VirtualSwitchSaiInterface::getStatsExt(

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -764,6 +764,19 @@ sai_status_t SwitchVpp::queryAttributeCapability(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchVpp::queryStatsStCapability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _Inout_ sai_stat_st_capability_list_t *stats_capability)
+{
+    SWSS_LOG_ENTER();
+
+    // VPP does not support streaming telemetry (HFTel / TAM).
+    // Returning NOT_SUPPORTED prevents HFTelOrch from being instantiated.
+
+    return SAI_STATUS_NOT_SUPPORTED;
+}
+
 uint64_t SwitchVpp::getObjectTypeAvailability(
         _In_ sai_object_type_t object_type)
 {

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -101,6 +101,11 @@ namespace saivs
                     _In_ sai_attr_id_t attr_id,
                     _Out_ sai_attr_capability_t *capability) override;
 
+            virtual sai_status_t queryStatsStCapability(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_object_type_t object_type,
+                    _Inout_ sai_stat_st_capability_list_t *stats_capability) override;
+
             virtual uint64_t getObjectTypeAvailability(
                     _In_ sai_object_type_t object_type) override;
 


### PR DESCRIPTION
### why
vpp doesn't support stats streaming. It needs to return NOT_SUPPORTED when receiving queryStatsStCapability.

### what this PR does
1. Fix VirtualSwitchSaiInterface::queryStatsStCapability, which incorrectly calls queryStatsCapability
2. Implements queryStatsCapability in SwitchVpp to override the base class implementation for vs.