### PR TITLE
Runtime knob for Southbound ZMQ

### DIFF
--- a/lib/ContextConfig.cpp
+++ b/lib/ContextConfig.cpp
@@ -18,8 +18,9 @@ ContextConfig::ContextConfig(
     m_dbFlex(dbFlex),
     m_dbState(dbState),
     m_zmqEnable(false),
-    m_zmqEndpoint("ipc:///tmp/zmq_ep"),
-    m_zmqNtfEndpoint("ipc:///tmp/zmq_ntf_ep")
+    m_loadedFromJson(false),
+    m_zmqEndpoint("tcp://127.0.0.1:5555"),
+    m_zmqNtfEndpoint("tcp://127.0.0.1:5556")
 {
     SWSS_LOG_ENTER();
 

--- a/lib/ContextConfig.h
+++ b/lib/ContextConfig.h
@@ -42,6 +42,8 @@ namespace sairedis
 
             bool m_zmqEnable;
 
+            bool m_loadedFromJson;
+
             std::string m_zmqEndpoint;
 
             std::string m_zmqNtfEndpoint;

--- a/lib/ContextConfigContainer.cpp
+++ b/lib/ContextConfigContainer.cpp
@@ -126,6 +126,7 @@ std::shared_ptr<ContextConfigContainer> ContextConfigContainer::loadFromFile(
             cc->m_zmqEnable = item["zmq_enable"];
             cc->m_zmqEndpoint = item["zmq_endpoint"];
             cc->m_zmqNtfEndpoint = item["zmq_ntf_endpoint"];
+            cc->m_loadedFromJson = true;
 
             SWSS_LOG_NOTICE("contextConfig zmq enable %s, endpoint: %s, ntf endpoint: %s",
                     (cc->m_zmqEnable) ? "true" : "false",

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -81,16 +81,19 @@ sai_status_t RedisRemoteSaiInterface::apiInitialize(
     m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
     m_zmqResponseBufferSize = SAI_ZMQ_DEFAULT_RESPONSE_BUFFER_SIZE;
 
-    if (m_contextConfig->m_zmqEnable)
+    if (m_contextConfig->m_loadedFromJson && m_contextConfig->m_zmqEnable)
     {
+        // context_config.json is authoritative: lock this context to ZMQ at init
+        SWSS_LOG_NOTICE("context %u: JSON zmq_enable=true, creating ZMQ channel at init",
+                m_contextConfig->m_guid);
+
         m_communicationChannel = std::make_shared<ZeroMQChannel>(
                 m_contextConfig->m_zmqEndpoint,
                 m_contextConfig->m_zmqNtfEndpoint,
                 std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3),
                 m_zmqResponseBufferSize);
 
-        SWSS_LOG_NOTICE("zmq enabled, forcing sync mode");
-
+        m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
         m_syncMode = true;
     }
     else
@@ -369,14 +372,24 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
         case SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE:
 
-            m_redisCommunicationMode = (sai_redis_communication_mode_t)attr->value.s32;
-
-            if (m_contextConfig->m_zmqEnable)
+            // JSON zmq_enable=true: transport locked to ZMQ at init; ignore attr
+            if (m_contextConfig->m_loadedFromJson && m_contextConfig->m_zmqEnable)
             {
-                SWSS_LOG_NOTICE("zmq enabled via context config");
+                if (attr->value.s32 == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+                {
+                    SWSS_LOG_NOTICE("context %u: JSON zmq_enable=true, comm-mode attr ZMQ_SYNC matches; ignoring redundant request",
+                            m_contextConfig->m_guid);
+                }
+                else
+                {
+                    SWSS_LOG_WARN("context %u: JSON zmq_enable=true enforces ZMQ_SYNC but caller requested comm-mode %d; ignoring",
+                            m_contextConfig->m_guid, attr->value.s32);
+                }
 
-                m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+                return SAI_STATUS_SUCCESS;
             }
+
+            m_redisCommunicationMode = (sai_redis_communication_mode_t)attr->value.s32;
 
             m_communicationChannel = nullptr;
 
@@ -415,11 +428,32 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
                     return SAI_STATUS_SUCCESS;
 
                 case SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC:
+                    // If context_config.json explicitly set zmq_enable=false,
+                    // respect it and fall back to RedisChannel
+                    if (m_contextConfig->m_loadedFromJson && !m_contextConfig->m_zmqEnable)
+                    {
+                        SWSS_LOG_NOTICE("context %u: zmq_enable=false in context config, falling back to Redis sync",
+                                m_contextConfig->m_guid);
+
+                        // Keep m_redisCommunicationMode aligned with the actual channel
+                        m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+
+                        m_syncMode = true;
+
+                        m_communicationChannel = std::make_shared<RedisChannel>(
+                                m_contextConfig->m_dbAsic,
+                                std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
+
+                        m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
+
+                        m_communicationChannel->setBuffered(false);
+
+                        return SAI_STATUS_SUCCESS;
+                    }
+
+                    SWSS_LOG_NOTICE("ZMQ sync mode enabled for context %u", m_contextConfig->m_guid);
 
                     m_contextConfig->m_zmqEnable = true;
-
-                    // main communication channel was created at initialize method
-                    // so this command will replace it with zmq channel
 
                     m_communicationChannel = std::make_shared<ZeroMQChannel>(
                             m_contextConfig->m_zmqEndpoint,
@@ -428,8 +462,6 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
                             m_zmqResponseBufferSize);
 
                     m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
-
-                    SWSS_LOG_NOTICE("zmq enabled, forcing sync mode");
 
                     m_syncMode = true;
 

--- a/lib/sairedis.h
+++ b/lib/sairedis.h
@@ -78,7 +78,7 @@ typedef enum _sai_redis_communication_mode_t
      * mode with zmq library. This mode requires some additional configuration
      * like main channel string and notification channel string. When using
      * this attribute those channels are set to default values:
-     * "ipc:///tmp/zmq_ep" and "ipc:///tmp/zmq_ntf_ep". To take control of
+     * "tcp://127.0.0.1:5555" and "tcp://127.0.0.1:5556". To take control of
      * those values a context config json file must be provided via
      * SAI_REDIS_KEY_CONTEXT_CONFIG profile argument.
      */

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -22,6 +22,8 @@
 #include "swss/tokenize.h"
 #include "swss/notificationproducer.h"
 #include "swss/exec.h"
+#include "swss/dbconnector.h"
+#include "swss/table.h"
 
 #include "meta/sai_serialize.h"
 #include "meta/ZeroMQSelectableChannel.h"
@@ -82,16 +84,8 @@ Syncd::Syncd(
         SWSS_LOG_THROW("no context config defined at global context %u", m_commandLineOptions->m_globalContext);
     }
 
-    if (m_contextConfig->m_zmqEnable && m_commandLineOptions->m_enableSyncMode)
-    {
-        SWSS_LOG_NOTICE("disabling command line sync mode, since context zmq enabled");
-
-        m_commandLineOptions->m_enableSyncMode = false;
-
-        m_commandLineOptions->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
-    }
-
-    if (m_commandLineOptions->m_enableSyncMode)
+    if (m_commandLineOptions->m_enableSyncMode
+            && !(m_contextConfig->m_loadedFromJson && m_contextConfig->m_zmqEnable))
     {
         SWSS_LOG_WARN("enable sync mode is deprecated, please use communication mode, FORCING redis sync mode");
 
@@ -104,11 +98,25 @@ Syncd::Syncd(
 
     if (m_commandLineOptions->m_redisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
     {
-        SWSS_LOG_NOTICE("zmq sync mode enabled via cmd line");
+        // If context_config.json explicitly set zmq_enable=false,
+        // respect it and fall back to Redis sync
+        if (m_contextConfig->m_loadedFromJson && !m_contextConfig->m_zmqEnable)
+        {
+            SWSS_LOG_NOTICE("context %u: zmq_enable=false in context config, falling back to Redis sync",
+                    m_contextConfig->m_guid);
 
-        m_contextConfig->m_zmqEnable = true;
+            m_enableSyncMode = true;
 
-        m_enableSyncMode = true;
+            m_commandLineOptions->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("zmq sync mode enabled via cmd line for context %u", m_contextConfig->m_guid);
+
+            m_contextConfig->m_zmqEnable = true;
+
+            m_enableSyncMode = true;
+        }
     }
 
     auto vso = std::make_shared<VendorSaiOptions>();
@@ -155,8 +163,14 @@ Syncd::Syncd(
     }
 
     bool isVirtualSwitch = m_profileMap.find(SAI_KEY_VS_SWITCH_TYPE) != m_profileMap.end();
+    swss::DBConnector configDb("CONFIG_DB", 0);
+    swss::Table deviceMetadataTable(&configDb, "DEVICE_METADATA");
+    std::string switchType;
+    deviceMetadataTable.hget("localhost", "switch_type", switchType);
 
-    if (m_contextConfig->m_zmqEnable && !isVirtualSwitch)
+    bool isDpuSwitch = switchType == "dpu";
+
+    if (m_contextConfig->m_zmqEnable && isDpuSwitch && !isVirtualSwitch)
     {
         m_client = std::make_shared<DisabledRedisClient>();
     }

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -11,6 +11,7 @@ ENABLE_SAITHRIFT=0
 TEMPLATES_DIR=/usr/share/sonic/templates
 PLATFORM_DIR=/usr/share/sonic/platform
 HWSKU_DIR=/usr/share/sonic/hwsku
+CONTEXT_CONFIG_FILE=$HWSKU_DIR/context_config.json
 SAI_PROFILE_DIR=/etc/sai.d
 
 VARS_FILE=$TEMPLATES_DIR/swss_vars.j2
@@ -41,8 +42,14 @@ mkdir -p /var/log/sai_failure_dump/
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SYNCD_VARS | jq -r '.synchronous_mode')
 SWITCH_TYPE=$(echo $SYNCD_VARS | jq -r '.switch_type')
+SOUTHBOUND_ZMQ=$(echo $SYNCD_VARS | jq -r '.orch_southbound_zmq_enabled')
 if [ "$SWITCH_TYPE" == "dpu" ]; then
-    CMD_ARGS+=" -z zmq_sync -x /usr/share/sonic/hwsku/context_config.json"
+    CMD_ARGS+=" -z zmq_sync -x $CONTEXT_CONFIG_FILE"
+elif [ "$SOUTHBOUND_ZMQ" == "true" ]; then
+    CMD_ARGS+=" -z zmq_sync"
+    if [ -f "$CONTEXT_CONFIG_FILE" ]; then
+        CMD_ARGS+=" -x $CONTEXT_CONFIG_FILE"
+    fi
 elif [ "$SYNC_MODE" == "enable" ]; then
     CMD_ARGS+=" -s"
 fi

--- a/unittest/lib/TestContextConfigContainer.cpp
+++ b/unittest/lib/TestContextConfigContainer.cpp
@@ -20,6 +20,30 @@ TEST(ContextConfigContainer, loadFromFile)
     EXPECT_NE(ccc.loadFromFile("files/ccc_bad.txt"), nullptr);
 }
 
+TEST(ContextConfigContainer, loadFromFileSetLoadedFromJson)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_container_ok.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+
+    ASSERT_NE(cc, nullptr);
+    EXPECT_TRUE(cc->m_loadedFromJson);
+}
+
+TEST(ContextConfigContainer, defaultDoesNotSetLoadedFromJson)
+{
+    auto ccc = ContextConfigContainer::loadFromFile(nullptr);
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+
+    ASSERT_NE(cc, nullptr);
+    EXPECT_FALSE(cc->m_loadedFromJson);
+}
+
 TEST(ContextConfigContainer, insert)
 {
     ContextConfigContainer ccc;

--- a/unittest/lib/TestRedisRemoteSaiInterface.cpp
+++ b/unittest/lib/TestRedisRemoteSaiInterface.cpp
@@ -1,5 +1,7 @@
 #include "RedisRemoteSaiInterface.h"
 #include "ContextConfigContainer.h"
+#include "ContextConfig.h"
+#include "RedisChannel.h"
 #include "sairediscommon.h"
 
 #include <gtest/gtest.h>
@@ -87,4 +89,26 @@ TEST(RedisRemoteSaiInterface, queryStatsStCapability)
               sai.queryStatsStCapability(0,
                                          SAI_OBJECT_TYPE_PORT,
                                          &stats_capability));
+}
+
+TEST(RedisRemoteSaiInterface, zmqSyncFallsBackToRedisSyncWhenJsonDisablesZmq)
+{
+    SWSS_LOG_ENTER();
+
+    auto cc = std::make_shared<ContextConfig>(0, "syncd", "ASIC_DB", "COUNTERS_DB", "FLEX_COUNTER_DB", "STATE_DB");
+    cc->m_loadedFromJson = true;
+    cc->m_zmqEnable = false;
+
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_TRUE(sai.m_syncMode);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC);
 }

--- a/unittest/lib/files/context_config_container_ok.json
+++ b/unittest/lib/files/context_config_container_ok.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "zmq_enable": true,
+            "zmq_endpoint": "ipc:///tmp/test_zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///tmp/test_zmq_ntf_ep",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/syncd/TestSyncd.cpp
+++ b/unittest/syncd/TestSyncd.cpp
@@ -211,6 +211,34 @@ TEST(Syncd, inspectAsic)
     EXPECT_EQ(SAI_STATUS_SUCCESS, sai->apiUninitialize());
 }
 
+TEST(Syncd, zmqSyncWithJsonDisabledFallsBackToRedisSync)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_contextConfig = "files/ctx_zmq_disabled.json";
+
+    auto syncd = std::make_shared<Syncd>(sai, cmd, false);
+
+    EXPECT_EQ(cmd->m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC);
+    EXPECT_TRUE(syncd->m_enableSyncMode);
+}
+
+TEST(Syncd, zmqSyncWithJsonEnabledUsesZmq)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_contextConfig = "files/ctx_zmq_enabled.json";
+
+    auto syncd = std::make_shared<Syncd>(sai, cmd, false);
+
+    EXPECT_EQ(cmd->m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+    EXPECT_TRUE(syncd->m_enableSyncMode);
+}
+
 using namespace syncd;
 
 #ifdef MOCK_METHOD

--- a/unittest/syncd/files/ctx_zmq_disabled.json
+++ b/unittest/syncd/files/ctx_zmq_disabled.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "ipc:///tmp/test_syncd_zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///tmp/test_syncd_zmq_ntf_ep",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/syncd/files/ctx_zmq_enabled.json
+++ b/unittest/syncd/files/ctx_zmq_enabled.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "zmq_enable": true,
+            "zmq_endpoint": "ipc:///tmp/test_syncd_zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///tmp/test_syncd_zmq_ntf_ep",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
#### Why I did it
Enable runtime-toggleable ZMQ communication between orchagent and syncd (southbound) via a CONFIG_DB knob.

#### How I did it

1. Changed default ZMQ endpoints in ContextConfig from ipc:///tmp/zmq_ep to tcp://127.0.0.1:5555 / tcp://127.0.0.1:5556 so orchagent↔syncd ZMQ works out-of-the-box without a hwsku-specific context_config.json.
2. Added an m_loadedFromJson flag to ContextConfig, set by ContextConfigContainer::loadFromFile(). This lets us distinguish "no config file present (defaults)" from "config file explicitly disables ZMQ".
3. In both RedisRemoteSaiInterface (orchagent side) and Syncd (syncd side): when -z zmq_sync is requested via cmdline but a loaded context_config.json sets zmq_enable=false, fall back to Redis sync. This allows context_config.json to act as an explicit override.
4. Scoped DisabledRedisClient (write-only-to-ZMQ) to DPU switches only. Non-DPU ZMQ retains a real Redis client so the ASIC_DB mirror is still populated for tools and observability.
5. syncd_init_common.sh reads orch_southbound_zmq_enabled from SYNCD_VARS (generated from CONFIG_DB DEVICE_METADATA) and passes -z zmq_sync when true.

#### Behavior changes

Documenting silent behavior changes for reviewers:

1. **Default ZMQ endpoints changed** from `ipc:///tmp/zmq_ep` / `ipc:///tmp/zmq_ntf_ep` to `tcp://127.0.0.1:5555` / `tcp://127.0.0.1:5556`. The doc comment in `lib/sairedis.h` for `SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC` is updated to match.
2. **`-z zmq_sync` cmdline flag is no longer absolute.** When `context_config.json` is loaded and sets `zmq_enable=false` for the context, both syncd and sairedis fall back to `REDIS_SYNC`. The JSON is now authoritative.
3. **`-s` flag interaction with JSON ZMQ.** The old code rewrote `m_commandLineOptions->m_redisCommunicationMode` to `ZMQ_SYNC` when `-s` was passed and `m_zmqEnable` was true. The new code skips that block when `m_loadedFromJson && m_zmqEnable`, so the field retains its initial value. Net transport is unchanged (ZMQ is still picked via the later `m_zmqEnable` check), but the cmdline-options state field is no longer rewritten.
4. **`DisabledRedisClient` is now DPU-only.** Non-DPU ZMQ deployments retain a real `RedisClient`, so the ASIC_DB mirror is still populated for tools and observability.
5. **State alignment after fallback.** When sairedis falls back to `RedisChannel` because JSON disables ZMQ, `m_redisCommunicationMode` is now set to `REDIS_SYNC` so the member variable matches the actual channel.

#### How to verify it
Ran route benchmark test with both configurations to confirm:

- Default behavior (knob disabled) remains unchanged
- ZMQ mode activates correctly when knob is enabled
- Routes program successfully through the full pipeline in both modes


#### Related PRs:

https://github.com/sonic-net/sonic-buildimage/pull/26638
https://github.com/sonic-net/sonic-swss/pull/4556
