### PR TITLE
debian: Avoid double libsairedis build for syncd-rpc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 1.0.0
 
 Package: syncd
 Architecture: any
-Build-Profiles: <syncd !vs>
+Build-Profiles: <syncd !vs !rpc>
 Depends: ${misc:Pre-Depends}
 Recommends: ${shlibs:Depends}
 Conflicts: syncd-rpc, syncd-vs

--- a/debian/rules
+++ b/debian/rules
@@ -55,20 +55,10 @@ endif
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
 override_dh_auto_configure:
-	dh_auto_configure -- ${SWSS_COMMON_CONFIG} $(configure_opts) $(DEB_CONFIGURE_EXTRA_FLAGS)
+	dh_auto_configure -- ${SWSS_COMMON_CONFIG} $(configure_opts) $(DEB_CONFIGURE_EXTRA_FLAGS) $(if $(filter rpc,$(DEB_BUILD_PROFILES)),--enable-rpcserver,)
 
 override_dh_install:
-ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
-	dh_install -N syncd-rpc
-	# This is to build a RPC-enabled version, and package that version into syncd-rpc
-	dh_auto_configure -- ${SWSS_COMMON_CONFIG} $(configure_opts) --enable-rpcserver
-	make clean
-	dh_auto_build
-	make install DESTDIR=$(shell pwd)/debian/tmp
-	dh_install -N syncd
-else
 	dh_install
-endif
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 endif


### PR DESCRIPTION
Fixes Issue #333 by configuring rpcserver once and preventing syncd from being built under the rpc profile, avoiding a second libsairedis rebuild.