### PR TITLE
[SmartSwitch] [DPU] Support maximum dash configuration size

### DIFF
--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -20,7 +20,7 @@
 
 #include <inttypes.h>
 
-#define SAI_ZMQ_DEFAULT_RESPONSE_BUFFER_SIZE (64*1024*1024)
+#define SAI_ZMQ_DEFAULT_RESPONSE_BUFFER_SIZE (128*1024*1024)
 
 using namespace sairedis;
 using namespace saimeta;

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -41,7 +41,7 @@
 
 #define DEF_SAI_WARM_BOOT_DATA_FILE "/var/warmboot/sai-warmboot.bin"
 #define SAI_FAILURE_DUMP_SCRIPT "/usr/bin/sai_failure_dump.sh"
-#define SYNCD_ZMQ_RESPONSE_BUFFER_SIZE (64*1024*1024)
+#define SYNCD_ZMQ_RESPONSE_BUFFER_SIZE (128*1024*1024)
 
 using namespace syncd;
 using namespace saimeta;


### PR DESCRIPTION
#### Why I did it
SONiC sairedis zmq does not currently support a large enough buffer size to handle the max dash scale config on DPU.

#### How I did it
Increase the buffer size to 128 MB to handle the max dash scale config.

#### How to verify it
Send the maximum dash scale config in a test and confirm config is applied.