### PR TITLE
[meta] Populate object_statuses on bulk validation failure; DASH entries use ITEM_NOT_FOUND for missing keys

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -667,14 +667,22 @@ sai_status_t Meta::bulkRemove(                                                  
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], false);                                                \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        if (status != SAI_STATUS_SUCCESS)                                                                               \
+        {                                                                                                               \
+            object_statuses[idx] = status;                                                                              \
+            return status;                                                                                              \
+        }                                                                              \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
             };                                                                                                          \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_remove(meta_key);                                                              \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        if (status != SAI_STATUS_SUCCESS)                                                                               \
+        {                                                                                                               \
+            object_statuses[idx] = status;                                                                            \
+            return status;                                                                                              \
+        }                                                                                  \
     }                                                                                                                   \
     auto status = m_implementation->bulkRemove(object_count, ot, mode, object_statuses);                                \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -2923,7 +2923,7 @@ sai_status_t Meta::meta_sai_validate_direction_lookup_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                     sai_serialize_object_meta_key(meta_key_direction_lookup_entry).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     return SAI_STATUS_SUCCESS;
@@ -2969,7 +2969,7 @@ sai_status_t Meta::meta_sai_validate_eni_ether_address_map_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                     sai_serialize_object_meta_key(meta_key_eni_ether_address_map_entry).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     return SAI_STATUS_SUCCESS;
@@ -3015,7 +3015,7 @@ sai_status_t Meta::meta_sai_validate_vip_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                     sai_serialize_object_meta_key(meta_key_vip_entry).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     return SAI_STATUS_SUCCESS;
@@ -3061,7 +3061,7 @@ sai_status_t Meta::meta_sai_validate_inbound_routing_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                     sai_serialize_object_meta_key(meta_key_inbound_routing_entry).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     return SAI_STATUS_SUCCESS;
@@ -3107,7 +3107,7 @@ sai_status_t Meta::meta_sai_validate_pa_validation_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                     sai_serialize_object_meta_key(meta_key_pa_validation_entry).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     return SAI_STATUS_SUCCESS;
@@ -3153,7 +3153,7 @@ sai_status_t Meta::meta_sai_validate_outbound_routing_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                     sai_serialize_object_meta_key(meta_key_outbound_routing_entry).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     return SAI_STATUS_SUCCESS;
@@ -3199,7 +3199,7 @@ sai_status_t Meta::meta_sai_validate_outbound_ca_to_pa_entry(
         SWSS_LOG_ERROR("object key %s doesn't exist",
                     sai_serialize_object_meta_key(meta_key_outbound_ca_to_pa_entry).c_str());
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_ITEM_NOT_FOUND;
     }
 
     return SAI_STATUS_SUCCESS;

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -18,6 +18,17 @@
 
 #define CHECK_STATUS_SUCCESS(s) { if ((s) != SAI_STATUS_SUCCESS) return (s); }
 
+// Like CHECK_STATUS_SUCCESS, but on failure updates object_statuses[idx] before return.
+#define CHECK_STATUS_SUCCESS_AND_UPDATE(s, object_statuses, idx)                 \
+    do {                                                                         \
+        sai_status_t _object_st = (s);                                           \
+        if (_object_st != SAI_STATUS_SUCCESS)                                    \
+        {                                                                        \
+            (object_statuses)[(idx)] = _object_st;                               \
+            return _object_st;                                                   \
+        }                                                                        \
+    } while (0)
+
 #define VALIDATION_LIST(md,vlist)                                               \
 {                                                                               \
     auto _status = meta_genetic_validation_list(md,vlist.count,vlist.list);     \
@@ -623,14 +634,14 @@ sai_status_t Meta::bulkCreate(                                                  
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], true);                                                 \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_AND_UPDATE(status, object_statuses, idx);                                                  \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
              };                                                                                                         \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_create(meta_key, ot[idx].switch_id, attr_count[idx], attr_list[idx]);          \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_AND_UPDATE(status, object_statuses, idx);                                                  \
     }                                                                                                                   \
     auto status = m_implementation->bulkCreate(object_count, ot, attr_count, attr_list, mode, object_statuses);         \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
@@ -667,22 +678,14 @@ sai_status_t Meta::bulkRemove(                                                  
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], false);                                                \
-        if (status != SAI_STATUS_SUCCESS)                                                                               \
-        {                                                                                                               \
-            object_statuses[idx] = status;                                                                              \
-            return status;                                                                                              \
-        }                                                                              \
+        CHECK_STATUS_SUCCESS_AND_UPDATE(status, object_statuses, idx);                                                  \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
             };                                                                                                          \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_remove(meta_key);                                                              \
-        if (status != SAI_STATUS_SUCCESS)                                                                               \
-        {                                                                                                               \
-            object_statuses[idx] = status;                                                                            \
-            return status;                                                                                              \
-        }                                                                                  \
+        CHECK_STATUS_SUCCESS_AND_UPDATE(status, object_statuses, idx);                                                  \
     }                                                                                                                   \
     auto status = m_implementation->bulkRemove(object_count, ot, mode, object_statuses);                                \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
@@ -721,14 +724,14 @@ sai_status_t Meta::bulkSet(                                                     
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], false);                                                \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_AND_UPDATE(status, object_statuses, idx);                                                  \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
              };                                                                                                         \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_set(meta_key, &attr_list[idx]);                                                \
-        CHECK_STATUS_SUCCESS(status);                                                                                   \
+        CHECK_STATUS_SUCCESS_AND_UPDATE(status, object_statuses, idx);                                                  \
     }                                                                                                                   \
     auto status = m_implementation->bulkSet(object_count, ot, attr_list, mode, object_statuses);                        \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \


### PR DESCRIPTION
**What I did**

### Bulk create / remove / set (`meta/Meta.cpp`)

1. **`CHECK_STATUS_SUCCESS_AND_UPDATE(status, object_statuses, idx)`** — Same as **`CHECK_STATUS_SUCCESS`**, but on non-**`SAI_STATUS_SUCCESS`** it assigns **`object_statuses[idx] = status`** before returning. That way the failing index is visible to callers of the typed bulk APIs.

2. **`DECLARE_BULK_CREATE_ENTRY`**, **`DECLARE_BULK_REMOVE_ENTRY`**, **`DECLARE_BULK_SET_ENTRY`** — After **`meta_sai_validate_*`** and after **`meta_generic_validation_{create,remove,set}`**, use **`CHECK_STATUS_SUCCESS_AND_UPDATE`** instead of **`CHECK_STATUS_SUCCESS`**.

### DASH entry validation (missing referenced object)

For **`meta_sai_validate_*`** entry types, when a required object key is not present in **`m_saiObjectCollection`**, the return code is **`SAI_STATUS_ITEM_NOT_FOUND`** instead of **`SAI_STATUS_INVALID_PARAMETER`**:

**Why I did it**

- Bulk APIs report per-object outcomes via `object_statuses`. Returning early from Meta validation without filling `object_statuses[idx]` leaves callers without the failing object’s status and causing retry.
- **`SAI_STATUS_ITEM_NOT_FOUND`** better matches the semantics of a missing object key than **`SAI_STATUS_INVALID_PARAMETER`**.

**How I verified it**
- **Integration test (APP_DB):** Apply base DASH config, add two outbound routes, **DEL** both routes once, then **DEL** the same keys again. The second delete exercises remove when the outbound routing entry is already gone from Meta’s collection, and it will not retry.

Log

```text
meta_sai_validate_outbound_routing_entry: object key SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY:{"destination":"0.0.0.1/32","outbound_routing_group_id":"oid:0x1400800000001f","switch_id":"oid:0x21000000000000"} doesn't exist
EntityBulker.flush remove entries failed, number of entries to remove: 2, status: SAI_STATUS_ITEM_NOT_FOUND
handleSaiRemoveStatus: Invalid entry for remove operation, SAI API: SAI_API_DASH_OUTBOUND_ROUTING, status: SAI_STATUS_ITEM_NOT_FOUND
removeOutboundRoutingPost: Failed to remove outbound routing entry for group_id_eni1:0.0.0.1/32

meta_sai_validate_outbound_routing_entry: object key SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY:{"destination":"0.0.0.2/32","outbound_routing_group_id":"oid:0x1400800000001f","switch_id":"oid:0x21000000000000"} doesn't exist
EntityBulker.flush remove entries failed, number of entries to remove: 1, status: SAI_STATUS_ITEM_NOT_FOUND
handleSaiRemoveStatus: Invalid entry for remove operation, SAI API: SAI_API_DASH_OUTBOUND_ROUTING, status: SAI_STATUS_ITEM_NOT_FOUND
removeOutboundRoutingPost: Failed to remove outbound routing entry for group_id_eni1:0.0.0.2/32
```