### PR TITLE
Fix the wrong RID to VID mapping for south bound notifications with ZMQ

### DIFF
--- a/syncd/VirtualOidTranslator.cpp
+++ b/syncd/VirtualOidTranslator.cpp
@@ -39,7 +39,7 @@ bool VirtualOidTranslator::tryTranslateRidToVid(
         return true;
     }
 
-    auto it = m_rid2vid.find(vid);
+    auto it = m_rid2vid.find(rid);
 
     if (it != m_rid2vid.end())
     {
@@ -170,14 +170,30 @@ void VirtualOidTranslator::translateRidsToVids(
     newVids.reserve(count);
 
     /*
-     * Get unknown (new) RIDs into newRids array.
+     * DisabledRedisClient::getVidsForRids (ZMQ / no-ASIC_DB) returns null for
+     * every RID. User-created objects (e.g. bulk create ports) already have
+     * RID->VID in m_rid2vid from insertRidsAndVids. Without this pass,
+     * redisSetDummyAsicStateForRealObjectIds / onPostPortsCreate would allocate
+     * new VIDs and overwrite the map, so notifications (e.g. port_state_change)
+     * would use wrong VIDs.
+     *
+     * Then collect RIDs that still have no VID for allocateNewObjectIds below.
      */
+
     for (size_t idx = 0; idx < count; idx++)
     {
         if (vids[idx] == SAI_NULL_OBJECT_ID)
         {
-            newRids.push_back(rids[idx]);
-            newVids.push_back(SAI_NULL_OBJECT_ID);
+            auto it = m_rid2vid.find(rids[idx]);
+            if (it != m_rid2vid.end())
+            {
+                vids[idx] = it->second;
+            }
+            else
+            {
+                newRids.push_back(rids[idx]);
+                newVids.push_back(SAI_NULL_OBJECT_ID);
+            }
         }
     }
 

--- a/unittest/syncd/TestVirtualOidTranslator.cpp
+++ b/unittest/syncd/TestVirtualOidTranslator.cpp
@@ -1,4 +1,5 @@
 #include "VirtualOidTranslator.h"
+#include "DisabledRedisClient.h"
 #include "RedisClient.h"
 #include "VendorSai.h"
 #include "lib/RedisVidIndexGenerator.h"
@@ -158,6 +159,130 @@ TEST(VirtualOidTranslator, tryTranslateVidToRid)
     mk.objectkey.key.fdb_entry.bv_id = 0x21;
 
     EXPECT_FALSE(vot.tryTranslateVidToRid(mk));
+
+    sai->apiUninitialize();
+}
+
+TEST(VirtualOidTranslator, tryTranslateRidToVidDisabledRedisClient)
+{
+    /*
+     * With DisabledRedisClient (ZMQ / no ASIC_DB RID map), tryTranslateRidToVid
+     * must use the in-memory m_rid2vid map filled by insertRidAndVid - not
+     * getVidForRid (which always returns SAI_NULL_OBJECT_ID).
+     *
+     * ASIC_DB is still used for RedisVidIndexGenerator / VirtualObjectIdManager;
+     * only the translator's BaseRedisClient is DisabledRedisClient, so RID->VID
+     * is not read from Redis for this path.
+     */
+    profileMap["SAI_VS_SWITCH_TYPE"] = "SAI_VS_SWITCH_TYPE_BCM56850";
+
+    auto dbAsic = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+    auto client = std::make_shared<DisabledRedisClient>();
+    auto sai = std::make_shared<saivs::Sai>();
+
+    ServiceMethodTable smt;
+
+    smt.profileGetValue = std::bind(&profileGetValue, _1, _2);
+    smt.profileGetNextValue = std::bind(&profileGetNextValue, _1, _2, _3);
+
+    sai_service_method_table_t test_services = smt.getServiceMethodTable();
+
+    sai_status_t status = sai->apiInitialize(0, &test_services);
+
+    EXPECT_EQ(status, SAI_STATUS_SUCCESS);
+
+    auto switchConfigContainer = std::make_shared<sairedis::SwitchConfigContainer>();
+    auto redisVidIndexGenerator = std::make_shared<sairedis::RedisVidIndexGenerator>(dbAsic, REDIS_KEY_VIDCOUNTER);
+
+    auto virtualObjectIdManager =
+        std::make_shared<sairedis::VirtualObjectIdManager>(
+                0,
+                switchConfigContainer,
+                redisVidIndexGenerator);
+
+    VirtualOidTranslator vot(client, virtualObjectIdManager, sai);
+
+    const sai_object_id_t rid = 0x21000000aa;
+    const sai_object_id_t vid = 0x21000000000000aaULL;
+
+    sai_object_id_t out = rid;
+
+    EXPECT_FALSE(vot.tryTranslateRidToVid(rid, out));
+    EXPECT_EQ(out, SAI_NULL_OBJECT_ID);
+
+    vot.insertRidAndVid(rid, vid);
+
+    EXPECT_EQ(client->getVidForRid(rid), SAI_NULL_OBJECT_ID);
+
+    out = rid;
+    EXPECT_TRUE(vot.tryTranslateRidToVid(rid, out));
+    EXPECT_EQ(out, vid);
+
+    sai_object_id_t nullOut = 0xdeadbeefULL;
+    EXPECT_TRUE(vot.tryTranslateRidToVid(SAI_NULL_OBJECT_ID, nullOut));
+    EXPECT_EQ(nullOut, SAI_NULL_OBJECT_ID);
+
+    sai->apiUninitialize();
+}
+
+TEST(VirtualOidTranslator, translateRidsToVidsDisabledRedisClient)
+{
+    /*
+     * DisabledRedisClient::getVidsForRids returns all SAI_NULL_OBJECT_ID.
+     * translateRidsToVids must still resolve RIDs that were registered with
+     * insertRidsAndVids (in-memory map), without allocating replacement VIDs.
+     *
+     * ASIC_DB is for RedisVidIndexGenerator only; translator uses DisabledRedisClient.
+     */
+    profileMap["SAI_VS_SWITCH_TYPE"] = "SAI_VS_SWITCH_TYPE_BCM56850";
+
+    auto dbAsic = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+    auto client = std::make_shared<DisabledRedisClient>();
+    auto sai = std::make_shared<saivs::Sai>();
+
+    ServiceMethodTable smt;
+    smt.profileGetValue = std::bind(&profileGetValue, _1, _2);
+    smt.profileGetNextValue = std::bind(&profileGetNextValue, _1, _2, _3);
+    sai_service_method_table_t test_services = smt.getServiceMethodTable();
+
+    sai_status_t status = sai->apiInitialize(0, &test_services);
+    EXPECT_EQ(status, SAI_STATUS_SUCCESS);
+
+    auto switchConfigContainer = std::make_shared<sairedis::SwitchConfigContainer>();
+    auto redisVidIndexGenerator = std::make_shared<sairedis::RedisVidIndexGenerator>(dbAsic, REDIS_KEY_VIDCOUNTER);
+    auto virtualObjectIdManager = std::make_shared<sairedis::VirtualObjectIdManager>(
+            0,
+            switchConfigContainer,
+            redisVidIndexGenerator);
+
+    VirtualOidTranslator vot(client, virtualObjectIdManager, sai);
+
+    const sai_object_id_t switchVid = 0x21000000000000ULL;
+    const sai_object_id_t rid0 = 0x1100000022ULL;
+    const sai_object_id_t rid1 = 0x2200000022ULL;
+    const sai_object_id_t vid0 = 0x2100000000000001ULL;
+    const sai_object_id_t vid1 = 0x2100000000000002ULL;
+
+    std::vector<sai_object_id_t> rids = {rid0, rid1};
+    std::vector<sai_object_id_t> insertVids = {vid0, vid1};
+
+    vot.insertRidsAndVids(rids.size(), rids.data(), insertVids.data());
+
+    std::vector<sai_object_id_t> probe(2);
+    client->getVidsForRids(rids.size(), rids.data(), probe.data());
+    EXPECT_EQ(probe[0], SAI_NULL_OBJECT_ID);
+    EXPECT_EQ(probe[1], SAI_NULL_OBJECT_ID);
+
+    std::vector<sai_object_id_t> outVids = {SAI_NULL_OBJECT_ID, SAI_NULL_OBJECT_ID};
+    vot.translateRidsToVids(switchVid, rids.size(), rids.data(), outVids.data());
+
+    EXPECT_EQ(outVids[0], vid0);
+    EXPECT_EQ(outVids[1], vid1);
+
+    sai_object_id_t singleRid = rid0;
+    sai_object_id_t singleVid = SAI_NULL_OBJECT_ID;
+    vot.translateRidsToVids(switchVid, 1, &singleRid, &singleVid);
+    EXPECT_EQ(singleVid, vid0);
 
     sai->apiUninitialize();
 }


### PR DESCRIPTION
Fixes the issue reported in https://github.com/sonic-net/sonic-buildimage/issues/26757 (break out ports are not coming up when south bound ZMQ is enabled)

In the current code when the ZMQ is enabled, VID2RID and RID2VID tables are not created in ASIC_DB.
When the breakout ports are created, orchagent bulks them and sairedis creates the Vids for all ports in the bulk (processBulkOidCreate), calls the SAI vendor API to create the port in SAI/ASIC and then updates the m_rid2vid & m_vid2rid maps.
In the same bulk process processBulkOidCreate->onPostPortsCreate (Added as part of https://github.com/sonic-net/sonic-sairedis/pull/1559), it discovers all the new RIDs, creates new VIDs again for these VIDs (please note getVidsForRids called from translateRidsToVids returns SAI_NULL_OBJECT_ID when ZMQ is enabled and it does not check the m_rid2vid map) and updates the m_rid2vid & m_vid2rid maps. However, the first VID added in the map (created in processBulkOidCreate)  is the one passed to orchagent . So Northbound API calls are working. However, when the south bound notifications are received from SAI (ex: port state change notification), the RID to VID mapping fails due to the bug in translateRidToVid (added as part of https://github.com/sonic-net/sonic-sairedis/pull/727) and also the VID creation twice in onPostPortsCreate.
This PR addresses these 2 issues and the RID to VID and also VID to RID translations are happening correctly now and the ports are coming up.