### PR TITLE
Ignore SAI_VPP_ERR_VALUE_EXIST from sw_interface_ip6_enable_disable

### DIFF
--- a/vslib/vpp/SwitchVppHostif.cpp
+++ b/vslib/vpp/SwitchVppHostif.cpp
@@ -382,11 +382,14 @@ sai_status_t SwitchVpp::vs_create_hostif_tap_interface(
     // enable ipv6, which will set link local address based on mac. ipv4 can be enabled
     // when ip is configured.
     err = sw_interface_ip6_enable_disable(hwif_name, true);
-    if (err < 0)
+    if (err == SAI_VPP_ERR_VALUE_EXIST)
     {
-        SWSS_LOG_ERROR("failed to enable ipv6 for %s", hwif_name);
-        close(tapfd);
-        return SAI_STATUS_FAILURE;
+        // IPv6 already enabled by LCP netlink sync
+        SWSS_LOG_INFO("ipv6 already enabled for %s, skipping", hwif_name);
+    }
+    else if (err < 0)
+    {
+        SWSS_LOG_ERROR("failed to enable ipv6 for %s (err=%d), continuing", hwif_name, err);
     }
 
     setIfNameToPortId(name, obj_id);

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -641,7 +641,7 @@ vl_api_want_interface_events_reply_t_handler (vl_api_want_interface_events_reply
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sw interface events enable failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sw interface events enable failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sw interface events enable successful"); }
 }
 
@@ -752,7 +752,7 @@ vl_api_create_subif_reply_t_handler (vl_api_create_subif_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("subinterface creation failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("subinterface creation failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("subinterface creation successful"); }
 }
 
@@ -762,7 +762,7 @@ vl_api_delete_subif_reply_t_handler (vl_api_delete_subif_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("subinterface deletion failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("subinterface deletion failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("subinterface deletion successful"); }
 }
 
@@ -772,7 +772,7 @@ vl_api_sw_interface_set_table_reply_t_handler (vl_api_sw_interface_set_table_rep
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sw interface vrf set failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sw interface vrf set failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sw interface vrf set successful"); }
 }
 
@@ -782,7 +782,7 @@ vl_api_sw_interface_add_del_address_reply_t_handler (vl_api_sw_interface_add_del
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sw interface address add/del failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sw interface address add/del failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sw interface address add/del successful"); }
 }
 
@@ -792,7 +792,7 @@ vl_api_sw_interface_set_flags_reply_t_handler (vl_api_sw_interface_set_flags_rep
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sw interface state set failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sw interface state set failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sw interface state set successful"); }
 }
 
@@ -802,7 +802,7 @@ vl_api_sw_interface_set_mtu_reply_t_handler (vl_api_sw_interface_set_mtu_reply_t
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sw interface mtu set failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sw interface mtu set failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sw interface mtu set successful"); }
 }
 static void
@@ -811,7 +811,7 @@ vl_api_sw_interface_set_mac_address_reply_t_handler (vl_api_sw_interface_set_mac
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sw interface mac set failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sw interface mac set failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sw interface mac set successful"); }
 }
 static void
@@ -820,7 +820,7 @@ vl_api_hw_interface_set_mtu_reply_t_handler (vl_api_hw_interface_set_mtu_reply_t
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("hw interface mtu set failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("hw interface mtu set failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("hw interface mtu set successful"); }
 }
 
@@ -830,7 +830,7 @@ vl_api_ip_table_add_del_reply_t_handler (vl_api_ip_table_add_del_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("ip vrf add failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("ip vrf add failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("ip vrf add successful"); }
 }
 
@@ -840,7 +840,7 @@ vl_api_ip_route_add_del_reply_t_handler (vl_api_ip_route_add_del_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("ip route add failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("ip route add failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("ip route add successful"); }
 }
 
@@ -851,7 +851,7 @@ vl_api_sw_interface_ip6_enable_disable_reply_t_handler(
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("ip6 enable/disable failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("ip6 enable/disable failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("ip6 enable/disable successful"); }
 }
 
@@ -861,7 +861,7 @@ vl_api_set_ip_flow_hash_v2_reply_t_handler (vl_api_ip_route_add_del_reply_t *msg
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("ip flow has set failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("ip flow has set failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("ip flow has set successful"); }
 }
 
@@ -871,7 +871,7 @@ vl_api_ip_neighbor_add_del_reply_t_handler (vl_api_ip_neighbor_add_del_reply_t *
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("ip neighbor add/del failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("ip neighbor add/del failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("ip neighbor add/del successful"); }
 }
 
@@ -881,7 +881,7 @@ vl_api_bridge_domain_add_del_reply_t_handler (vl_api_bridge_domain_add_del_reply
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bridge_domain_add_del add/del failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bridge_domain_add_del add/del failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bridge_domain_add_del add/del successful"); }
 
 }
@@ -891,7 +891,7 @@ vl_api_sw_interface_set_l2_bridge_reply_t_handler (vl_api_sw_interface_set_l2_br
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sw inteface set l2 bridge reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sw inteface set l2 bridge reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sw inteface set l2 bridge reply handler successful"); }
 
 }
@@ -901,7 +901,7 @@ vl_api_l2_interface_vlan_tag_rewrite_reply_t_handler (vl_api_l2_interface_vlan_t
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("l2 interface vlan tag rewrite reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("l2 interface vlan tag rewrite reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("l2 interface vlan tag rewrite reply handler successful"); }
 
 }
@@ -911,7 +911,7 @@ vl_api_bvi_create_reply_t_handler (vl_api_bvi_create_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bvi create reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bvi create reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bvi create reply handler successful"); }
 }
 
@@ -921,7 +921,7 @@ vl_api_bvi_delete_reply_t_handler (vl_api_bvi_delete_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bvi delete reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bvi delete reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bvi delete reply handler successful"); }
 }
 
@@ -931,7 +931,7 @@ vl_api_bridge_flags_reply_t_handler (vl_api_bridge_flags_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bridge flags reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bridge flags reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bridge flags reply handler successful"); }
 }
 
@@ -941,7 +941,7 @@ vl_api_l2fib_add_del_reply_t_handler (vl_api_l2fib_add_del_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("l2fib add del reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("l2fib add del reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("l2fib add del reply handler successful"); }
 
 }
@@ -951,7 +951,7 @@ vl_api_l2fib_flush_all_reply_t_handler (vl_api_l2fib_flush_all_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("l2fib flush all reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("l2fib flush all reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("l2fib flush all reply handler successful"); }
 
 }
@@ -961,7 +961,7 @@ vl_api_l2fib_flush_int_reply_t_handler (vl_api_l2fib_flush_int_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("l2fib flush int reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("l2fib flush int reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("l2fib flush int reply handler successful"); }
 
 }
@@ -972,7 +972,7 @@ vl_api_l2fib_flush_bd_reply_t_handler (vl_api_l2fib_flush_bd_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("l2fib flush bd reply handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("l2fib flush bd reply handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("l2fib flush bd reply handler successful"); }
 }
 
@@ -982,7 +982,7 @@ vl_api_bfd_udp_add_reply_t_handler (vl_api_bfd_udp_add_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bfd udp add reply handler  failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bfd udp add reply handler  failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bfd udp add reply handler  successful"); }
 
 }
@@ -993,7 +993,7 @@ vl_api_bfd_udp_del_reply_t_handler (vl_api_bfd_udp_del_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bfd udp del reply handler  failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bfd udp del reply handler  failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bfd udp del reply handler  successful"); }
 
 }
@@ -1004,7 +1004,7 @@ vl_api_want_bfd_events_reply_t_handler (vl_api_want_bfd_events_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bfd events enable failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bfd events enable failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bfd events enable successful"); }
 }
 
@@ -1014,7 +1014,7 @@ vl_api_bfd_udp_enable_multihop_reply_t_handler (vl_api_bfd_udp_enable_multihop_r
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bfd enable multihop failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bfd enable multihop failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bfd enable multihop successful"); }
 }
 
@@ -1078,7 +1078,7 @@ vl_api_vxlan_add_del_tunnel_v3_reply_t_handler (
 
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
-    if (retval) { SAIVPP_ERROR("vxlan_add_del handler failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("vxlan_add_del handler failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("vxlan_add_del handler successful: if_idx,%d", ntohl(msg->sw_if_index)); }
 }
 
@@ -1091,7 +1091,7 @@ vl_api_tunterm_acl_add_replace_reply_t_handler(vl_api_tunterm_acl_add_replace_re
     uint32_t *tunterm_index = (uint32_t *) get_index_ptr(msg->context);
     *tunterm_index = ntohl(msg->tunterm_acl_index);
 
-    if (retval) { SAIVPP_ERROR("tunterm acl add_replace failed(%d) tunterm_index index %u", retval, *tunterm_index); }
+    if (retval) { SAIVPP_ERROR("tunterm acl add_replace failed(%d:%s) tunterm_index index %u", retval, sai_vpp_err_to_string(retval), *tunterm_index); }
     else { SAIVPP_INFO("tunterm acl add_replace successful tunterm_index index %u", *tunterm_index); }
     release_index(msg->context);
 }
@@ -1102,7 +1102,7 @@ vl_api_tunterm_acl_del_reply_t_handler(vl_api_tunterm_acl_del_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("tunterm acl del failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("tunterm acl del failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("tunterm acl del successful"); }
 }
 
@@ -1112,7 +1112,7 @@ vl_api_tunterm_acl_interface_add_del_reply_t_handler(vl_api_tunterm_acl_interfac
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("tunterm acl interface set/reset failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("tunterm acl interface set/reset failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("tunterm acl interface set/reset successful"); }
 }
 
@@ -1127,7 +1127,7 @@ vl_api_bond_create_reply_t_handler (vl_api_bond_create_reply_t *msg)
       *swif_idx = ntohl(msg->sw_if_index);
     }
 
-    if (retval) { SAIVPP_ERROR("bond add failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bond add failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else
     {
         uint32_t bond_if_index =  ntohl(msg->sw_if_index);
@@ -1142,7 +1142,7 @@ vl_api_bond_delete_reply_t_handler (vl_api_bond_delete_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bond delete failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bond delete failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bond delete successful"); }
 }
 
@@ -1152,7 +1152,7 @@ vl_api_bond_add_member_reply_t_handler (vl_api_bond_add_member_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bond add member failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bond add member failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bond add member successful"); }
 }
 
@@ -1162,7 +1162,7 @@ vl_api_bond_detach_member_reply_t_handler (vl_api_bond_detach_member_reply_t *ms
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("bond detach member failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("bond detach member failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("bond detach member successful"); }
 }
 
@@ -1172,7 +1172,7 @@ vl_api_sr_localsid_add_del_reply_t_handler(vl_api_sr_localsid_add_del_reply_t *m
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sr local sid add/del failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sr local sid add/del failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sr local sid add/del successful"); }
 }
 
@@ -1182,7 +1182,7 @@ vl_api_sr_policy_add_v2_reply_t_handler(vl_api_sr_policy_add_v2_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sr policy add failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sr policy add failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sr policy add successful"); }
 }
 
@@ -1192,7 +1192,7 @@ vl_api_sr_policy_del_reply_t_handler(vl_api_sr_policy_del_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sr policy del failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sr policy del failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sr policy del successful"); }
 }
 
@@ -1202,7 +1202,7 @@ vl_api_sr_steering_add_del_reply_t_handler(vl_api_sr_steering_add_del_reply_t *m
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sr steer add/del failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sr steer add/del failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sr steer add/del successful"); }
 }
 
@@ -1212,7 +1212,7 @@ vl_api_sr_set_encap_source_reply_t_handler(vl_api_sr_set_encap_source_reply_t *m
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("sr set encap source failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("sr set encap source failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("sr set encap source successful"); }
 }
 
@@ -1333,7 +1333,7 @@ static void vl_api_lcp_itf_pair_add_del_reply_t_handler(vl_api_lcp_itf_pair_add_
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("linux_cp hostif creation failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("linux_cp hostif creation failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("linux_cp hostif creation successful"); }
 }
 
@@ -1342,7 +1342,7 @@ static void vl_api_lcp_ethertype_enable_reply_t_handler(vl_api_lcp_ethertype_ena
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("linux_cp ethertype enabled failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("linux_cp ethertype enabled failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("linux_cp ethertype enabled successful"); }
 }
 
@@ -1354,7 +1354,7 @@ static void vl_api_acl_add_replace_reply_t_handler(vl_api_acl_add_replace_reply_
     uint32_t *acl_index = (uint32_t *) get_index_ptr(msg->context);
     *acl_index = ntohl(msg->acl_index);
 
-    if (retval) { SAIVPP_ERROR("acl add_replace failed(%d) acl index %u", retval, *acl_index); }
+    if (retval) { SAIVPP_ERROR("acl add_replace failed(%d:%s) acl index %u", retval, sai_vpp_err_to_string(retval), *acl_index); }
     else { SAIVPP_INFO("acl add_replace successful acl index %u", *acl_index); }
     release_index(msg->context);
 }
@@ -1364,7 +1364,7 @@ static void vl_api_acl_del_reply_t_handler(vl_api_acl_del_reply_t *msg)
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("acl del failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("acl del failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("acl del successful"); }
 }
 
@@ -1374,7 +1374,7 @@ vl_api_acl_stats_intf_counters_enable_reply_t_handler (vl_api_acl_stats_intf_cou
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("acl counters enable failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("acl counters enable failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("acl counters enable successful"); }
 }
 
@@ -1384,7 +1384,7 @@ vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 
-    if (retval) { SAIVPP_ERROR("acl interface set/reset failed(%d)", retval); }
+    if (retval) { SAIVPP_ERROR("acl interface set/reset failed(%d:%s)", retval, sai_vpp_err_to_string(retval)); }
     else { SAIVPP_INFO("acl interface set/reset successful"); }
 }
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -26,6 +26,18 @@
 #include <vppinfra/error.h>
 
 #include "SaiVppXlate.h"
+#include <vnet/api_errno.h>
+
+/*
+ * Compile-time checks: ensure every SAI_VPP_ERR_ constant in SaiVppXlate.h
+ * matches the corresponding VNET_API_ERROR_* value from vnet/api_errno.h.
+ * If VPP renumbers an error code, the build will fail here.
+ */
+#define _(a, b) \
+    _Static_assert(SAI_VPP_ERR_##a == VNET_API_ERROR_##a, \
+                   "SAI_VPP_ERR_" #a " mismatch with VPP");
+foreach_sai_vpp_error
+#undef _
 
 #include <vnet/ip/ip_types_api.h>
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -22,6 +22,173 @@ extern "C" {
 
 #include <netinet/in.h>
 
+/*
+ * VPP API error codes mirrored from vnet/error.h.
+ * Use SAI_VPP_ERR_ prefix to avoid collision with the VPP enum names.
+ * Verified at compile time via _Static_assert in SaiVppXlate.c.
+ *
+ * Keep in sync with foreach_vnet_error in vnet/error.h.
+ */
+#define foreach_sai_vpp_error                                                  \
+  _(UNSPECIFIED, -1)                                                           \
+  _(INVALID_SW_IF_INDEX, -2)                                                   \
+  _(NO_SUCH_FIB, -3)                                                           \
+  _(NO_SUCH_INNER_FIB, -4)                                                     \
+  _(NO_SUCH_LABEL, -5)                                                         \
+  _(NO_SUCH_ENTRY, -6)                                                         \
+  _(INVALID_VALUE, -7)                                                         \
+  _(INVALID_VALUE_2, -8)                                                       \
+  _(UNIMPLEMENTED, -9)                                                         \
+  _(INVALID_SW_IF_INDEX_2, -10)                                                \
+  _(SYSCALL_ERROR_1, -11)                                                      \
+  _(SYSCALL_ERROR_2, -12)                                                      \
+  _(SYSCALL_ERROR_3, -13)                                                      \
+  _(SYSCALL_ERROR_4, -14)                                                      \
+  _(SYSCALL_ERROR_5, -15)                                                      \
+  _(SYSCALL_ERROR_6, -16)                                                      \
+  _(SYSCALL_ERROR_7, -17)                                                      \
+  _(SYSCALL_ERROR_8, -18)                                                      \
+  _(SYSCALL_ERROR_9, -19)                                                      \
+  _(SYSCALL_ERROR_10, -20)                                                     \
+  _(FEATURE_DISABLED, -30)                                                     \
+  _(INVALID_REGISTRATION, -31)                                                 \
+  _(NEXT_HOP_NOT_IN_FIB, -50)                                                  \
+  _(UNKNOWN_DESTINATION, -51)                                                  \
+  _(NO_PATHS_IN_ROUTE, -52)                                                    \
+  _(NEXT_HOP_NOT_FOUND_MP, -53)                                                \
+  _(NO_MATCHING_INTERFACE, -54)                                                \
+  _(INVALID_VLAN, -55)                                                         \
+  _(VLAN_ALREADY_EXISTS, -56)                                                  \
+  _(INVALID_SRC_ADDRESS, -57)                                                  \
+  _(INVALID_DST_ADDRESS, -58)                                                  \
+  _(ADDRESS_LENGTH_MISMATCH, -59)                                              \
+  _(ADDRESS_NOT_FOUND_FOR_INTERFACE, -60)                                      \
+  _(ADDRESS_NOT_DELETABLE, -61)                                                \
+  _(IP6_NOT_ENABLED, -62)                                                      \
+  _(NO_SUCH_NODE, -63)                                                         \
+  _(NO_SUCH_NODE2, -64)                                                        \
+  _(NO_SUCH_TABLE, -65)                                                        \
+  _(NO_SUCH_TABLE2, -66)                                                       \
+  _(NO_SUCH_TABLE3, -67)                                                       \
+  _(SUBIF_ALREADY_EXISTS, -68)                                                 \
+  _(SUBIF_CREATE_FAILED, -69)                                                  \
+  _(INVALID_MEMORY_SIZE, -70)                                                  \
+  _(INVALID_INTERFACE, -71)                                                    \
+  _(INVALID_VLAN_TAG_COUNT, -72)                                               \
+  _(INVALID_ARGUMENT, -73)                                                     \
+  _(UNEXPECTED_INTF_STATE, -74)                                                \
+  _(TUNNEL_EXIST, -75)                                                         \
+  _(INVALID_DECAP_NEXT, -76)                                                   \
+  _(RESPONSE_NOT_READY, -77)                                                   \
+  _(NOT_CONNECTED, -78)                                                        \
+  _(IF_ALREADY_EXISTS, -79)                                                    \
+  _(BOND_SLAVE_NOT_ALLOWED, -80)                                               \
+  _(VALUE_EXIST, -81)                                                          \
+  _(SAME_SRC_DST, -82)                                                        \
+  _(IP6_MULTICAST_ADDRESS_NOT_PRESENT, -83)                                    \
+  _(SR_POLICY_NAME_NOT_PRESENT, -84)                                           \
+  _(NOT_RUNNING_AS_ROOT, -85)                                                  \
+  _(ALREADY_CONNECTED, -86)                                                    \
+  _(UNSUPPORTED_JNI_VERSION, -87)                                              \
+  _(IP_PREFIX_INVALID, -88)                                                    \
+  _(INVALID_WORKER, -89)                                                       \
+  _(LISP_DISABLED, -90)                                                        \
+  _(CLASSIFY_TABLE_NOT_FOUND, -91)                                             \
+  _(INVALID_EID_TYPE, -92)                                                     \
+  _(CANNOT_CREATE_PCAP_FILE, -93)                                              \
+  _(INCORRECT_ADJACENCY_TYPE, -94)                                             \
+  _(EXCEEDED_NUMBER_OF_RANGES_CAPACITY, -95)                                   \
+  _(EXCEEDED_NUMBER_OF_PORTS_CAPACITY, -96)                                    \
+  _(INVALID_ADDRESS_FAMILY, -97)                                               \
+  _(INVALID_SUB_SW_IF_INDEX, -98)                                              \
+  _(TABLE_TOO_BIG, -99)                                                        \
+  _(CANNOT_ENABLE_DISABLE_FEATURE, -100)                                       \
+  _(BFD_EEXIST, -101)                                                          \
+  _(BFD_ENOENT, -102)                                                          \
+  _(BFD_EINUSE, -103)                                                          \
+  _(BFD_NOTSUPP, -104)                                                         \
+  _(ADDRESS_IN_USE, -105)                                                      \
+  _(ADDRESS_NOT_IN_USE, -106)                                                  \
+  _(QUEUE_FULL, -107)                                                          \
+  _(APP_UNSUPPORTED_CFG, -108)                                                 \
+  _(URI_FIFO_CREATE_FAILED, -109)                                              \
+  _(LISP_RLOC_LOCAL, -110)                                                     \
+  _(BFD_EAGAIN, -111)                                                          \
+  _(INVALID_GPE_MODE, -112)                                                    \
+  _(LISP_GPE_ENTRIES_PRESENT, -113)                                            \
+  _(ADDRESS_FOUND_FOR_INTERFACE, -114)                                         \
+  _(SESSION_CONNECT, -115)                                                     \
+  _(ENTRY_ALREADY_EXISTS, -116)                                                \
+  _(SVM_SEGMENT_CREATE_FAIL, -117)                                             \
+  _(APPLICATION_NOT_ATTACHED, -118)                                            \
+  _(BD_ALREADY_EXISTS, -119)                                                   \
+  _(BD_IN_USE, -120)                                                           \
+  _(BD_NOT_MODIFIABLE, -121)                                                   \
+  _(BD_ID_EXCEED_MAX, -122)                                                    \
+  _(SUBIF_DOESNT_EXIST, -123)                                                  \
+  _(L2_MACS_EVENT_CLINET_PRESENT, -124)                                        \
+  _(INVALID_QUEUE, -125)                                                       \
+  _(UNSUPPORTED, -126)                                                         \
+  _(DUPLICATE_IF_ADDRESS, -127)                                                \
+  _(APP_INVALID_NS, -128)                                                      \
+  _(APP_WRONG_NS_SECRET, -129)                                                 \
+  _(APP_CONNECT_SCOPE, -130)                                                   \
+  _(APP_ALREADY_ATTACHED, -131)                                                \
+  _(SESSION_REDIRECT, -132)                                                    \
+  _(ILLEGAL_NAME, -133)                                                        \
+  _(NO_NAME_SERVERS, -134)                                                     \
+  _(NAME_SERVER_NOT_FOUND, -135)                                               \
+  _(NAME_RESOLUTION_NOT_ENABLED, -136)                                         \
+  _(NAME_SERVER_FORMAT_ERROR, -137)                                            \
+  _(NAME_SERVER_NO_SUCH_NAME, -138)                                            \
+  _(NAME_SERVER_NO_ADDRESSES, -139)                                            \
+  _(NAME_SERVER_NEXT_SERVER, -140)                                             \
+  _(APP_CONNECT_FILTERED, -141)                                                \
+  _(ACL_IN_USE_INBOUND, -142)                                                  \
+  _(ACL_IN_USE_OUTBOUND, -143)                                                 \
+  _(INIT_FAILED, -144)                                                         \
+  _(NETLINK_ERROR, -145)                                                       \
+  _(BIER_BSL_UNSUP, -146)                                                      \
+  _(INSTANCE_IN_USE, -147)                                                     \
+  _(INVALID_SESSION_ID, -148)                                                  \
+  _(ACL_IN_USE_BY_LOOKUP_CONTEXT, -149)                                        \
+  _(INVALID_VALUE_3, -150)                                                     \
+  _(NON_ETHERNET, -151)                                                        \
+  _(BD_ALREADY_HAS_BVI, -152)                                                  \
+  _(INVALID_PROTOCOL, -153)                                                    \
+  _(INVALID_ALGORITHM, -154)                                                   \
+  _(RSRC_IN_USE, -155)                                                         \
+  _(KEY_LENGTH, -156)                                                          \
+  _(FIB_PATH_UNSUPPORTED_NH_PROTO, -157)                                       \
+  _(API_ENDIAN_FAILED, -159)                                                   \
+  _(NO_CHANGE, -160)                                                           \
+  _(MISSING_CERT_KEY, -161)                                                    \
+  _(LIMIT_EXCEEDED, -162)                                                      \
+  _(IKE_NO_PORT, -163)                                                         \
+  _(UDP_PORT_TAKEN, -164)                                                      \
+  _(EAGAIN, -165)                                                              \
+  _(INVALID_VALUE_4, -166)                                                     \
+  _(BUSY, -167)                                                                \
+  _(BUG, -168)                                                                 \
+  _(FEATURE_ALREADY_DISABLED, -169)                                            \
+  _(FEATURE_ALREADY_ENABLED, -170)                                             \
+  _(INVALID_PREFIX_LENGTH, -171)
+
+/* Generate SAI_VPP_ERR_<NAME> defines */
+#define _(a, b) static const int SAI_VPP_ERR_##a = (b);
+foreach_sai_vpp_error
+#undef _
+
+    static inline const char *sai_vpp_err_to_string(int err)
+    {
+        switch (err) {
+#define _(a, b) case (b): return #a;
+        foreach_sai_vpp_error
+#undef _
+        default: return "UNKNOWN";
+        }
+    }
+
     typedef enum {
 	VPP_NEXTHOP_NORMAL = 1,
 	VPP_NEXTHOP_LOCAL = 2


### PR DESCRIPTION
### why
sw_interface_ip6_enable_disable returns SAI_VPP_ERR_VALUE_EXIST if ipv6 already enabled on the interface. This could happen in a race condition when SONIC sets ipv6 address in TAP, for example Ethernet1. linux-cp plugin receives the netlink event and enables ipv6 on the PHY interface.

### what this PR does
1. Ignore SAI_VPP_ERR_VALUE_EXIST error from sw_interface_ip6_enable_disable
2. Define SAI_VPP_ERR_ code to match the errors defined in vnet/api_error.h