### PR TITLE
Convert SNR raw value to dB as per SAI definition

### DIFF
--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <climits>
 #include <algorithm>
+#include <cmath>
 #include <unordered_map>
 
 #include <arpa/inet.h>
@@ -1820,11 +1821,13 @@ std::string sai_serialize_port_snr_list(
         return j.dump();
     }
 
-    // Create dictionary format: {"0": 3712, "1": 3840, ...}
+    // Convert raw U16 SNR (in 1/256 dB units) to dB value per SAI definition
+    // e.g., raw value 5248 represents 5248/256 = 20.5 dB (Single decimal precision)
     for (uint32_t i = 0; i < snr_list.count; ++i)
     {
         std::string lane_key = std::to_string(snr_list.list[i].lane);
-        j[lane_key] = snr_list.list[i].snr;
+        double dB = static_cast<double>(snr_list.list[i].snr) / 256.0;
+        j[lane_key] = std::round(dB * 10.0) / 10.0;
     }
 
     return j.dump();
@@ -4670,14 +4673,15 @@ void sai_deserialize_port_snr_list(
         uint32_t idx = 0;
         for (auto it = j.begin(); it != j.end(); ++it, ++idx)
         {
-            if (!it.value().is_number_unsigned())
+            if (!it.value().is_number())
             {
                 SWSS_LOG_ERROR("Invalid SNR value type for lane %s", it.key().c_str());
                 continue;
             }
 
+            // Convert dB value back to raw U16 (in 1/256 dB units) per SAI definition
             snr_list.list[idx].lane = static_cast<uint32_t>(std::stoul(it.key()));
-            snr_list.list[idx].snr = it.value().get<sai_uint16_t>();
+            snr_list.list[idx].snr = static_cast<sai_uint16_t>(std::round(it.value().get<double>() * 256.0));
         }
     }
     catch (const json::parse_error& e)

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -1822,12 +1822,12 @@ std::string sai_serialize_port_snr_list(
     }
 
     // Convert raw U16 SNR (in 1/256 dB units) to dB value per SAI definition
-    // e.g., raw value 5248 represents 5248/256 = 20.5 dB (Single decimal precision)
+    // e.g., raw value 5248 represents 5248/256 = 20.50 dB (Two decimal precision)
     for (uint32_t i = 0; i < snr_list.count; ++i)
     {
         std::string lane_key = std::to_string(snr_list.list[i].lane);
         double dB = static_cast<double>(snr_list.list[i].snr) / 256.0;
-        j[lane_key] = std::round(dB * 10.0) / 10.0;
+        j[lane_key] = std::round(dB * 100.0) / 100.0;
     }
 
     return j.dump();

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -192,7 +192,7 @@ TEST(SaiSerialize, sai_serialize_port_snr_list)
 
             auto s = sai_serialize_attr_value(*meta, attr, false);
 
-            std::string expected = "{\"0\":14.5,\"1\":15.0,\"2\":16.3}";
+            std::string expected = "{\"0\":14.5,\"1\":15.0,\"2\":16.25}";
             EXPECT_EQ(s, expected);
 
         }
@@ -201,7 +201,7 @@ TEST(SaiSerialize, sai_serialize_port_snr_list)
 
 TEST(SaiSerialize, sai_deserialize_port_snr_list)
 {
-    std::string json_str = R"({"0":14.5,"1":15.8})";
+    std::string json_str = R"({"0":14.5,"1":15.75})";
 
     sai_port_snr_list_t snr_list;
     memset(&snr_list, 0, sizeof(snr_list));
@@ -215,7 +215,7 @@ TEST(SaiSerialize, sai_deserialize_port_snr_list)
     EXPECT_EQ(snr_list.list[0].snr, 3712);
 
     EXPECT_EQ(snr_list.list[1].lane, 1);
-    EXPECT_EQ(snr_list.list[1].snr, 4045);
+    EXPECT_EQ(snr_list.list[1].snr, 4032);
 
     delete[] snr_list.list;
 

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -192,7 +192,7 @@ TEST(SaiSerialize, sai_serialize_port_snr_list)
 
             auto s = sai_serialize_attr_value(*meta, attr, false);
 
-            std::string expected = "{\"0\":3712,\"1\":3840,\"2\":4160}";
+            std::string expected = "{\"0\":14.5,\"1\":15.0,\"2\":16.3}";
             EXPECT_EQ(s, expected);
 
         }
@@ -201,7 +201,7 @@ TEST(SaiSerialize, sai_serialize_port_snr_list)
 
 TEST(SaiSerialize, sai_deserialize_port_snr_list)
 {
-    std::string json_str = R"({"0":3712,"1":4032})";
+    std::string json_str = R"({"0":14.5,"1":15.8})";
 
     sai_port_snr_list_t snr_list;
     memset(&snr_list, 0, sizeof(snr_list));
@@ -215,7 +215,7 @@ TEST(SaiSerialize, sai_deserialize_port_snr_list)
     EXPECT_EQ(snr_list.list[0].snr, 3712);
 
     EXPECT_EQ(snr_list.list[1].lane, 1);
-    EXPECT_EQ(snr_list.list[1].snr, 4032);
+    EXPECT_EQ(snr_list.list[1].snr, 4045);
 
     delete[] snr_list.list;
 

--- a/unittest/syncd/TestPortPhyAttr.cpp
+++ b/unittest/syncd/TestPortPhyAttr.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <gtest/gtest.h>
 #include <memory>
+#include <cmath>
 
 using namespace saimeta;
 using namespace sairedis;
@@ -247,16 +248,17 @@ TEST_F(TestPortPhyAttr, CollectDataAndValidateCountersDB)
 
     std::cout << "Actual rx_snr value: " << rxSnrValue << std::endl;
 
-    // Lane key is string, SNR value is number (no quotes around value)
-    // Validate all lanes (0-7) with SNR values: 145, 150, 155, 160, 165, 170, 175, 180
+    // Lane key is string, SNR value is dB (raw_value / 256.0, rounded to 2 decimals)
+    // Validate all lanes (0-7) with raw SNR values: 145, 150, 155, 160, 165, 170, 175, 180
+    // Converted to dB: 0.57, 0.59, 0.61, 0.63, 0.64, 0.66, 0.68, 0.7
     for (uint32_t lane = 0; lane < MAX_LANES_PER_PORT; lane++) {
-        uint32_t expected_snr = 145 + (lane * 5);
+        uint32_t raw_snr = 145 + (lane * 5);
+        double dB = std::round(static_cast<double>(raw_snr) / 256.0 * 100.0) / 100.0;
         std::ostringstream expected_entry;
-        expected_entry << "\"" << lane << "\":" << expected_snr;
+        expected_entry << "\"" << lane << "\":" << dB;
 
         EXPECT_TRUE(rxSnrValue.find(expected_entry.str()) != std::string::npos)
-            << "Lane " << lane << " SNR should be " << expected_snr
-            << " in format \"" << lane << "\":" << expected_snr
+            << "Lane " << lane << " SNR should be " << dB << " dB (raw " << raw_snr << ")"
             << "\nActual full value: " << rxSnrValue
             << "\nLooking for: " << expected_entry.str();
     }


### PR DESCRIPTION
Convert SNR raw value to dB as raw / 256.0 as per the `sai_port_snr_values_t` SAI definition

Both serialization and de-serialization is handled accordingly.