### PR TITLE
[meta]: Enable validation for SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1953,7 +1953,9 @@ void Meta::meta_generic_validation_post_remove(
                 }
                 break;
 
-                // case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+            case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+                // no object references to decrement for uint8 list
+                break;
 
                 // ACL ACTION
 
@@ -3620,7 +3622,12 @@ sai_status_t Meta::meta_generic_validation_create(
                     break;
                 }
 
-                // case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+            case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+                if (value.aclfield.enable)
+                {
+                    VALIDATION_LIST(md, value.aclfield.data.u8list);
+                }
+                break;
 
                 // ACL ACTION
 
@@ -4273,7 +4280,12 @@ sai_status_t Meta::meta_generic_validation_set(
                 break;
             }
 
-            // case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+        case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+            if (value.aclfield.enable)
+            {
+                VALIDATION_LIST(md, value.aclfield.data.u8list);
+            }
+            break;
 
             // ACL ACTION
 
@@ -4748,7 +4760,9 @@ sai_status_t Meta::meta_generic_validation_get(
                 VALIDATION_LIST(md, value.aclfield.data.objlist);
                 break;
 
-                // case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+            case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+                VALIDATION_LIST(md, value.aclfield.data.u8list);
+                break;
 
                 // ACL ACTION
 
@@ -5017,7 +5031,12 @@ void Meta::meta_generic_validation_post_get(
                     meta_generic_validation_post_get_objlist(meta_key, md, switch_id, value.aclfield.data.objlist.count, value.aclfield.data.objlist.list);
                 break;
 
-                // case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST: (2 lists)
+            case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+                if (value.aclfield.enable)
+                {
+                    VALIDATION_LIST_GET(md, value.aclfield.data.u8list);
+                }
+                break;
 
                 // ACL ACTION
 
@@ -5995,7 +6014,9 @@ void Meta::meta_generic_validation_post_create(
                 }
                 break;
 
-                // case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+            case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+                // no object references to increment for uint8 list
+                break;
 
                 // ACL ACTION
 
@@ -6222,7 +6243,9 @@ void Meta::meta_generic_validation_post_set(
                 break;
             }
 
-            // case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+        case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+            // no object references to handle for uint8 list
+            break;
 
             // ACL ACTION
 
@@ -7526,6 +7549,10 @@ void Meta::populate(
                         count = value.aclfield.data.objlist.count;
                         list = value.aclfield.data.objlist.list;
                     }
+                    break;
+
+                case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+                    // no object references in uint8 list
                     break;
 
                 case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -3622,6 +3622,7 @@ sai_status_t Meta::meta_generic_validation_create(
                     break;
                 }
 
+            // Used by UDF-backed ACL match fields (byte pattern + mask).
             case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
                 if (value.aclfield.enable)
                 {

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -2042,7 +2042,17 @@ std::string sai_serialize_acl_field(
             return sai_serialize_oid_list(field.data.objlist, countOnly);
 
         case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
-            return sai_serialize_number_list(field.data.u8list, countOnly) + "&mask:" + sai_serialize_number_list(field.mask.u8list, countOnly, true);
+            {
+                std::string result = sai_serialize_number_list(field.data.u8list, countOnly);
+
+                // Only serialize mask if it's properly initialized
+                if (field.mask.u8list.list != NULL && field.mask.u8list.count > 0)
+                {
+                    result += "&mask:" + sai_serialize_number_list(field.mask.u8list, countOnly, true);
+                }
+
+                return result;
+            }
 
         default:
             SWSS_LOG_THROW("sai attr value %s is not implemented, FIXME", sai_serialize_attr_value_type(meta.attrvaluetype).c_str());

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -2042,17 +2042,7 @@ std::string sai_serialize_acl_field(
             return sai_serialize_oid_list(field.data.objlist, countOnly);
 
         case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
-            {
-                std::string result = sai_serialize_number_list(field.data.u8list, countOnly);
-
-                // Only serialize mask if it's properly initialized
-                if (field.mask.u8list.list != NULL && field.mask.u8list.count > 0)
-                {
-                    result += "&mask:" + sai_serialize_number_list(field.mask.u8list, countOnly, true);
-                }
-
-                return result;
-            }
+            return sai_serialize_number_list(field.data.u8list, countOnly) + "&mask:" + sai_serialize_number_list(field.mask.u8list, countOnly, true);
 
         default:
             SWSS_LOG_THROW("sai attr value %s is not implemented, FIXME", sai_serialize_attr_value_type(meta.attrvaluetype).c_str());

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -100,6 +100,7 @@ TODO
 TPID
 TXSC
 TestCase
+UDF
 tokenize
 VID
 VIDCOUNTER

--- a/unittest/meta/TestLegacyOther.cpp
+++ b/unittest/meta/TestLegacyOther.cpp
@@ -1040,3 +1040,50 @@ TEST(Legacy, bulk_route_entry_create)
     std::cout << "ms: " << (double)us.count()/1000 << " / " << n << "/" << object_count << std::endl;
 }
 
+TEST(Legacy, acl_entry_udf_uint8_list_field)
+{
+    SWSS_LOG_ENTER();
+
+    clear_local();
+
+    sai_object_id_t switch_id = create_switch();
+    sai_object_id_t aclentry;
+    sai_object_id_t table_id = insert_dummy_object(SAI_OBJECT_TYPE_ACL_TABLE, switch_id);
+
+    uint8_t data[4] = {0x11, 0x22, 0x33, 0x44};
+    uint8_t mask[4] = {0xff, 0xff, 0xff, 0xff};
+
+    std::vector<sai_attribute_t> vattrs;
+
+    sai_attribute_t a_table;
+    memset(&a_table, 0, sizeof(a_table));
+    a_table.id = SAI_ACL_ENTRY_ATTR_TABLE_ID;
+    a_table.value.oid = table_id;
+    vattrs.push_back(a_table);
+
+    sai_attribute_t a_udf;
+    memset(&a_udf, 0, sizeof(a_udf));
+    a_udf.id = SAI_ACL_ENTRY_ATTR_USER_DEFINED_FIELD_GROUP_MIN;
+    a_udf.value.aclfield.enable = true;
+    a_udf.value.aclfield.data.u8list.count = 4;
+    a_udf.value.aclfield.data.u8list.list = data;
+    a_udf.value.aclfield.mask.u8list.count = 4;
+    a_udf.value.aclfield.mask.u8list.list = mask;
+    vattrs.push_back(a_udf);
+
+    auto status = g_meta->create(SAI_OBJECT_TYPE_ACL_ENTRY, &aclentry, switch_id,
+                                 (uint32_t)vattrs.size(), vattrs.data());
+    EXPECT_EQ(SAI_STATUS_SUCCESS, status);
+
+    status = g_meta->set(SAI_OBJECT_TYPE_ACL_ENTRY, aclentry, &a_udf);
+    EXPECT_EQ(SAI_STATUS_SUCCESS, status);
+
+    status = g_meta->get(SAI_OBJECT_TYPE_ACL_ENTRY, aclentry, 1, &a_udf);
+    EXPECT_EQ(SAI_STATUS_SUCCESS, status);
+
+    status = g_meta->remove(SAI_OBJECT_TYPE_ACL_ENTRY, aclentry);
+    EXPECT_EQ(SAI_STATUS_SUCCESS, status);
+
+    remove_switch(switch_id);
+}
+

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -1739,6 +1739,20 @@ TEST(Meta, populate)
     m.populate(dump);
 }
 
+TEST(Meta, populate_acl_entry_udf_uint8_list)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    swss::TableDump dump;
+
+    dump["SAI_OBJECT_TYPE_ACL_TABLE:oid:0x7000000000700"]["SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE"] = "true";
+    dump["SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x8000000000701"]["SAI_ACL_ENTRY_ATTR_TABLE_ID"] = "oid:0x7000000000700";
+    dump["SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x8000000000701"]["SAI_ACL_ENTRY_ATTR_USER_DEFINED_FIELD_GROUP_MIN"] =
+            "4:17,34,51,68&mask:4:0xff,0xff,0xff,0xff";
+
+    m.populate(dump);
+}
+
 TEST(Meta, bulkGetClearStats)
 {
     Meta m(std::make_shared<MetaTestSaiInterface>());


### PR DESCRIPTION
HLD: https://github.com/sonic-net/SONiC/pull/2299
#### Why I did it

`SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST` is the value type used for ACL fields backed by UDF (user-defined field) groups — the byte pattern and mask live in `aclfield.data.u8list`. In `meta/Meta.cpp` the validation cases for this type were commented out in all five paths (`create`, `set`, `get`, `post_get`, `post_remove`), so UDF ACL matches were being silently skipped by the meta layer.

This blocks the UDF feature being added to orchagent (companion PR: **sonic-net/sonic-swss#<[4493](https://github.com/sonic-net/sonic-swss/pull/4493)#>**) — without metadata validation, UDF ACL rules don't round-trip correctly through sairedis.

##### Work item tracking
- Microsoft ADO **(number only)**: _N/A_

#### How I did it

`meta/Meta.cpp` — uncommented and enabled the `SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST` case in:

- `meta_generic_validation_create` — `VALIDATION_LIST(md, value.aclfield.data.u8list)` when `aclfield.enable` is set.
- `meta_generic_validation_set` — same, for `SET` operations.
- `meta_generic_validation_get` — unconditional `VALIDATION_LIST` on `get`.
- `meta_generic_validation_post_get` — `VALIDATION_LIST_GET` when enabled.
- `meta_generic_validation_post_remove` — no-op (no object references to decrement for `u8list`), but the case is now present rather than falling through.

`meta/SaiSerialize.cpp` — added serialization support for the `u8list` field so it round-trips through the sairedis record/replay layer.

#### How to verify it

Build:
- sairedis builds cleanly (`make`).
- Existing `meta` unit tests pass (`make check` in `meta/` and `unittest/`).

Runtime (with the companion orchagent PR):
- Create a UDF group + UDF match via `config_db.json`; verify sairedis accepts the `CREATE` for an `ACL_ENTRY` referencing the UDF group as a match field (visible in `sairedis.rec`).
- Confirm `syncd` receives and applies the `ACL_ENTRY` attributes including the `u8list` byte pattern.
- Without this PR, the same flow silently drops the UDF match validation — any malformed `u8list` would reach syncd unchecked.

#### Which release branch to backport (provide reason below if selected)

_Not a backport — enables a new feature (UDF ACL matching)._

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] `master`

#### Description for the changelog

Enable meta validation for `SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST` (ACL fields with uint8 list values, used by UDF).
