### PR TITLE
vpp: Change NO_LINUX_NL default to y

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -440,7 +440,10 @@ namespace saivs
 
             std::map<sai_object_id_t, std::shared_ptr<IpVrfInfo>> vrf_objMap;
             bool nbr_env_read = false;
-            bool nbr_active = false;
+            // nbr_active is true by default, can be set to false by env var NO_LINUX_NL = n.
+            // If false, it will rely on linux_nl_plugin to sync ip to VPP.
+            // no neighbor entries will be added to vpp from SAI
+            bool nbr_active = true;
             std::map<std::string, std::string> m_intf_prefix_map;
             std::unordered_map<std::string, uint32_t> lpbInstMap;
             std::unordered_map<std::string, std::string> lpbIpToHostIfMap;

--- a/vslib/vpp/SwitchVppNbr.cpp
+++ b/vslib/vpp/SwitchVppNbr.cpp
@@ -140,8 +140,8 @@ bool SwitchVpp::is_ip_nbr_active()
         const char *val;
 
         val = getenv("NO_LINUX_NL");
-        if (val && (*val == 'y' || *val == 'Y')) {
-            nbr_active = true;
+        if (val && (*val == 'n' || *val == 'N')) {
+            nbr_active = false;
         }
         nbr_env_read = true;
     }


### PR DESCRIPTION
### why
sonic-vpp has been running with NO_LINUX_NL = y for a long time. This is the mode that has been tested. It relies on vpp-cfg-init script to set the env: https://github.com/sonic-net/sonic-platform-vpp/blob/4b1268df9bf31b8b3b7bca50a7365024baccd424/sonic-platform-modules-vpp/files/etc/config-setup/factory-default-hooks.d/10-01-vpp-cfg-init#L71-L73

The saivpp code has the default value equivalent to NO_LINUX_NL = n. This is not consistent with the default value we are using through above script.

For other platforms that are using vpp data plane, we should make the default value to y so unless it is needed, those platforms do not need to create /etc/sonic/vpp/syncd_vpp_env for setting this flag.

### what this PR does
change default value nbr_active to true, which is derived from  NO_LINUX_NL=y env. If the env is not set, it is default to y.
