### PR TITLE
vpp: handle unknown speed from vpp_get_interface_speed

### DIFF
--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -14,6 +14,7 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <endian.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -2711,6 +2712,11 @@ int vpp_get_interface_speed (const char *hwif_name, uint32_t *speed)
     }
 
     *speed = (uint32_t) p[0];
+
+    if (*speed == 0 || *speed == UINT32_MAX) {
+        VPP_UNLOCK();
+        return -ENOENT;
+    }
 
     VPP_UNLOCK();
 


### PR DESCRIPTION
### why
VPP's DPDK virtio driver reports link_speed = 0xFFFFFFFF when speed is unknown. vpp_get_interface_speed returned this raw value, and refresh_port_oper_speed divided it by 1000. This ends up interface speed showing as below.
```
show int status
     Interface            Lanes    Speed    MTU    FEC           Alias            Vlan    Oper    Admin    Type    Asym PFC
--------------  ---------------  -------  -----  -----  --------------  --------------  ------  -------  ------  ----------
     Ethernet0      25,26,27,28  4295.0G   9100    N/A    fortyGigE0/0  PortChannel102      up       up     N/A         off
     Ethernet4      29,30,31,32  4295.0G   9100    N/A    fortyGigE0/4  PortChannel102      up       up     N/A         off
```
Furthermore, it breaks sonic-mgmt show_interface.py ansible module because the parse isn't expecting "." in speed column.

### what this PR does
If interface speed is UINT32_MAX, return -ENOENT. This indicates to the caller that interface speed is not available so it will fall back to configured speed.