### PR TITLE
Add PRBS attribute serialization and deserialization support

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -2028,6 +2028,14 @@ void Meta::meta_generic_validation_post_remove(
                 // no special action required
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                // no special action required
+                break;
+
             default:
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
         }
@@ -3802,6 +3810,26 @@ sai_status_t Meta::meta_generic_validation_create(
                 VALIDATION_LIST(md, value.portserdestaps);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+                // primitive PRBS RX state
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+                VALIDATION_LIST(md, value.prbs_rx_status_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+                VALIDATION_LIST(md, value.prbs_rx_state_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+                // primitive PRBS BER
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                VALIDATION_LIST(md, value.prbs_ber_list);
+                break;
+
             default:
 
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -4450,6 +4478,26 @@ sai_status_t Meta::meta_generic_validation_set(
             VALIDATION_LIST(md, value.portserdestaps);
             break;
 
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            // primitive PRBS RX state
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            VALIDATION_LIST(md, value.prbs_rx_status_list);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            VALIDATION_LIST(md, value.prbs_rx_state_list);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            // primitive PRBS BER
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+            VALIDATION_LIST(md, value.prbs_ber_list);
+            break;
+
         default:
 
             META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -4855,6 +4903,26 @@ sai_status_t Meta::meta_generic_validation_get(
                 VALIDATION_LIST(md, value.portserdestaps);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+                // primitive PRBS RX state
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+                VALIDATION_LIST(md, value.prbs_rx_status_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+                VALIDATION_LIST(md, value.prbs_rx_state_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+                // primitive PRBS BER
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                VALIDATION_LIST(md, value.prbs_ber_list);
+                break;
+
             default:
 
                 // acl capability will is more complex since is in/out we need to check stage
@@ -5166,6 +5234,26 @@ void Meta::meta_generic_validation_post_get(
 
             case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
                 VALIDATION_LIST_GET(md, value.portserdestaps);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+                // primitive PRBS RX state
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+                VALIDATION_LIST_GET(md, value.prbs_rx_status_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+                VALIDATION_LIST_GET(md, value.prbs_rx_state_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+                // primitive PRBS BER
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                VALIDATION_LIST_GET(md, value.prbs_ber_list);
                 break;
 
             default:
@@ -6065,6 +6153,14 @@ void Meta::meta_generic_validation_post_create(
                 // no special action required
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                // no special action required
+                break;
+
             default:
 
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -6304,6 +6400,14 @@ void Meta::meta_generic_validation_post_set(
             break;
 
         case SAI_ATTR_VALUE_TYPE_IP_PREFIX_LIST:
+            // no special action required
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
             // no special action required
             break;
 

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -2041,6 +2041,14 @@ void Meta::meta_generic_validation_post_remove(
                 // no special action required
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                // no special action required
+                break;
+
             default:
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
         }
@@ -3835,6 +3843,26 @@ sai_status_t Meta::meta_generic_validation_create(
                 VALIDATION_LIST(md, value.portserdestaps);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+                // primitive PRBS RX state
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+                VALIDATION_LIST(md, value.prbs_rx_status_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+                VALIDATION_LIST(md, value.prbs_rx_state_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+                // primitive PRBS BER
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                VALIDATION_LIST(md, value.prbs_ber_list);
+                break;
+
             default:
 
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -4488,6 +4516,26 @@ sai_status_t Meta::meta_generic_validation_set(
             VALIDATION_LIST(md, value.portserdestaps);
             break;
 
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            // primitive PRBS RX state
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            VALIDATION_LIST(md, value.prbs_rx_status_list);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            VALIDATION_LIST(md, value.prbs_rx_state_list);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            // primitive PRBS BER
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+            VALIDATION_LIST(md, value.prbs_ber_list);
+            break;
+
         default:
 
             META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -4898,6 +4946,26 @@ sai_status_t Meta::meta_generic_validation_get(
                 VALIDATION_LIST(md, value.portserdestaps);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+                // primitive PRBS RX state
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+                VALIDATION_LIST(md, value.prbs_rx_status_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+                VALIDATION_LIST(md, value.prbs_rx_state_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+                // primitive PRBS BER
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                VALIDATION_LIST(md, value.prbs_ber_list);
+                break;
+
             default:
 
                 // acl capability will is more complex since is in/out we need to check stage
@@ -5214,6 +5282,26 @@ void Meta::meta_generic_validation_post_get(
 
             case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
                 VALIDATION_LIST_GET(md, value.portserdestaps);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+                // primitive PRBS RX state
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+                VALIDATION_LIST_GET(md, value.prbs_rx_status_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+                VALIDATION_LIST_GET(md, value.prbs_rx_state_list);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+                // primitive PRBS BER
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                VALIDATION_LIST_GET(md, value.prbs_ber_list);
                 break;
 
             default:
@@ -6118,6 +6206,14 @@ void Meta::meta_generic_validation_post_create(
                 // no special action required
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+                // no special action required
+                break;
+
             default:
 
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
@@ -6365,6 +6461,14 @@ void Meta::meta_generic_validation_post_set(
             break;
 
         case SAI_ATTR_VALUE_TYPE_IP_PREFIX_LIST:
+            // no special action required
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
             // no special action required
             break;
 

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -2340,6 +2340,159 @@ std::string sai_serialize_segment_list(
     return s + ":" + l;
 }
 
+std::string sai_serialize_prbs_per_lane_rx_status_list(
+        _In_ const sai_prbs_per_lane_rx_status_list_t& prbs_rx_status_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["count"] = prbs_rx_status_list.count;
+
+    if (prbs_rx_status_list.list == NULL || countOnly)
+    {
+        j["list"] = nullptr;
+
+        return j.dump();
+    }
+
+    if (prbs_rx_status_list.count > 256)
+    {
+        SWSS_LOG_THROW("PRBS RX status list count %u exceeds sanity maximum (256)", prbs_rx_status_list.count);
+    }
+
+    json arr = json::array();
+
+    for (uint32_t i = 0; i < prbs_rx_status_list.count; ++i)
+    {
+        json item;
+        item["lane"] = sai_serialize_number(prbs_rx_status_list.list[i].lane, false);
+        item["rx_status"] = sai_serialize_enum(prbs_rx_status_list.list[i].rx_status, &sai_metadata_enum_sai_port_prbs_rx_status_t);
+        arr.push_back(item);
+    }
+
+    j["list"] = arr;
+
+    return j.dump();
+}
+
+static json sai_serialize_prbs_rx_state_json(
+        _In_ const sai_prbs_rx_state_t& prbs_rx_state)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["rx_status"] = sai_serialize_enum(prbs_rx_state.rx_status, &sai_metadata_enum_sai_port_prbs_rx_status_t);
+    j["error_count"] = sai_serialize_number(prbs_rx_state.error_count);
+
+    return j;
+}
+
+std::string sai_serialize_prbs_rx_state(
+        _In_ const sai_prbs_rx_state_t& prbs_rx_state)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_prbs_rx_state_json(prbs_rx_state).dump();
+}
+
+std::string sai_serialize_prbs_per_lane_rx_state_list(
+        _In_ const sai_prbs_per_lane_rx_state_list_t& prbs_rx_state_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["count"] = prbs_rx_state_list.count;
+
+    if (prbs_rx_state_list.list == NULL || countOnly)
+    {
+        j["list"] = nullptr;
+
+        return j.dump();
+    }
+
+    if (prbs_rx_state_list.count > 256)
+    {
+        SWSS_LOG_THROW("PRBS RX state list count %u exceeds sanity maximum (256)", prbs_rx_state_list.count);
+    }
+
+    json arr = json::array();
+
+    for (uint32_t i = 0; i < prbs_rx_state_list.count; ++i)
+    {
+        json item;
+        item["lane"] = sai_serialize_number(prbs_rx_state_list.list[i].lane, false);
+        item["rx_state"] = sai_serialize_prbs_rx_state_json(prbs_rx_state_list.list[i].rx_state);
+        arr.push_back(item);
+    }
+
+    j["list"] = arr;
+
+    return j.dump();
+}
+
+static json sai_serialize_prbs_bit_error_rate_json(
+        _In_ const sai_prbs_bit_error_rate_t& prbs_ber)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["mantissa"] = sai_serialize_number(prbs_ber.mantissa);
+    j["exponent"] = sai_serialize_number(prbs_ber.exponent);
+
+    return j;
+}
+
+std::string sai_serialize_prbs_bit_error_rate(
+        _In_ const sai_prbs_bit_error_rate_t& prbs_ber)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_prbs_bit_error_rate_json(prbs_ber).dump();
+}
+
+std::string sai_serialize_prbs_per_lane_bit_error_rate_list(
+        _In_ const sai_prbs_per_lane_bit_error_rate_list_t& prbs_ber_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["count"] = prbs_ber_list.count;
+
+    if (prbs_ber_list.list == NULL || countOnly)
+    {
+        j["list"] = nullptr;
+
+        return j.dump();
+    }
+
+    if (prbs_ber_list.count > 256)
+    {
+        SWSS_LOG_THROW("PRBS BER list count %u exceeds sanity maximum (256)", prbs_ber_list.count);
+    }
+
+    json arr = json::array();
+
+    for (uint32_t i = 0; i < prbs_ber_list.count; ++i)
+    {
+        json item;
+        item["lane"] = sai_serialize_number(prbs_ber_list.list[i].lane, false);
+        item["ber"] = sai_serialize_prbs_bit_error_rate_json(prbs_ber_list.list[i].ber);
+        arr.push_back(item);
+    }
+
+    j["list"] = arr;
+
+    return j.dump();
+}
+
 std::string sai_serialize_attr_value(
         _In_ const sai_attr_metadata_t& meta,
         _In_ const sai_attribute_t &attr,
@@ -2538,6 +2691,21 @@ std::string sai_serialize_attr_value(
 
         case SAI_ATTR_VALUE_TYPE_POE_PORT_POWER_CONSUMPTION:
             return sai_serialize_poe_port_power_consumption(attr.value.portpowerconsumption);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            return sai_serialize_prbs_rx_state(attr.value.rx_state);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            return sai_serialize_prbs_per_lane_rx_status_list(attr.value.prbs_rx_status_list, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            return sai_serialize_prbs_per_lane_rx_state_list(attr.value.prbs_rx_state_list, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            return sai_serialize_prbs_bit_error_rate(attr.value.prbs_ber);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+            return sai_serialize_prbs_per_lane_bit_error_rate_list(attr.value.prbs_ber_list, countOnly);
 
         default:
             SWSS_LOG_THROW("sai attr value type %s is not implemented, FIXME", sai_serialize_attr_value_type(meta.attrvaluetype).c_str());
@@ -5134,6 +5302,21 @@ void sai_deserialize_attr_value(
         case SAI_ATTR_VALUE_TYPE_POE_PORT_POWER_CONSUMPTION:
             return sai_deserialize_poe_port_power_consumption(s, attr.value.portpowerconsumption);
 
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            return sai_deserialize_prbs_rx_state(s, attr.value.rx_state);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            return sai_deserialize_prbs_per_lane_rx_status_list(s, attr.value.prbs_rx_status_list, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            return sai_deserialize_prbs_per_lane_rx_state_list(s, attr.value.prbs_rx_state_list, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            return sai_deserialize_prbs_bit_error_rate(s, attr.value.prbs_ber);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+            return sai_deserialize_prbs_per_lane_bit_error_rate_list(s, attr.value.prbs_ber_list, countOnly);
+
         default:
             SWSS_LOG_THROW("deserialize type %s is not supported yet FIXME",
                     sai_serialize_attr_value_type(meta.attrvaluetype).c_str());
@@ -6563,6 +6746,24 @@ void sai_deserialize_free_attribute_value(
         case SAI_ATTR_VALUE_TYPE_POE_PORT_POWER_CONSUMPTION:
             break;
 
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            sai_free_list(attr.value.prbs_rx_status_list);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            sai_free_list(attr.value.prbs_rx_state_list);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+            sai_free_list(attr.value.prbs_ber_list);
+            break;
+
         default:
             SWSS_LOG_THROW("sai attr value %s is not implemented, FIXME", sai_serialize_attr_value_type(type).c_str());
     }
@@ -6593,6 +6794,163 @@ void sai_deserialzie_poe_port_signature_type(
     SWSS_LOG_ENTER();
 
     sai_deserialize_enum(s, &sai_metadata_enum_sai_poe_port_signature_type_t, (int32_t&)value);
+}
+
+void sai_deserialize_prbs_per_lane_rx_status_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_rx_status_list_t& prbs_rx_status_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::parse(s);
+
+    prbs_rx_status_list.count = j["count"];
+
+    if (countOnly)
+    {
+        return;
+    }
+
+    if (j["list"] == nullptr)
+    {
+        prbs_rx_status_list.list = NULL;
+        return;
+    }
+
+    json arr = j["list"];
+
+    if (arr.size() != (size_t)prbs_rx_status_list.count)
+    {
+        SWSS_LOG_THROW("PRBS per-lane RX status list count mismatch %lu vs %u", arr.size(), prbs_rx_status_list.count);
+    }
+
+    prbs_rx_status_list.list = sai_alloc_n_of_ptr_type(prbs_rx_status_list.count, prbs_rx_status_list.list);
+
+    for (uint32_t i = 0; i < prbs_rx_status_list.count; i++)
+    {
+        sai_deserialize_number(arr[i]["lane"], prbs_rx_status_list.list[i].lane, false);
+
+        int32_t rx_status;
+        sai_deserialize_enum(arr[i]["rx_status"], &sai_metadata_enum_sai_port_prbs_rx_status_t, rx_status);
+        prbs_rx_status_list.list[i].rx_status = (sai_port_prbs_rx_status_t)rx_status;
+    }
+}
+
+static void sai_deserialize_prbs_rx_state_json(
+        _In_ const json& j,
+        _Out_ sai_prbs_rx_state_t& value)
+{
+    SWSS_LOG_ENTER();
+
+    int32_t rx_status;
+    sai_deserialize_enum(j["rx_status"], &sai_metadata_enum_sai_port_prbs_rx_status_t, rx_status);
+    value.rx_status = (sai_port_prbs_rx_status_t)rx_status;
+    sai_deserialize_number(j["error_count"], value.error_count);
+}
+
+void sai_deserialize_prbs_rx_state(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_rx_state_t& value)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_prbs_rx_state_json(json::parse(s), value);
+}
+
+static void sai_deserialize_prbs_bit_error_rate_json(
+        _In_ const json& j,
+        _Out_ sai_prbs_bit_error_rate_t& value)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_number(j["mantissa"], value.mantissa);
+    sai_deserialize_number(j["exponent"], value.exponent);
+}
+
+void sai_deserialize_prbs_bit_error_rate(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_bit_error_rate_t& value)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_prbs_bit_error_rate_json(json::parse(s), value);
+}
+
+void sai_deserialize_prbs_per_lane_rx_state_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_rx_state_list_t& prbs_rx_state_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::parse(s);
+
+    prbs_rx_state_list.count = j["count"];
+
+    if (countOnly)
+    {
+        return;
+    }
+
+    if (j["list"] == nullptr)
+    {
+        prbs_rx_state_list.list = NULL;
+        return;
+    }
+
+    json arr = j["list"];
+
+    if (arr.size() != (size_t)prbs_rx_state_list.count)
+    {
+        SWSS_LOG_THROW("PRBS per-lane RX state list count mismatch %lu vs %u", arr.size(), prbs_rx_state_list.count);
+    }
+
+    prbs_rx_state_list.list = sai_alloc_n_of_ptr_type(prbs_rx_state_list.count, prbs_rx_state_list.list);
+
+    for (uint32_t i = 0; i < prbs_rx_state_list.count; i++)
+    {
+        sai_deserialize_number(arr[i]["lane"], prbs_rx_state_list.list[i].lane, false);
+        sai_deserialize_prbs_rx_state_json(arr[i]["rx_state"], prbs_rx_state_list.list[i].rx_state);
+    }
+}
+
+void sai_deserialize_prbs_per_lane_bit_error_rate_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_bit_error_rate_list_t& prbs_ber_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::parse(s);
+
+    prbs_ber_list.count = j["count"];
+
+    if (countOnly)
+    {
+        return;
+    }
+
+    if (j["list"] == nullptr)
+    {
+        prbs_ber_list.list = NULL;
+        return;
+    }
+
+    json arr = j["list"];
+
+    if (arr.size() != (size_t)prbs_ber_list.count)
+    {
+        SWSS_LOG_THROW("PRBS per-lane BER list count mismatch %lu vs %u", arr.size(), prbs_ber_list.count);
+    }
+
+    prbs_ber_list.list = sai_alloc_n_of_ptr_type(prbs_ber_list.count, prbs_ber_list.list);
+
+    for (uint32_t i = 0; i < prbs_ber_list.count; i++)
+    {
+        sai_deserialize_number(arr[i]["lane"], prbs_ber_list.list[i].lane, false);
+        sai_deserialize_prbs_bit_error_rate_json(arr[i]["ber"], prbs_ber_list.list[i].ber);
+    }
 }
 
 void sai_deserialize_poe_port_power_consumption(

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -2385,6 +2385,159 @@ std::string sai_serialize_segment_list(
     return s + ":" + l;
 }
 
+std::string sai_serialize_prbs_per_lane_rx_status_list(
+        _In_ const sai_prbs_per_lane_rx_status_list_t& prbs_rx_status_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["count"] = prbs_rx_status_list.count;
+
+    if (prbs_rx_status_list.list == NULL || countOnly)
+    {
+        j["list"] = nullptr;
+
+        return j.dump();
+    }
+
+    if (prbs_rx_status_list.count > 256)
+    {
+        SWSS_LOG_THROW("PRBS RX status list count %u exceeds sanity maximum (256)", prbs_rx_status_list.count);
+    }
+
+    json arr = json::array();
+
+    for (uint32_t i = 0; i < prbs_rx_status_list.count; ++i)
+    {
+        json item;
+        item["lane"] = sai_serialize_number(prbs_rx_status_list.list[i].lane, false);
+        item["rx_status"] = sai_serialize_enum(prbs_rx_status_list.list[i].rx_status, &sai_metadata_enum_sai_port_prbs_rx_status_t);
+        arr.push_back(item);
+    }
+
+    j["list"] = arr;
+
+    return j.dump();
+}
+
+static json sai_serialize_prbs_rx_state_json(
+        _In_ const sai_prbs_rx_state_t& prbs_rx_state)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["rx_status"] = sai_serialize_enum(prbs_rx_state.rx_status, &sai_metadata_enum_sai_port_prbs_rx_status_t);
+    j["error_count"] = sai_serialize_number(prbs_rx_state.error_count);
+
+    return j;
+}
+
+std::string sai_serialize_prbs_rx_state(
+        _In_ const sai_prbs_rx_state_t& prbs_rx_state)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_prbs_rx_state_json(prbs_rx_state).dump();
+}
+
+std::string sai_serialize_prbs_per_lane_rx_state_list(
+        _In_ const sai_prbs_per_lane_rx_state_list_t& prbs_rx_state_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["count"] = prbs_rx_state_list.count;
+
+    if (prbs_rx_state_list.list == NULL || countOnly)
+    {
+        j["list"] = nullptr;
+
+        return j.dump();
+    }
+
+    if (prbs_rx_state_list.count > 256)
+    {
+        SWSS_LOG_THROW("PRBS RX state list count %u exceeds sanity maximum (256)", prbs_rx_state_list.count);
+    }
+
+    json arr = json::array();
+
+    for (uint32_t i = 0; i < prbs_rx_state_list.count; ++i)
+    {
+        json item;
+        item["lane"] = sai_serialize_number(prbs_rx_state_list.list[i].lane, false);
+        item["rx_state"] = sai_serialize_prbs_rx_state_json(prbs_rx_state_list.list[i].rx_state);
+        arr.push_back(item);
+    }
+
+    j["list"] = arr;
+
+    return j.dump();
+}
+
+static json sai_serialize_prbs_bit_error_rate_json(
+        _In_ const sai_prbs_bit_error_rate_t& prbs_ber)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["mantissa"] = sai_serialize_number(prbs_ber.mantissa);
+    j["exponent"] = sai_serialize_number(prbs_ber.exponent);
+
+    return j;
+}
+
+std::string sai_serialize_prbs_bit_error_rate(
+        _In_ const sai_prbs_bit_error_rate_t& prbs_ber)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_prbs_bit_error_rate_json(prbs_ber).dump();
+}
+
+std::string sai_serialize_prbs_per_lane_bit_error_rate_list(
+        _In_ const sai_prbs_per_lane_bit_error_rate_list_t& prbs_ber_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["count"] = prbs_ber_list.count;
+
+    if (prbs_ber_list.list == NULL || countOnly)
+    {
+        j["list"] = nullptr;
+
+        return j.dump();
+    }
+
+    if (prbs_ber_list.count > 256)
+    {
+        SWSS_LOG_THROW("PRBS BER list count %u exceeds sanity maximum (256)", prbs_ber_list.count);
+    }
+
+    json arr = json::array();
+
+    for (uint32_t i = 0; i < prbs_ber_list.count; ++i)
+    {
+        json item;
+        item["lane"] = sai_serialize_number(prbs_ber_list.list[i].lane, false);
+        item["ber"] = sai_serialize_prbs_bit_error_rate_json(prbs_ber_list.list[i].ber);
+        arr.push_back(item);
+    }
+
+    j["list"] = arr;
+
+    return j.dump();
+}
+
 std::string sai_serialize_attr_value(
         _In_ const sai_attr_metadata_t& meta,
         _In_ const sai_attribute_t &attr,
@@ -2583,6 +2736,21 @@ std::string sai_serialize_attr_value(
 
         case SAI_ATTR_VALUE_TYPE_POE_PORT_POWER_CONSUMPTION:
             return sai_serialize_poe_port_power_consumption(attr.value.portpowerconsumption);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            return sai_serialize_prbs_rx_state(attr.value.rx_state);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            return sai_serialize_prbs_per_lane_rx_status_list(attr.value.prbs_rx_status_list, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            return sai_serialize_prbs_per_lane_rx_state_list(attr.value.prbs_rx_state_list, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            return sai_serialize_prbs_bit_error_rate(attr.value.prbs_ber);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+            return sai_serialize_prbs_per_lane_bit_error_rate_list(attr.value.prbs_ber_list, countOnly);
 
         default:
             SWSS_LOG_THROW("sai attr value type %s is not implemented, FIXME", sai_serialize_attr_value_type(meta.attrvaluetype).c_str());
@@ -5227,6 +5395,21 @@ void sai_deserialize_attr_value(
         case SAI_ATTR_VALUE_TYPE_POE_PORT_POWER_CONSUMPTION:
             return sai_deserialize_poe_port_power_consumption(s, attr.value.portpowerconsumption);
 
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            return sai_deserialize_prbs_rx_state(s, attr.value.rx_state);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            return sai_deserialize_prbs_per_lane_rx_status_list(s, attr.value.prbs_rx_status_list, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            return sai_deserialize_prbs_per_lane_rx_state_list(s, attr.value.prbs_rx_state_list, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            return sai_deserialize_prbs_bit_error_rate(s, attr.value.prbs_ber);
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+            return sai_deserialize_prbs_per_lane_bit_error_rate_list(s, attr.value.prbs_ber_list, countOnly);
+
         default:
             SWSS_LOG_THROW("deserialize type %s is not supported yet FIXME",
                     sai_serialize_attr_value_type(meta.attrvaluetype).c_str());
@@ -6656,6 +6839,24 @@ void sai_deserialize_free_attribute_value(
         case SAI_ATTR_VALUE_TYPE_POE_PORT_POWER_CONSUMPTION:
             break;
 
+        case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
+            sai_free_list(attr.value.prbs_rx_status_list);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
+            sai_free_list(attr.value.prbs_rx_state_list);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
+            sai_free_list(attr.value.prbs_ber_list);
+            break;
+
         default:
             SWSS_LOG_THROW("sai attr value %s is not implemented, FIXME", sai_serialize_attr_value_type(type).c_str());
     }
@@ -6686,6 +6887,163 @@ void sai_deserialzie_poe_port_signature_type(
     SWSS_LOG_ENTER();
 
     sai_deserialize_enum(s, &sai_metadata_enum_sai_poe_port_signature_type_t, (int32_t&)value);
+}
+
+void sai_deserialize_prbs_per_lane_rx_status_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_rx_status_list_t& prbs_rx_status_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::parse(s);
+
+    prbs_rx_status_list.count = j["count"];
+
+    if (countOnly)
+    {
+        return;
+    }
+
+    if (j["list"] == nullptr)
+    {
+        prbs_rx_status_list.list = NULL;
+        return;
+    }
+
+    json arr = j["list"];
+
+    if (arr.size() != (size_t)prbs_rx_status_list.count)
+    {
+        SWSS_LOG_THROW("PRBS per-lane RX status list count mismatch %lu vs %u", arr.size(), prbs_rx_status_list.count);
+    }
+
+    prbs_rx_status_list.list = sai_alloc_n_of_ptr_type(prbs_rx_status_list.count, prbs_rx_status_list.list);
+
+    for (uint32_t i = 0; i < prbs_rx_status_list.count; i++)
+    {
+        sai_deserialize_number(arr[i]["lane"], prbs_rx_status_list.list[i].lane, false);
+
+        int32_t rx_status;
+        sai_deserialize_enum(arr[i]["rx_status"], &sai_metadata_enum_sai_port_prbs_rx_status_t, rx_status);
+        prbs_rx_status_list.list[i].rx_status = (sai_port_prbs_rx_status_t)rx_status;
+    }
+}
+
+static void sai_deserialize_prbs_rx_state_json(
+        _In_ const json& j,
+        _Out_ sai_prbs_rx_state_t& value)
+{
+    SWSS_LOG_ENTER();
+
+    int32_t rx_status;
+    sai_deserialize_enum(j["rx_status"], &sai_metadata_enum_sai_port_prbs_rx_status_t, rx_status);
+    value.rx_status = (sai_port_prbs_rx_status_t)rx_status;
+    sai_deserialize_number(j["error_count"], value.error_count);
+}
+
+void sai_deserialize_prbs_rx_state(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_rx_state_t& value)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_prbs_rx_state_json(json::parse(s), value);
+}
+
+static void sai_deserialize_prbs_bit_error_rate_json(
+        _In_ const json& j,
+        _Out_ sai_prbs_bit_error_rate_t& value)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_number(j["mantissa"], value.mantissa);
+    sai_deserialize_number(j["exponent"], value.exponent);
+}
+
+void sai_deserialize_prbs_bit_error_rate(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_bit_error_rate_t& value)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_prbs_bit_error_rate_json(json::parse(s), value);
+}
+
+void sai_deserialize_prbs_per_lane_rx_state_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_rx_state_list_t& prbs_rx_state_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::parse(s);
+
+    prbs_rx_state_list.count = j["count"];
+
+    if (countOnly)
+    {
+        return;
+    }
+
+    if (j["list"] == nullptr)
+    {
+        prbs_rx_state_list.list = NULL;
+        return;
+    }
+
+    json arr = j["list"];
+
+    if (arr.size() != (size_t)prbs_rx_state_list.count)
+    {
+        SWSS_LOG_THROW("PRBS per-lane RX state list count mismatch %lu vs %u", arr.size(), prbs_rx_state_list.count);
+    }
+
+    prbs_rx_state_list.list = sai_alloc_n_of_ptr_type(prbs_rx_state_list.count, prbs_rx_state_list.list);
+
+    for (uint32_t i = 0; i < prbs_rx_state_list.count; i++)
+    {
+        sai_deserialize_number(arr[i]["lane"], prbs_rx_state_list.list[i].lane, false);
+        sai_deserialize_prbs_rx_state_json(arr[i]["rx_state"], prbs_rx_state_list.list[i].rx_state);
+    }
+}
+
+void sai_deserialize_prbs_per_lane_bit_error_rate_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_bit_error_rate_list_t& prbs_ber_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::parse(s);
+
+    prbs_ber_list.count = j["count"];
+
+    if (countOnly)
+    {
+        return;
+    }
+
+    if (j["list"] == nullptr)
+    {
+        prbs_ber_list.list = NULL;
+        return;
+    }
+
+    json arr = j["list"];
+
+    if (arr.size() != (size_t)prbs_ber_list.count)
+    {
+        SWSS_LOG_THROW("PRBS per-lane BER list count mismatch %lu vs %u", arr.size(), prbs_ber_list.count);
+    }
+
+    prbs_ber_list.list = sai_alloc_n_of_ptr_type(prbs_ber_list.count, prbs_ber_list.list);
+
+    for (uint32_t i = 0; i < prbs_ber_list.count; i++)
+    {
+        sai_deserialize_number(arr[i]["lane"], prbs_ber_list.list[i].lane, false);
+        sai_deserialize_prbs_bit_error_rate_json(arr[i]["ber"], prbs_ber_list.list[i].ber);
+    }
 }
 
 void sai_deserialize_poe_port_power_consumption(

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -334,6 +334,24 @@ std::string sai_serialize_taps_list(
         _In_ const sai_taps_list_t& port_serdes_taps_list,
         _In_ bool countOnly);
 
+std::string sai_serialize_prbs_rx_state(
+        _In_ const sai_prbs_rx_state_t& prbs_rx_state);
+
+std::string sai_serialize_prbs_per_lane_rx_status_list(
+        _In_ const sai_prbs_per_lane_rx_status_list_t& prbs_rx_status_list,
+        _In_ bool countOnly);
+
+std::string sai_serialize_prbs_per_lane_rx_state_list(
+        _In_ const sai_prbs_per_lane_rx_state_list_t& prbs_rx_state_list,
+        _In_ bool countOnly);
+
+std::string sai_serialize_prbs_bit_error_rate(
+        _In_ const sai_prbs_bit_error_rate_t& prbs_ber);
+
+std::string sai_serialize_prbs_per_lane_bit_error_rate_list(
+        _In_ const sai_prbs_per_lane_bit_error_rate_list_t& prbs_ber_list,
+        _In_ bool countOnly);
+
 // serialize notifications
 
 std::string sai_serialize_fdb_event_ntf(
@@ -626,6 +644,29 @@ void sai_deserialize_chardata(
 void sai_deserialize_poe_port_power_consumption(
         _In_ const std::string& s,
         _Out_ sai_poe_port_power_consumption_t& pppc);
+
+void sai_deserialize_prbs_rx_state(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_rx_state_t& value);
+
+void sai_deserialize_prbs_per_lane_rx_status_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_rx_status_list_t& prbs_rx_status_list,
+        _In_ bool countOnly);
+
+void sai_deserialize_prbs_per_lane_rx_state_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_rx_state_list_t& prbs_rx_state_list,
+        _In_ bool countOnly);
+
+void sai_deserialize_prbs_bit_error_rate(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_bit_error_rate_t& value);
+
+void sai_deserialize_prbs_per_lane_bit_error_rate_list(
+        _In_ const std::string& s,
+        _Out_ sai_prbs_per_lane_bit_error_rate_list_t& prbs_ber_list,
+        _In_ bool countOnly);
 
 // deserialize notifications
 

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -15,6 +15,7 @@ ApplyView
 AsicView
 AttrHash
 BCM
+BER
 BFD
 Bool
 CHARDATA
@@ -69,6 +70,7 @@ OIDs
 ObjectAttrHash
 ObjectHash
 PN
+PRBS
 PORTs
 QUEUEs
 REQ
@@ -321,6 +323,7 @@ phy
 plaintext
 pn
 PN
+prbs
 policer
 PORTs
 pre

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -15,6 +15,7 @@ ApplyView
 AsicView
 AttrHash
 BCM
+BER
 BFD
 Bool
 CHARDATA
@@ -70,6 +71,7 @@ OIDs
 ObjectAttrHash
 ObjectHash
 PN
+PRBS
 PORTs
 QUEUEs
 REQ
@@ -324,6 +326,7 @@ phy
 plaintext
 pn
 PN
+prbs
 policer
 PORTs
 pre

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -2157,3 +2157,99 @@ TEST(Meta, meta_validation_uint64_range_list)
     // Remove exercises meta_generic_validation_post_remove (UINT64_RANGE_LIST path)
     EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(SAI_OBJECT_TYPE_TAM_INT, tam_int_id));
 }
+
+TEST(Meta, meta_validation_prbs_get_per_lane_ber_and_rx_state)
+{
+    SWSS_LOG_ENTER();
+
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switch_id = 0;
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switch_id, SAI_NULL_OBJECT_ID, 1, &attr));
+
+    // Create a port so the object exists in metadata collection
+    sai_object_id_t port_id = 0;
+    uint32_t lanes[1] = {1};
+    sai_attribute_t port_attrs[2];
+
+    port_attrs[0].id = SAI_PORT_ATTR_HW_LANE_LIST;
+    port_attrs[0].value.u32list.count = 1;
+    port_attrs[0].value.u32list.list = lanes;
+    port_attrs[1].id = SAI_PORT_ATTR_SPEED;
+    port_attrs[1].value.u32 = 10000;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_PORT, &port_id, switch_id, 2, port_attrs));
+
+    // Test get with SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST
+    // Exercises meta_generic_validation_get and meta_generic_validation_post_get PRBS_PER_LANE_BIT_ERROR_RATE_LIST case
+    sai_prbs_per_lane_bit_error_rate_t ber_lanes[4] = {};
+    memset(ber_lanes, 0, sizeof(ber_lanes));
+
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 4;
+    attr.value.prbs_ber_list.list = ber_lanes;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
+
+    // Test get with SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST
+    sai_prbs_per_lane_rx_state_t state_lanes[4] = {};
+    memset(state_lanes, 0, sizeof(state_lanes));
+
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+    attr.value.prbs_rx_state_list.count = 4;
+    attr.value.prbs_rx_state_list.list = state_lanes;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
+}
+
+TEST(Meta, meta_validation_prbs_set_per_lane_ber_list)
+{
+    SWSS_LOG_ENTER();
+
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switch_id = 0;
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switch_id, SAI_NULL_OBJECT_ID, 1, &attr));
+
+    sai_object_id_t port_id = 0;
+    uint32_t lanes[1] = {2};
+    sai_attribute_t port_attrs[2];
+
+    port_attrs[0].id = SAI_PORT_ATTR_HW_LANE_LIST;
+    port_attrs[0].value.u32list.count = 1;
+    port_attrs[0].value.u32list.list = lanes;
+    port_attrs[1].id = SAI_PORT_ATTR_SPEED;
+    port_attrs[1].value.u32 = 10000;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_PORT, &port_id, switch_id, 2, port_attrs));
+
+    // Enable unittest mode and allow setting the READ_ONLY PRBS BER list attribute
+    // This exercises meta_generic_validation_set PRBS_PER_LANE_BIT_ERROR_RATE_LIST case
+    m.meta_unittests_enable(true);
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.meta_unittests_allow_readonly_set_once(
+            SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST));
+
+    sai_prbs_per_lane_bit_error_rate_t ber_lanes[2] = {};
+    ber_lanes[0].lane = 0;
+    ber_lanes[0].ber.mantissa = 123;
+    ber_lanes[0].ber.exponent = 9;
+    ber_lanes[1].lane = 1;
+    ber_lanes[1].ber.mantissa = 456;
+    ber_lanes[1].ber.exponent = 12;
+
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 2;
+    attr.value.prbs_ber_list.list = ber_lanes;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
+}

--- a/unittest/meta/TestMeta.cpp
+++ b/unittest/meta/TestMeta.cpp
@@ -2163,7 +2163,6 @@ TEST(Meta, meta_sai_on_port_state_change_snoop)
     Meta m(std::make_shared<MetaTestSaiInterface>());
 
     sai_object_id_t switchId = 0;
-
     sai_attribute_t attr;
 
     attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
@@ -2200,7 +2199,6 @@ TEST(Meta, meta_sai_on_port_host_tx_ready_change_snoop)
     Meta m(std::make_shared<MetaTestSaiInterface>());
 
     sai_object_id_t switchId = 0;
-
     sai_attribute_t attr;
 
     attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
@@ -2235,4 +2233,100 @@ TEST(Meta, meta_sai_on_port_host_tx_ready_change_snoop)
             portId,
             switchId,
             SAI_PORT_HOST_TX_READY_STATUS_NOT_READY);
+}
+
+TEST(Meta, meta_validation_prbs_get_per_lane_ber_and_rx_state)
+{
+    SWSS_LOG_ENTER();
+
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switch_id = 0;
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switch_id, SAI_NULL_OBJECT_ID, 1, &attr));
+
+    // Create a port so the object exists in metadata collection
+    sai_object_id_t port_id = 0;
+    uint32_t lanes[1] = {1};
+    sai_attribute_t port_attrs[2];
+
+    port_attrs[0].id = SAI_PORT_ATTR_HW_LANE_LIST;
+    port_attrs[0].value.u32list.count = 1;
+    port_attrs[0].value.u32list.list = lanes;
+    port_attrs[1].id = SAI_PORT_ATTR_SPEED;
+    port_attrs[1].value.u32 = 10000;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_PORT, &port_id, switch_id, 2, port_attrs));
+
+    // Test get with SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST
+    // Exercises meta_generic_validation_get and meta_generic_validation_post_get PRBS_PER_LANE_BIT_ERROR_RATE_LIST case
+    sai_prbs_per_lane_bit_error_rate_t ber_lanes[4] = {};
+    memset(ber_lanes, 0, sizeof(ber_lanes));
+
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 4;
+    attr.value.prbs_ber_list.list = ber_lanes;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
+
+    // Test get with SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST
+    sai_prbs_per_lane_rx_state_t state_lanes[4] = {};
+    memset(state_lanes, 0, sizeof(state_lanes));
+
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+    attr.value.prbs_rx_state_list.count = 4;
+    attr.value.prbs_rx_state_list.list = state_lanes;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.get(SAI_OBJECT_TYPE_PORT, port_id, 1, &attr));
+}
+
+TEST(Meta, meta_validation_prbs_set_per_lane_ber_list)
+{
+    SWSS_LOG_ENTER();
+
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switch_id = 0;
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_SWITCH, &switch_id, SAI_NULL_OBJECT_ID, 1, &attr));
+
+    sai_object_id_t port_id = 0;
+    uint32_t lanes[1] = {2};
+    sai_attribute_t port_attrs[2];
+
+    port_attrs[0].id = SAI_PORT_ATTR_HW_LANE_LIST;
+    port_attrs[0].value.u32list.count = 1;
+    port_attrs[0].value.u32list.list = lanes;
+    port_attrs[1].id = SAI_PORT_ATTR_SPEED;
+    port_attrs[1].value.u32 = 10000;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(SAI_OBJECT_TYPE_PORT, &port_id, switch_id, 2, port_attrs));
+
+    // Enable unittest mode and allow setting the READ_ONLY PRBS BER list attribute
+    // This exercises meta_generic_validation_set PRBS_PER_LANE_BIT_ERROR_RATE_LIST case
+    m.meta_unittests_enable(true);
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.meta_unittests_allow_readonly_set_once(
+            SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST));
+
+    sai_prbs_per_lane_bit_error_rate_t ber_lanes[2] = {};
+    ber_lanes[0].lane = 0;
+    ber_lanes[0].ber.mantissa = 123;
+    ber_lanes[0].ber.exponent = 9;
+    ber_lanes[1].lane = 1;
+    ber_lanes[1].ber.mantissa = 456;
+    ber_lanes[1].ber.exponent = 12;
+
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 2;
+    attr.value.prbs_ber_list.list = ber_lanes;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
 }

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -2779,3 +2779,133 @@ TEST(SaiSerialize, serialize_u64_range)
     EXPECT_EQ(dst.value.u64range.min, 111);
     EXPECT_EQ(dst.value.u64range.max, 222);
 }
+
+TEST(SaiSerialize, sai_serialize_prbs_bit_error_rate_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    sai_prbs_bit_error_rate_t ber;
+    ber.mantissa = 123;
+    ber.exponent = 9;
+
+    auto s = sai_serialize_prbs_bit_error_rate(ber);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["mantissa"], "123");
+    EXPECT_EQ(j["exponent"], "9");
+
+    sai_prbs_bit_error_rate_t ber2;
+    memset(&ber2, 0, sizeof(ber2));
+    sai_deserialize_prbs_bit_error_rate(s, ber2);
+
+    EXPECT_EQ(ber2.mantissa, 123u);
+    EXPECT_EQ(ber2.exponent, 9u);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_rx_status_list_count_overflow_throws)
+{
+    SWSS_LOG_ENTER();
+
+    sai_prbs_per_lane_rx_status_t dummy[1] = {};
+    sai_prbs_per_lane_rx_status_list_t list;
+    list.count = 257;
+    list.list = dummy;
+
+    EXPECT_THROW(sai_serialize_prbs_per_lane_rx_status_list(list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_rx_state_list_count_overflow_throws)
+{
+    SWSS_LOG_ENTER();
+
+    sai_prbs_per_lane_rx_state_t dummy[1] = {};
+    sai_prbs_per_lane_rx_state_list_t list;
+    list.count = 257;
+    list.list = dummy;
+
+    EXPECT_THROW(sai_serialize_prbs_per_lane_rx_state_list(list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_ber_list_count_overflow_throws)
+{
+    SWSS_LOG_ENTER();
+
+    sai_prbs_per_lane_bit_error_rate_t dummy[1] = {};
+    sai_prbs_per_lane_bit_error_rate_list_t list;
+    list.count = 257;
+    list.list = dummy;
+
+    EXPECT_THROW(sai_serialize_prbs_per_lane_bit_error_rate_list(list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_deserialize_prbs_rx_status_list_count_mismatch_throws)
+{
+    SWSS_LOG_ENTER();
+
+    // Build JSON with count=2 but only 1 entry in the list to trigger count mismatch
+    json j;
+    j["count"] = 2;
+    json arr = json::array();
+    json item;
+    item["lane"] = "0";
+    item["rx_status"] = "SAI_PORT_PRBS_RX_STATUS_OK";
+    arr.push_back(item);
+    j["list"] = arr;
+
+    std::string s = j.dump();
+
+    sai_prbs_per_lane_rx_status_list_t list;
+    memset(&list, 0, sizeof(list));
+
+    EXPECT_THROW(sai_deserialize_prbs_per_lane_rx_status_list(s, list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_deserialize_prbs_rx_state_list_count_mismatch_throws)
+{
+    SWSS_LOG_ENTER();
+
+    // Build JSON with count=2 but only 1 entry in the list to trigger count mismatch
+    json j;
+    j["count"] = 2;
+    json arr = json::array();
+    json item;
+    item["lane"] = "0";
+    json rx_state;
+    rx_state["rx_status"] = "SAI_PORT_PRBS_RX_STATUS_OK";
+    rx_state["error_count"] = "0";
+    item["rx_state"] = rx_state;
+    arr.push_back(item);
+    j["list"] = arr;
+
+    std::string s = j.dump();
+
+    sai_prbs_per_lane_rx_state_list_t list;
+    memset(&list, 0, sizeof(list));
+
+    EXPECT_THROW(sai_deserialize_prbs_per_lane_rx_state_list(s, list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_deserialize_prbs_ber_list_count_mismatch_throws)
+{
+    SWSS_LOG_ENTER();
+
+    // Build JSON with count=2 but only 1 entry in the list to trigger count mismatch
+    json j;
+    j["count"] = 2;
+    json arr = json::array();
+    json item;
+    item["lane"] = "0";
+    json ber;
+    ber["mantissa"] = "123";
+    ber["exponent"] = "9";
+    item["ber"] = ber;
+    arr.push_back(item);
+    j["list"] = arr;
+
+    std::string s = j.dump();
+
+    sai_prbs_per_lane_bit_error_rate_list_t list;
+    memset(&list, 0, sizeof(list));
+
+    EXPECT_THROW(sai_deserialize_prbs_per_lane_bit_error_rate_list(s, list, false), std::runtime_error);
+}

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -244,17 +244,12 @@ TEST(SaiSerialize, sai_serialize_attr_value)
             case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST:
             case SAI_ATTR_VALUE_TYPE_FABRIC_PORT_REACHABILITY:
-            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
             case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
             case SAI_ATTR_VALUE_TYPE_TLV_LIST:
             case SAI_ATTR_VALUE_TYPE_MAP_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
             case SAI_ATTR_VALUE_TYPE_ACL_CHAIN_LIST:
             case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
-            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
-            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
-            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
-            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
                 continue;
 
             default:
@@ -1773,6 +1768,402 @@ TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_nul
     EXPECT_EQ(deserialized_data[0].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED);
 
     sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_rx_state_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_RX_STATE);
+    ASSERT_NE(meta, nullptr);
+    attr.id = SAI_PORT_ATTR_PRBS_RX_STATE;
+
+    attr.value.rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS;
+    attr.value.rx_state.error_count = 42;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["rx_status"], "SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS");
+    EXPECT_EQ(j["error_count"], "42");
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_RX_STATE;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.rx_state.rx_status, SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS);
+    EXPECT_EQ(attr2.value.rx_state.error_count, 42);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_state_list_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_rx_state_t lanes[2];
+    lanes[0].lane = 0;
+    lanes[0].rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+    lanes[0].rx_state.error_count = 0;
+    lanes[1].lane = 1;
+    lanes[1].rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS;
+    lanes[1].rx_state.error_count = 7;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+    attr.value.prbs_rx_state_list.count = 2;
+    attr.value.prbs_rx_state_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 2);
+    ASSERT_TRUE(j["list"].is_array());
+    EXPECT_EQ(j["list"].size(), 2);
+    EXPECT_EQ(j["list"][0]["lane"], "0");
+    EXPECT_TRUE(j["list"][0]["rx_state"].is_object());
+    EXPECT_EQ(j["list"][1]["lane"], "1");
+    EXPECT_TRUE(j["list"][1]["rx_state"].is_object());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.count, 2);
+    ASSERT_NE(attr2.value.prbs_rx_state_list.list, nullptr);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[0].lane, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[0].rx_state.rx_status, SAI_PORT_PRBS_RX_STATUS_OK);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[0].rx_state.error_count, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[1].lane, 1);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[1].rx_state.rx_status, SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[1].rx_state.error_count, 7);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_state_list_countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_rx_state_t lanes[2];
+    lanes[0].lane = 0;
+    lanes[0].rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+    lanes[0].rx_state.error_count = 0;
+    lanes[1].lane = 1;
+    lanes[1].rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_NOT_LOCKED;
+    lanes[1].rx_state.error_count = 0;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+    attr.value.prbs_rx_state_list.count = 2;
+    attr.value.prbs_rx_state_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, true);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 2);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, true);
+
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.count, 2);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_state_list_null_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+    attr.value.prbs_rx_state_list.count = 0;
+    attr.value.prbs_rx_state_list.list = NULL;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 0);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.count, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list, nullptr);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_bit_error_rate_list_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_bit_error_rate_t lanes[2];
+    lanes[0].lane = 0;
+    lanes[0].ber.mantissa = 123;
+    lanes[0].ber.exponent = 9;
+    lanes[1].lane = 1;
+    lanes[1].ber.mantissa = 456;
+    lanes[1].ber.exponent = 12;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 2;
+    attr.value.prbs_ber_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 2);
+    ASSERT_TRUE(j["list"].is_array());
+    EXPECT_EQ(j["list"].size(), 2);
+    EXPECT_EQ(j["list"][0]["lane"], "0");
+    EXPECT_TRUE(j["list"][0]["ber"].is_object());
+    EXPECT_EQ(j["list"][1]["lane"], "1");
+    EXPECT_TRUE(j["list"][1]["ber"].is_object());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_ber_list.count, 2);
+    ASSERT_NE(attr2.value.prbs_ber_list.list, nullptr);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[0].lane, 0);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[0].ber.mantissa, 123);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[0].ber.exponent, 9);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[1].lane, 1);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[1].ber.mantissa, 456);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[1].ber.exponent, 12);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_bit_error_rate_list_countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_bit_error_rate_t lanes[1];
+    lanes[0].lane = 0;
+    lanes[0].ber.mantissa = 99;
+    lanes[0].ber.exponent = 3;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 1;
+    attr.value.prbs_ber_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, true);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 1);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, true);
+
+    EXPECT_EQ(attr2.value.prbs_ber_list.count, 1);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_bit_error_rate_list_null_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 0;
+    attr.value.prbs_ber_list.list = NULL;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 0);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_ber_list.count, 0);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list, nullptr);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_status_list_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_rx_status_t lanes[3];
+    lanes[0].lane = 0;
+    lanes[0].rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+    lanes[1].lane = 1;
+    lanes[1].rx_status = SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS;
+    lanes[2].lane = 2;
+    lanes[2].rx_status = SAI_PORT_PRBS_RX_STATUS_NOT_LOCKED;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+    attr.value.prbs_rx_status_list.count = 3;
+    attr.value.prbs_rx_status_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 3);
+    ASSERT_TRUE(j["list"].is_array());
+    EXPECT_EQ(j["list"].size(), 3);
+    EXPECT_EQ(j["list"][0]["lane"], "0");
+    EXPECT_EQ(j["list"][0]["rx_status"], "SAI_PORT_PRBS_RX_STATUS_OK");
+    EXPECT_EQ(j["list"][1]["lane"], "1");
+    EXPECT_EQ(j["list"][1]["rx_status"], "SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS");
+    EXPECT_EQ(j["list"][2]["lane"], "2");
+    EXPECT_EQ(j["list"][2]["rx_status"], "SAI_PORT_PRBS_RX_STATUS_NOT_LOCKED");
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.count, 3);
+    ASSERT_NE(attr2.value.prbs_rx_status_list.list, nullptr);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[0].lane, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[0].rx_status, SAI_PORT_PRBS_RX_STATUS_OK);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[1].lane, 1);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[1].rx_status, SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[2].lane, 2);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[2].rx_status, SAI_PORT_PRBS_RX_STATUS_NOT_LOCKED);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_status_list_countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_rx_status_t lanes[2];
+    lanes[0].lane = 0;
+    lanes[0].rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+    lanes[1].lane = 1;
+    lanes[1].rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+    attr.value.prbs_rx_status_list.count = 2;
+    attr.value.prbs_rx_status_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, true);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 2);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, true);
+
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.count, 2);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_status_list_null_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+    attr.value.prbs_rx_status_list.count = 0;
+    attr.value.prbs_rx_status_list.list = NULL;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 0);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.count, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list, nullptr);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
 }
 
 TEST(SaiSerialize, sai_serialize_taps_list)

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -244,17 +244,12 @@ TEST(SaiSerialize, sai_serialize_attr_value)
             case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST:
             case SAI_ATTR_VALUE_TYPE_FABRIC_PORT_REACHABILITY:
-            case SAI_ATTR_VALUE_TYPE_PRBS_RX_STATE:
             case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
             case SAI_ATTR_VALUE_TYPE_TLV_LIST:
             case SAI_ATTR_VALUE_TYPE_MAP_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
             case SAI_ATTR_VALUE_TYPE_ACL_CHAIN_LIST:
             case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
-            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATUS_LIST:
-            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_RX_STATE_LIST:
-            case SAI_ATTR_VALUE_TYPE_PRBS_BIT_ERROR_RATE:
-            case SAI_ATTR_VALUE_TYPE_PRBS_PER_LANE_BIT_ERROR_RATE_LIST:
                 continue;
 
             default:
@@ -1805,6 +1800,402 @@ TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_nul
     EXPECT_EQ(deserialized_data[0].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED);
 
     sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_rx_state_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_RX_STATE);
+    ASSERT_NE(meta, nullptr);
+    attr.id = SAI_PORT_ATTR_PRBS_RX_STATE;
+
+    attr.value.rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS;
+    attr.value.rx_state.error_count = 42;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["rx_status"], "SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS");
+    EXPECT_EQ(j["error_count"], "42");
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_RX_STATE;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.rx_state.rx_status, SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS);
+    EXPECT_EQ(attr2.value.rx_state.error_count, 42);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_state_list_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_rx_state_t lanes[2];
+    lanes[0].lane = 0;
+    lanes[0].rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+    lanes[0].rx_state.error_count = 0;
+    lanes[1].lane = 1;
+    lanes[1].rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS;
+    lanes[1].rx_state.error_count = 7;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+    attr.value.prbs_rx_state_list.count = 2;
+    attr.value.prbs_rx_state_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 2);
+    ASSERT_TRUE(j["list"].is_array());
+    EXPECT_EQ(j["list"].size(), 2);
+    EXPECT_EQ(j["list"][0]["lane"], "0");
+    EXPECT_TRUE(j["list"][0]["rx_state"].is_object());
+    EXPECT_EQ(j["list"][1]["lane"], "1");
+    EXPECT_TRUE(j["list"][1]["rx_state"].is_object());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.count, 2);
+    ASSERT_NE(attr2.value.prbs_rx_state_list.list, nullptr);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[0].lane, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[0].rx_state.rx_status, SAI_PORT_PRBS_RX_STATUS_OK);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[0].rx_state.error_count, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[1].lane, 1);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[1].rx_state.rx_status, SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list[1].rx_state.error_count, 7);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_state_list_countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_rx_state_t lanes[2];
+    lanes[0].lane = 0;
+    lanes[0].rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+    lanes[0].rx_state.error_count = 0;
+    lanes[1].lane = 1;
+    lanes[1].rx_state.rx_status = SAI_PORT_PRBS_RX_STATUS_NOT_LOCKED;
+    lanes[1].rx_state.error_count = 0;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+    attr.value.prbs_rx_state_list.count = 2;
+    attr.value.prbs_rx_state_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, true);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 2);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, true);
+
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.count, 2);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_state_list_null_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+    attr.value.prbs_rx_state_list.count = 0;
+    attr.value.prbs_rx_state_list.list = NULL;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 0);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATE_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.count, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_state_list.list, nullptr);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_bit_error_rate_list_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_bit_error_rate_t lanes[2];
+    lanes[0].lane = 0;
+    lanes[0].ber.mantissa = 123;
+    lanes[0].ber.exponent = 9;
+    lanes[1].lane = 1;
+    lanes[1].ber.mantissa = 456;
+    lanes[1].ber.exponent = 12;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 2;
+    attr.value.prbs_ber_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 2);
+    ASSERT_TRUE(j["list"].is_array());
+    EXPECT_EQ(j["list"].size(), 2);
+    EXPECT_EQ(j["list"][0]["lane"], "0");
+    EXPECT_TRUE(j["list"][0]["ber"].is_object());
+    EXPECT_EQ(j["list"][1]["lane"], "1");
+    EXPECT_TRUE(j["list"][1]["ber"].is_object());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_ber_list.count, 2);
+    ASSERT_NE(attr2.value.prbs_ber_list.list, nullptr);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[0].lane, 0);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[0].ber.mantissa, 123);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[0].ber.exponent, 9);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[1].lane, 1);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[1].ber.mantissa, 456);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list[1].ber.exponent, 12);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_bit_error_rate_list_countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_bit_error_rate_t lanes[1];
+    lanes[0].lane = 0;
+    lanes[0].ber.mantissa = 99;
+    lanes[0].ber.exponent = 3;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 1;
+    attr.value.prbs_ber_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, true);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 1);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, true);
+
+    EXPECT_EQ(attr2.value.prbs_ber_list.count, 1);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_bit_error_rate_list_null_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+    attr.value.prbs_ber_list.count = 0;
+    attr.value.prbs_ber_list.list = NULL;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 0);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_BER_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_ber_list.count, 0);
+    EXPECT_EQ(attr2.value.prbs_ber_list.list, nullptr);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_status_list_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_rx_status_t lanes[3];
+    lanes[0].lane = 0;
+    lanes[0].rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+    lanes[1].lane = 1;
+    lanes[1].rx_status = SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS;
+    lanes[2].lane = 2;
+    lanes[2].rx_status = SAI_PORT_PRBS_RX_STATUS_NOT_LOCKED;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+    attr.value.prbs_rx_status_list.count = 3;
+    attr.value.prbs_rx_status_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 3);
+    ASSERT_TRUE(j["list"].is_array());
+    EXPECT_EQ(j["list"].size(), 3);
+    EXPECT_EQ(j["list"][0]["lane"], "0");
+    EXPECT_EQ(j["list"][0]["rx_status"], "SAI_PORT_PRBS_RX_STATUS_OK");
+    EXPECT_EQ(j["list"][1]["lane"], "1");
+    EXPECT_EQ(j["list"][1]["rx_status"], "SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS");
+    EXPECT_EQ(j["list"][2]["lane"], "2");
+    EXPECT_EQ(j["list"][2]["rx_status"], "SAI_PORT_PRBS_RX_STATUS_NOT_LOCKED");
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.count, 3);
+    ASSERT_NE(attr2.value.prbs_rx_status_list.list, nullptr);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[0].lane, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[0].rx_status, SAI_PORT_PRBS_RX_STATUS_OK);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[1].lane, 1);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[1].rx_status, SAI_PORT_PRBS_RX_STATUS_LOCK_WITH_ERRORS);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[2].lane, 2);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list[2].rx_status, SAI_PORT_PRBS_RX_STATUS_NOT_LOCKED);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_status_list_countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_prbs_per_lane_rx_status_t lanes[2];
+    lanes[0].lane = 0;
+    lanes[0].rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+    lanes[1].lane = 1;
+    lanes[1].rx_status = SAI_PORT_PRBS_RX_STATUS_OK;
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+    attr.value.prbs_rx_status_list.count = 2;
+    attr.value.prbs_rx_status_list.list = lanes;
+
+    auto s = sai_serialize_attr_value(*meta, attr, true);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 2);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, true);
+
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.count, 2);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_per_lane_rx_status_list_null_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST);
+    ASSERT_NE(meta, nullptr);
+
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+    attr.value.prbs_rx_status_list.count = 0;
+    attr.value.prbs_rx_status_list.list = NULL;
+
+    auto s = sai_serialize_attr_value(*meta, attr, false);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["count"], 0);
+    EXPECT_TRUE(j["list"].is_null());
+
+    sai_attribute_t attr2;
+    memset(&attr2, 0, sizeof(attr2));
+    attr2.id = SAI_PORT_ATTR_PRBS_PER_LANE_RX_STATUS_LIST;
+
+    sai_deserialize_attr_value(s, *meta, attr2, false);
+
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.count, 0);
+    EXPECT_EQ(attr2.value.prbs_rx_status_list.list, nullptr);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr2);
 }
 
 TEST(SaiSerialize, sai_serialize_taps_list)

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -2918,3 +2918,133 @@ TEST(SaiDeserialize, sai_deserialize_enum)
     sai_deserialize_enum("SAI_STATS_MODE_READ|SAI_STATS_MODE_WRITE", emd, value);
     EXPECT_EQ(value, SAI_STATS_MODE_READ);
 }
+
+TEST(SaiSerialize, sai_serialize_prbs_bit_error_rate_roundtrip)
+{
+    SWSS_LOG_ENTER();
+
+    sai_prbs_bit_error_rate_t ber;
+    ber.mantissa = 123;
+    ber.exponent = 9;
+
+    auto s = sai_serialize_prbs_bit_error_rate(ber);
+
+    json j = json::parse(s);
+    EXPECT_EQ(j["mantissa"], "123");
+    EXPECT_EQ(j["exponent"], "9");
+
+    sai_prbs_bit_error_rate_t ber2;
+    memset(&ber2, 0, sizeof(ber2));
+    sai_deserialize_prbs_bit_error_rate(s, ber2);
+
+    EXPECT_EQ(ber2.mantissa, 123u);
+    EXPECT_EQ(ber2.exponent, 9u);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_rx_status_list_count_overflow_throws)
+{
+    SWSS_LOG_ENTER();
+
+    sai_prbs_per_lane_rx_status_t dummy[1] = {};
+    sai_prbs_per_lane_rx_status_list_t list;
+    list.count = 257;
+    list.list = dummy;
+
+    EXPECT_THROW(sai_serialize_prbs_per_lane_rx_status_list(list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_rx_state_list_count_overflow_throws)
+{
+    SWSS_LOG_ENTER();
+
+    sai_prbs_per_lane_rx_state_t dummy[1] = {};
+    sai_prbs_per_lane_rx_state_list_t list;
+    list.count = 257;
+    list.list = dummy;
+
+    EXPECT_THROW(sai_serialize_prbs_per_lane_rx_state_list(list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_serialize_prbs_ber_list_count_overflow_throws)
+{
+    SWSS_LOG_ENTER();
+
+    sai_prbs_per_lane_bit_error_rate_t dummy[1] = {};
+    sai_prbs_per_lane_bit_error_rate_list_t list;
+    list.count = 257;
+    list.list = dummy;
+
+    EXPECT_THROW(sai_serialize_prbs_per_lane_bit_error_rate_list(list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_deserialize_prbs_rx_status_list_count_mismatch_throws)
+{
+    SWSS_LOG_ENTER();
+
+    // Build JSON with count=2 but only 1 entry in the list to trigger count mismatch
+    json j;
+    j["count"] = 2;
+    json arr = json::array();
+    json item;
+    item["lane"] = "0";
+    item["rx_status"] = "SAI_PORT_PRBS_RX_STATUS_OK";
+    arr.push_back(item);
+    j["list"] = arr;
+
+    std::string s = j.dump();
+
+    sai_prbs_per_lane_rx_status_list_t list;
+    memset(&list, 0, sizeof(list));
+
+    EXPECT_THROW(sai_deserialize_prbs_per_lane_rx_status_list(s, list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_deserialize_prbs_rx_state_list_count_mismatch_throws)
+{
+    SWSS_LOG_ENTER();
+
+    // Build JSON with count=2 but only 1 entry in the list to trigger count mismatch
+    json j;
+    j["count"] = 2;
+    json arr = json::array();
+    json item;
+    item["lane"] = "0";
+    json rx_state;
+    rx_state["rx_status"] = "SAI_PORT_PRBS_RX_STATUS_OK";
+    rx_state["error_count"] = "0";
+    item["rx_state"] = rx_state;
+    arr.push_back(item);
+    j["list"] = arr;
+
+    std::string s = j.dump();
+
+    sai_prbs_per_lane_rx_state_list_t list;
+    memset(&list, 0, sizeof(list));
+
+    EXPECT_THROW(sai_deserialize_prbs_per_lane_rx_state_list(s, list, false), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_deserialize_prbs_ber_list_count_mismatch_throws)
+{
+    SWSS_LOG_ENTER();
+
+    // Build JSON with count=2 but only 1 entry in the list to trigger count mismatch
+    json j;
+    j["count"] = 2;
+    json arr = json::array();
+    json item;
+    item["lane"] = "0";
+    json ber;
+    ber["mantissa"] = "123";
+    ber["exponent"] = "9";
+    item["ber"] = ber;
+    arr.push_back(item);
+    j["list"] = arr;
+
+    std::string s = j.dump();
+
+    sai_prbs_per_lane_bit_error_rate_list_t list;
+    memset(&list, 0, sizeof(list));
+
+    EXPECT_THROW(sai_deserialize_prbs_per_lane_bit_error_rate_list(s, list, false), std::runtime_error);
+}


### PR DESCRIPTION
This commit implements serialization and deserialization support for SAI 1.18 PRBS (Pseudo-Random Binary Sequence) per-lane diagnostic attributes in the SAI Redis metadata layer.