### PR TITLE
[meta] Skip validation for mandatory deprecated attributes in Meta.

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -3896,6 +3896,13 @@ sai_status_t Meta::meta_generic_validation_create(
             continue;
         }
 
+        if (md.isdeprecated)
+        {
+            // skip deprecated attributes
+            META_LOG_NOTICE(md, "attribute is mandatory but deprecated, skipping validation");
+            continue;
+        }
+
         const auto &it = attrs.find(md.attrid);
 
         if (it == attrs.end())


### PR DESCRIPTION
What i did:
Updated the generic object creation validation logic in Meta.cpp to check the isdeprecated flag of SAI attributes. If an attribute is marked as both mandatory and deprecated, skips the requirement check instead of potentially failing the operation.

Why i did:
In SAI, some legacy attributes are marked as mandatory for backward compatibility but are simultaneously deprecated in favor of newer mechanisms. Enforcing mandatory checks on deprecated attributes can cause unnecessary validation failures in orchestration agents that have already migrated to modern attributes, hindering smooth transitions and system stability.

How i did:
Verified the persistence mechanism through the local build and UT.