### PR TITLE
[vslib] Add LLR profile attribute capability and port stats

### DIFF
--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -55,6 +55,7 @@ IPv
 Inseg
 KEYs
 LLC
+LLR
 LOGLEVEL
 LOOPBACK
 MACsec
@@ -136,6 +137,7 @@ ATTR
 AttrHash
 attrid
 attridname
+attribs
 attrs
 attrvalue
 BCM

--- a/unittest/vslib/TestSwitchStateBase.cpp
+++ b/unittest/vslib/TestSwitchStateBase.cpp
@@ -454,7 +454,7 @@ TEST(SwitchStateBase, query_stats_st_capability)
 
     sai_stat_st_capability_list_t stats_capability;
     std::vector<sai_stat_st_capability_t> buffer;
-    buffer.resize(96);
+    buffer.resize(128);
     stats_capability.count = static_cast<uint32_t>(buffer.size());
     stats_capability.list = buffer.data();
 
@@ -489,4 +489,96 @@ TEST(SwitchStateBase, getObjectTypeAvailability_standalone)
     // Test that default implementation logs warning and returns 0
     uint64_t availability = ss.getObjectTypeAvailability(SAI_OBJECT_TYPE_MY_SID_ENTRY);
     EXPECT_EQ(availability, 0);
+}
+
+// --- LLR profile attribute capability tests ---
+
+// Verify CREATE_ONLY attributes (create=true, set=false, get=true)
+TEST_F(SwitchStateBaseTest, queryLlrProfileCapability_CreateOnly)
+{
+    sai_attr_capability_t cap;
+
+    EXPECT_EQ(m_ss->queryAttributeCapability(m_swid,
+                  SAI_OBJECT_TYPE_PORT_LLR_PROFILE,
+                  SAI_PORT_LLR_PROFILE_ATTR_OUTSTANDING_FRAMES_MAX,
+                  &cap),
+              SAI_STATUS_SUCCESS);
+    EXPECT_TRUE(cap.create_implemented);
+    EXPECT_FALSE(cap.set_implemented);
+    EXPECT_TRUE(cap.get_implemented);
+
+    EXPECT_EQ(m_ss->queryAttributeCapability(m_swid,
+                  SAI_OBJECT_TYPE_PORT_LLR_PROFILE,
+                  SAI_PORT_LLR_PROFILE_ATTR_OUTSTANDING_BYTES_MAX,
+                  &cap),
+              SAI_STATUS_SUCCESS);
+    EXPECT_TRUE(cap.create_implemented);
+    EXPECT_FALSE(cap.set_implemented);
+    EXPECT_TRUE(cap.get_implemented);
+}
+
+// Verify set not supported attributes (create=true, set=false, get=true)
+TEST_F(SwitchStateBaseTest, queryLlrProfileCapability_NoSet)
+{
+    sai_attr_capability_t cap;
+
+    EXPECT_EQ(m_ss->queryAttributeCapability(m_swid,
+                  SAI_OBJECT_TYPE_PORT_LLR_PROFILE,
+                  SAI_PORT_LLR_PROFILE_ATTR_REPLAY_COUNT_MAX,
+                  &cap),
+              SAI_STATUS_SUCCESS);
+    EXPECT_TRUE(cap.create_implemented);
+    EXPECT_FALSE(cap.set_implemented);
+    EXPECT_TRUE(cap.get_implemented);
+
+    EXPECT_EQ(m_ss->queryAttributeCapability(m_swid,
+                  SAI_OBJECT_TYPE_PORT_LLR_PROFILE,
+                  SAI_PORT_LLR_PROFILE_ATTR_PCS_LOST_TIMEOUT,
+                  &cap),
+              SAI_STATUS_SUCCESS);
+    EXPECT_TRUE(cap.create_implemented);
+    EXPECT_FALSE(cap.set_implemented);
+    EXPECT_TRUE(cap.get_implemented);
+}
+
+// Verify fully unsupported attribute (create=false, set=false, get=false)
+TEST_F(SwitchStateBaseTest, queryLlrProfileCapability_Unsupported)
+{
+    sai_attr_capability_t cap;
+
+    EXPECT_EQ(m_ss->queryAttributeCapability(m_swid,
+                  SAI_OBJECT_TYPE_PORT_LLR_PROFILE,
+                  SAI_PORT_LLR_PROFILE_ATTR_DATA_AGE_TIMEOUT,
+                  &cap),
+              SAI_STATUS_SUCCESS);
+    EXPECT_FALSE(cap.create_implemented);
+    EXPECT_FALSE(cap.set_implemented);
+    EXPECT_FALSE(cap.get_implemented);
+}
+
+// Verify fully supported CREATE_AND_SET attrs: create=true, set=true, get=true (default path)
+TEST_F(SwitchStateBaseTest, queryLlrProfileCapability_FullySupported)
+{
+    const std::vector<std::pair<sai_attr_id_t, std::string>> fully_supported_attrs = {
+        {SAI_PORT_LLR_PROFILE_ATTR_REPLAY_TIMER_MAX,       "REPLAY_TIMER_MAX"},
+        {SAI_PORT_LLR_PROFILE_ATTR_INIT_LLR_FRAME_ACTION,  "INIT_LLR_FRAME_ACTION"},
+        {SAI_PORT_LLR_PROFILE_ATTR_FLUSH_LLR_FRAME_ACTION, "FLUSH_LLR_FRAME_ACTION"},
+        {SAI_PORT_LLR_PROFILE_ATTR_RE_INIT_ON_FLUSH,       "RE_INIT_ON_FLUSH"},
+        {SAI_PORT_LLR_PROFILE_ATTR_CTLOS_TARGET_SPACING,   "CTLOS_TARGET_SPACING"},
+    };
+
+    for (const auto &p : fully_supported_attrs)
+    {
+        SCOPED_TRACE(p.second);
+        sai_attr_capability_t cap;
+
+        EXPECT_EQ(m_ss->queryAttributeCapability(m_swid,
+                      SAI_OBJECT_TYPE_PORT_LLR_PROFILE,
+                      p.first,
+                      &cap),
+                  SAI_STATUS_SUCCESS);
+        EXPECT_TRUE(cap.create_implemented);
+        EXPECT_TRUE(cap.set_implemented);
+        EXPECT_TRUE(cap.get_implemented);
+    }
 }

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -4461,6 +4461,32 @@ sai_status_t SwitchStateBase::queryAttributeCapability(
        return queryMacsecPostCapability(object_type, attr_capability);
     }
 
+    if (object_type == SAI_OBJECT_TYPE_PORT_LLR_PROFILE)
+    {
+        switch (attr_id)
+        {
+            // SAI Create-only and simulate set not implemented attribs.
+            case SAI_PORT_LLR_PROFILE_ATTR_OUTSTANDING_FRAMES_MAX:
+            case SAI_PORT_LLR_PROFILE_ATTR_OUTSTANDING_BYTES_MAX:
+            case SAI_PORT_LLR_PROFILE_ATTR_REPLAY_COUNT_MAX:
+            case SAI_PORT_LLR_PROFILE_ATTR_PCS_LOST_TIMEOUT:
+                attr_capability->create_implemented = true;
+                attr_capability->set_implemented    = false;
+                attr_capability->get_implemented    = true;
+                return SAI_STATUS_SUCCESS;
+
+            // Simulate attributes not implemented at all.
+            case SAI_PORT_LLR_PROFILE_ATTR_DATA_AGE_TIMEOUT:
+                attr_capability->create_implemented = false;
+                attr_capability->set_implemented    = false;
+                attr_capability->get_implemented    = false;
+                return SAI_STATUS_SUCCESS;
+
+            default:
+                break;
+        }
+    }
+
     attr_capability->create_implemented = true;
     attr_capability->set_implemented    = true;
     attr_capability->get_implemented    = true;
@@ -4606,7 +4632,29 @@ sai_status_t SwitchStateBase::queryPortStatsCapability(
         SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS,
         SAI_PORT_STAT_TRIM_PACKETS,
         SAI_PORT_STAT_DROPPED_TRIM_PACKETS,
-        SAI_PORT_STAT_TX_TRIM_PACKETS
+        SAI_PORT_STAT_TX_TRIM_PACKETS,
+        SAI_PORT_STAT_LLR_TX_INIT_CTL_OS,
+        SAI_PORT_STAT_LLR_TX_INIT_ECHO_CTL_OS,
+        SAI_PORT_STAT_LLR_TX_ACK_CTL_OS,
+        SAI_PORT_STAT_LLR_TX_NACK_CTL_OS,
+        SAI_PORT_STAT_LLR_TX_DISCARD,
+        SAI_PORT_STAT_LLR_TX_OK,
+        SAI_PORT_STAT_LLR_TX_POISONED,
+        SAI_PORT_STAT_LLR_TX_REPLAY,
+        SAI_PORT_STAT_LLR_RX_INIT_CTL_OS,
+        SAI_PORT_STAT_LLR_RX_INIT_ECHO_CTL_OS,
+        SAI_PORT_STAT_LLR_RX_ACK_CTL_OS,
+        SAI_PORT_STAT_LLR_RX_NACK_CTL_OS,
+        SAI_PORT_STAT_LLR_RX_ACK_NACK_SEQ_ERROR,
+        SAI_PORT_STAT_LLR_RX_OK,
+        SAI_PORT_STAT_LLR_RX_POISONED,
+        SAI_PORT_STAT_LLR_RX_BAD,
+        SAI_PORT_STAT_LLR_RX_EXPECTED_SEQ_GOOD,
+        SAI_PORT_STAT_LLR_RX_EXPECTED_SEQ_POISONED,
+        SAI_PORT_STAT_LLR_RX_EXPECTED_SEQ_BAD,
+        SAI_PORT_STAT_LLR_RX_MISSING_SEQ,
+        SAI_PORT_STAT_LLR_RX_DUPLICATE_SEQ,
+        SAI_PORT_STAT_LLR_RX_REPLAY
     };
 
     if (stats_capability->count < portStatList.size())


### PR DESCRIPTION
**Why I did**
HLD: https://github.com/sonic-net/SONiC/pull/2098

**What I did**

LLR profile attribute capabilty query:
- Add per-attribute capability handling for SAI_OBJECT_TYPE_PORT_LLR_PROFILE
- OUTSTANDING_FRAMES_MAX, OUTSTANDING_BYTES_MAX: create-only (set is false), mandatory profile attribute.
- REPLAY_COUNT_MAX, PCS_LOST_TIMEOUT: create-only (set is false)
- DATA_AGE_TIMEOUT: fully unsupported
- All other LLR profile attrs: fully supported (default path)

Stats capability:
- Add all LLR SAI_PORT_STAT_LLR_* counters to the VS supported stats list

**How I verified it**
Unit tests (TestSwitchStateBase.cpp):
- Added unit tests for the all the capability query support added.

**PR Dependencies:** None

Signed-off-by: Ravi Minnikanti <rminnikanti@marvell.com>