### PR TITLE
vpp: fix race condition causing syncd crash

### DIFF
--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1690,6 +1690,12 @@ int init_vpp_client()
         }
         dump_interface_table(vam);
 
+        /* Initialize the event queue before enabling any VPP event source,
+         * otherwise an early sw_interface_event from VPP can be dispatched
+         * to vl_api_sw_interface_event_t_handler -> vpp_ev_enqueue while
+         * vpp_evq_p is still NULL, causing a SIGSEGV. */
+        vpp_evq_init();
+
         vpp_acl_counters_enable_disable(true);
 
         /* Enable LACP punt/xc in linux-cp */
@@ -1712,7 +1718,6 @@ int init_vpp_client()
         /* Enable BFD multihop support in VPP */
         vpp_bfd_udp_enable_multihop();
 
-        vpp_evq_init();
         vpp_client_init = 1;
         return 0;
     } else {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes a race condition during init_switch causing syncd crash

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
We saw below core dump during init_switch.
```
#0  0x0000ffffb5c369d0 in vpp_ev_enqueue (ev=0xaaaabe182c50) at vpp/vppxlate/SaiVppXlate.c:397
#1  vl_api_sw_interface_event_t_handler (mp=<optimized out>) at vpp/vppxlate/SaiVppXlate.c:687
#2  0x0000ffffb5264470 in vl_msg_api_handler_no_free ()
   from /nobackup/yuega2/sonic-buildimage-cisco.202603.arctos-periodic-40135/syncd_dbg/rootfs/lib/aarch64-linux-gnu/libvlibapi.so.25.02.0
#3  0x0000ffffb5205648 in ?? ()
   from /nobackup/yuega2/sonic-buildimage-cisco.202603.arctos-periodic-40135/syncd_dbg/rootfs/lib/aarch64-linux-gnu/libvlibmemoryclient.so.25.02.0
#4  0x0000ffffb5c3cd54 in vpp_intf_events_enable_disable (enable=true) at vpp/vppxlate/SaiVppXlate.c:1839
#5  init_vpp_client () at vpp/vppxlate/SaiVppXlate.c:1704
#6  0x0000ffffb5c208bc in saivs::SwitchVpp::vpp_dp_initialize (this=this@entry=0xaaaabe17a3d0) at vpp/SwitchVppRif.cpp:468
#7  0x0000ffffb5c0508c in saivs::SwitchVpp::SwitchVpp (this=this@entry=0xaaaabe17a3d0, switch_id=switch_id@entry=141733920768, manager=..., config=..., 
    warmBootState=...) at vpp/SwitchVpp.cpp:44
```
This happened during init_switch right after vpp_intf_events_enable_disable, an event came in but event_queue had not been properly initialized.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
Move event queue initialization before enabling events from vpp.

#### How did you verify/test it?
Run sonic-mgmt via https://github.com/sonic-net/sonic-buildimage/pull/27039
#### Any platform specific information?
vpp specific
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
