### PR TITLE
vslib: handle VPP hostif link events by netdev name

### DIFF
--- a/vslib/SwitchStateBaseHostif.cpp
+++ b/vslib/SwitchStateBaseHostif.cpp
@@ -953,11 +953,11 @@ void SwitchStateBase::syncOnLinkMsg(
     auto portId = getPortIdFromIfName(ifname);
 
     /*
-     * Runtime netlink events can arrive for a Linux hostif name that is not in
-     * lanemap. VPP, for example, keeps lanemap keyed by hardware names such as
-     * etp1 while Linux CP reports events for the TAP name Ethernet1. Once the
-     * ifindex and hostif name are registered, accept the event without requiring
-     * the TAP name to also appear in lanemap.
+     * Runtime link events can arrive for a Linux hostif name that is absent
+     * from the lane map. Some switch models keep the lane map keyed by
+     * hardware names, while Linux reports events for the hostif name. Once the
+     * index and hostif name are registered, accept the event without requiring
+     * the hostif name to also appear in the lane map.
      */
     if (strncmp(ifname.c_str(), SAI_VS_VETH_PREFIX, sizeof(SAI_VS_VETH_PREFIX) - 1) != 0 &&
             portId == SAI_NULL_OBJECT_ID && !map->hasInterface(ifname))

--- a/vslib/SwitchStateBaseHostif.cpp
+++ b/vslib/SwitchStateBaseHostif.cpp
@@ -950,8 +950,17 @@ void SwitchStateBase::syncOnLinkMsg(
         return;
     }
 
+    auto portId = getPortIdFromIfName(ifname);
+
+    /*
+     * Runtime netlink events can arrive for a Linux hostif name that is not in
+     * lanemap. VPP, for example, keeps lanemap keyed by hardware names such as
+     * etp1 while Linux CP reports events for the TAP name Ethernet1. Once the
+     * ifindex and hostif name are registered, accept the event without requiring
+     * the TAP name to also appear in lanemap.
+     */
     if (strncmp(ifname.c_str(), SAI_VS_VETH_PREFIX, sizeof(SAI_VS_VETH_PREFIX) - 1) != 0 &&
-            !map->hasInterface(ifname))
+            portId == SAI_NULL_OBJECT_ID && !map->hasInterface(ifname))
     {
         SWSS_LOG_ERROR("skipping newlink for %s, name not found in map", ifname.c_str());
         return;
@@ -964,7 +973,11 @@ void SwitchStateBase::syncOnLinkMsg(
 
     auto state = (ifflags & IFF_LOWER_UP) ? SAI_PORT_OPER_STATUS_UP : SAI_PORT_OPER_STATUS_DOWN;
 
-    auto portId = getPortIdFromIfName(ifname);
+    if (portId == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("skipping newlink for %s, port id not found", ifname.c_str());
+        return;
+    }
 
     send_port_oper_status_notification(portId, state, false);
 }

--- a/vslib/vpp/SwitchVppHostif.cpp
+++ b/vslib/vpp/SwitchVppHostif.cpp
@@ -236,6 +236,9 @@ bool SwitchVpp::register_hostif_info(
         return false;
     }
 
+    setIfNameToPortId(tapname, port_id);
+    setPortIdToTapName(port_id, tapname);
+
     m_hostif_info_map[tapname] =
         std::make_shared<HostInterfaceInfo>(
                 ifindex,
@@ -245,7 +248,7 @@ bool SwitchVpp::register_hostif_info(
                 port_id,
                 m_switchConfig->m_eventQueue);
 
-    SWSS_LOG_INFO(
+    SWSS_LOG_NOTICE(
             "registered hostif info for %s, ifindex %d",
             tapname.c_str(),
             ifindex);
@@ -431,9 +434,6 @@ sai_status_t SwitchVpp::vs_create_hostif_tap_interface(
 
         return SAI_STATUS_FAILURE;
     }
-
-    setIfNameToPortId(name, obj_id);
-    setPortIdToTapName(obj_id, name);
 
     SWSS_LOG_INFO("created tap interface %s", name.c_str());
 

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -29,6 +29,48 @@ using namespace saivs;
 
 int SwitchVpp::currentMaxInstance = 0;
 
+namespace
+{
+    bool get_linux_intf_carrier_state(
+            _In_ const char *ifname,
+            _Out_ bool &link_up)
+    {
+        SWSS_LOG_ENTER();
+
+        std::string carrier_path = std::string("/sys/class/net/") + ifname + "/carrier";
+        std::ifstream carrier(carrier_path);
+
+        if (carrier.good())
+        {
+            int carrier_value = 0;
+            carrier >> carrier_value;
+
+            if (!carrier.fail())
+            {
+                link_up = carrier_value != 0;
+                return true;
+            }
+        }
+
+        std::string operstate_path = std::string("/sys/class/net/") + ifname + "/operstate";
+        std::ifstream operstate(operstate_path);
+
+        if (operstate.good())
+        {
+            std::string state;
+            operstate >> state;
+
+            if (!operstate.fail())
+            {
+                link_up = state == "up";
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 // TODO to cpp
 IpVrfInfo::IpVrfInfo(
     _In_ sai_object_id_t obj_id,
@@ -488,6 +530,20 @@ sai_status_t SwitchVpp::asyncIntfStateUpdate(const char *hwif_name, bool link_up
     if (port_oid == SAI_NULL_OBJECT_ID) {
         SWSS_LOG_NOTICE("Failed find port oid for tap interface %s. Ignore the update.", tap);
         return SAI_STATUS_SUCCESS;
+    }
+
+    if (link_up)
+    {
+        bool tap_link_up = false;
+
+        if (get_linux_intf_carrier_state(tap, tap_link_up) && !tap_link_up)
+        {
+            SWSS_LOG_NOTICE(
+                    "VPP interface %s reported UP, but Linux hostif %s carrier is down; reporting DOWN",
+                    hwif_name,
+                    tap);
+            link_up = false;
+        }
     }
 
     auto state = link_up ? SAI_PORT_OPER_STATUS_UP : SAI_PORT_OPER_STATUS_DOWN;


### PR DESCRIPTION
## Summary

Complete VPP hostif link-state handling when the Linux hostif/netdev name differs from the VPP hardware interface name.

## Changes

- Allow `syncOnLinkMsg()` to accept registered hostif netdev names even when the name is not present in lanemap.
- Populate hostif name-to-port mappings before inserting the hostif entry.
- Log VPP hostif registration at `NOTICE` level for live validation.
- Guard against stale VPP `UP` events overriding Linux hostif carrier-down state.