### PR TITLE
zmq: reset ZMQ_REQ socket when zmq_poll times out

### DIFF
--- a/lib/ZeroMQChannel.cpp
+++ b/lib/ZeroMQChannel.cpp
@@ -280,10 +280,24 @@ sai_status_t ZeroMQChannel::wait(
 
         if (rc == 0)
         {
-            SWSS_LOG_ERROR("zmq_poll timed out for: %s", command.c_str());
+            // REQ socket is now stuck in WAITING FOR REPLY state because
+            // zmq_send was done but zmq_recv did not complete. Close and
+            // recreate the socket to reset the state machine (Issue #26300).
 
-            // notice, at this point we could throw, since in REP/REQ pattern
-            // we are forced to use send/recv in that specific order
+            SWSS_LOG_ERROR("zmq_poll timed out for: %s, resetting REQ socket", command.c_str());
+
+            zmq_close(m_socket);
+
+            m_socket = zmq_socket(m_context, ZMQ_REQ);
+
+            int connect_rc = zmq_connect(m_socket, m_endpoint.c_str());
+
+            if (connect_rc != 0)
+            {
+                SWSS_LOG_THROW("failed to reconnect zmq endpoint %s after timeout, zmqerrno: %d",
+                        m_endpoint.c_str(),
+                        zmq_errno());
+            }
 
             return SAI_STATUS_FAILURE;
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-buildimage/issues/26300

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
Reset ZMQ_REQ socket when zmq_poll times out.

#### How did you verify/test it?
Leaving the socket in a bad state can cause can orchagent to crash with runtime_error when crmorch (or any orch) calls zmq_send() on it.

#### Any platform specific information?
Impacts only platforms that use zmq for orchagent -> syncd communication

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
``` 
- zmq_poll times out in wait() → logs the error and returns SAI_STATUS_FAILURE without receiving the response. This leaves the ZMQ REQ socket stuck in the "waiting for recv" state.
  
- The caller (orchagent CRM) logs the DASH_VNET failure, then continues to the next SAI operation.
  
- The next set() call tries zmq_send on the same REQ socket, but ZMQ's REQ/REP pattern enforces strict send→recv→send→recv ordering. Since the recv was never done after the previous send, zmq_send fails with EFSM (156384763 = ZMQ_EFSM — "Operation cannot be accomplished in current state").

- SWSS_LOG_THROW fires → std::runtime_error → orchagent crashes.
```