### PR TITLE
Add Timestamps for FEC Histogram Counters

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1131,6 +1131,8 @@ public:
             m_objectIdsMap.erase(iter);
         }
 
+        m_prevFecHistogramValues.erase(vid);
+
         // An object can be in both m_objectIdsMap and the bulk context
         // when bulk polling is supported by some counter prefixes but unsupported by some others
         if (!removeBulkStatsContext(vid) && log)
@@ -1146,6 +1148,10 @@ public:
     {
         SWSS_LOG_ENTER();
         sai_stats_mode_t effective_stats_mode = m_groupStatsMode;
+        // Wall-clock timestamp for FEC histogram counters (distinct from steady_clock used for framework collection timing)
+        auto fec_timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
         for (const auto &kv : m_objectIdsMap)
         {
             const auto &vid = kv.first;
@@ -1170,6 +1176,25 @@ public:
             {
                 values.emplace_back(serializeStat(statIds[i]), std::to_string(stats[i]));
             }
+
+            // Add timestamps for FEC histogram counters only when value has changed
+            for (size_t i = 0; i != statIds.size(); i++)
+            {
+                auto stat_id = static_cast<int>(statIds[i]);
+                if (stat_id >= SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S0 &&
+                    stat_id <= SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S15)
+                {
+                    auto &prevValues = m_prevFecHistogramValues[vid];
+                    auto prevIt = prevValues.find(stat_id);
+                    uint64_t currentVal = stats[i];
+                    if (prevIt == prevValues.end() || prevIt->second != currentVal)
+                    {
+                        values.emplace_back(serializeStat(statIds[i]) + "_TIMESTAMP", std::to_string(fec_timestamp));
+                        prevValues[stat_id] = currentVal;
+                    }
+                }
+            }
+
             countersTable.set(sai_serialize_object_id(vid), values, "");
         }
 
@@ -1355,6 +1380,10 @@ private:
 
         auto time_stamp = std::chrono::steady_clock::now().time_since_epoch().count();
 
+        // Wall-clock timestamp for FEC histogram counters (distinct from steady_clock above used for framework collection timing)
+        auto fec_timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
         std::vector<swss::FieldValueTuple> values;
         for (size_t i = 0; i < ctx.object_keys.size(); i++)
         {
@@ -1368,6 +1397,24 @@ private:
             for (size_t j = 0; j < ctx.counter_ids.size(); j++)
             {
                 values.emplace_back(serializeStat(ctx.counter_ids[j]), std::to_string(ctx.counters[i * ctx.counter_ids.size() + j]));
+            }
+
+            // Add timestamps for FEC histogram counters only when value has changed
+            for (size_t j = 0; j < ctx.counter_ids.size(); j++)
+            {
+                auto stat_id = static_cast<int>(ctx.counter_ids[j]);
+                if (stat_id >= SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S0 &&
+                    stat_id <= SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S15)
+                {
+                    auto &prevValues = m_prevFecHistogramValues[vid];
+                    auto prevIt = prevValues.find(stat_id);
+                    uint64_t currentVal = ctx.counters[i * ctx.counter_ids.size() + j];
+                    if (prevIt == prevValues.end() || prevIt->second != currentVal)
+                    {
+                        values.emplace_back(serializeStat(ctx.counter_ids[j]) + "_TIMESTAMP", std::to_string(fec_timestamp));
+                        prevValues[stat_id] = currentVal;
+                    }
+                }
             }
 
             countersTable.set(sai_serialize_object_id(vid), values, "");
@@ -1651,6 +1698,9 @@ protected:
     std::set<StatType> m_supportedBulkCounters;
     std::map<sai_object_id_t, std::shared_ptr<CounterIdsType>> m_objectIdsMap;
     std::map<std::vector<StatType>, std::shared_ptr<BulkContextType>> m_bulkContexts;
+
+    // Track previous FEC histogram counter values per VID+stat to only update timestamps on change
+    std::map<sai_object_id_t, std::map<int, uint64_t>> m_prevFecHistogramValues;
 };
 
 /**


### PR DESCRIPTION
Track per-VID FEC histogram counter values and append _TIMESTAMP fields (epoch milliseconds) to counter table entries when values change. This enables operators to determine the freshness of each FEC codeword error bucket. Implemented in both non-bulk (collectData) and bulk (bulkCollectData) collection paths.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
FEC histogram counters (S0–S15) are polled periodically by FlexCounter, but users have no way to know when a given bin value last changed. Adding per-bin timestamps lets operator determine the freshness of each FEC codeword error bucket.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

-  In FlexCounter.cpp, added a per-VID map (m_prevFecHistogramValues) that tracks the last-seen value of each FEC histogram stat (S0–S15).
- In both the non-bulk (collectData) and bulk (bulkCollectData) collection paths, after collecting counter values, check whether each FEC histogram bin has changed since the last poll.
- If a bin value has changed (or is seen for the first time), append a _TIMESTAMP field with the current epoch time in milliseconds to the counter table entry.
- Clean up the tracking map when an object is removed (removeObject).

#### How did you verify/test it?
```
admin@device:~$ show int counters fec-histogram Ethernet504
Symbol Errors Per Codeword       Codewords  Last Updated
----------------------------  ------------  -----------------------
BIN0                          314158685800  2026-03-26 01:39:56
BIN1                           22519111278  2026-03-26 01:39:56
BIN2                            1240501695  2026-03-26 01:39:56
BIN3                              54230751  2026-03-26 01:39:56
BIN4                               2117541  2026-03-26 01:39:56
BIN5                                 76776  2026-03-26 01:39:56
BIN6                                  2789  2026-03-26 01:39:56
BIN7                                    89  2026-03-26 01:38:56
BIN8                                    10  2026-03-26 01:37:56
BIN9                                     0  2026-03-26 01:21:39
BIN10                                    0  2026-03-26 01:21:39
BIN11                                    0  2026-03-26 01:21:39
BIN12                                    0  2026-03-26 01:21:39
BIN13                                    0  2026-03-26 01:21:39
BIN14                                    0  2026-03-26 01:21:39
BIN15                                    0  2026-03-26 01:21:39
```

```
root@blkt158:/home/admin# show int counters fec-histogram Ethernet440 --relative-timestamp
Symbol Errors Per Codeword      Codewords  Last Updated         Relative Time
----------------------------  -----------  -------------------  ---------------
BIN0                          13131172045  2026-04-16 16:03:04  8 seconds ago
BIN1                              1596328  2026-04-16 16:03:04  8 seconds ago
BIN2                                21674  2026-04-16 16:03:04  8 seconds ago
BIN3                                    6  2026-04-16 16:03:04  8 seconds ago
BIN4                                    0  2026-04-16 16:02:06  1 minute ago
BIN5                                    0  2026-04-16 16:02:06  1 minute ago
BIN6                                    0  2026-04-16 16:02:06  1 minute ago
BIN7                                    0  2026-04-16 16:02:06  1 minute ago
BIN8                                    0  2026-04-16 16:02:06  1 minute ago
BIN9                                    0  2026-04-16 16:02:06  1 minute ago
BIN10                                   0  2026-04-16 16:02:06  1 minute ago
BIN11                                   0  2026-04-16 16:02:06  1 minute ago
BIN12                                   0  2026-04-16 16:02:06  1 minute ago
BIN13                                   0  2026-04-16 16:02:06  1 minute ago
BIN14                                   0  2026-04-16 16:02:06  1 minute ago
BIN15                                   0  2026-04-16 16:02:06  1 minute ago
```

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
