### PR TITLE
[vpp] Fix LAG subinterface hwif name resolution

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -934,6 +934,13 @@ namespace saivs
                     _Out_ uint32_t *vpp_rule_base_index,
                     _Out_ uint32_t *num_rules);
 
+            const char* vpp_resolve_parent_hwif(
+                    _In_ sai_object_type_t ot,
+                    _In_ uint32_t bond_id,
+                    _In_ const char *tap_name,
+                    _Out_ char *buf,
+                    _In_ size_t buflen);
+
             bool vpp_get_hwif_name (
                     _In_ sai_object_id_t object_id,
                     _In_ uint32_t vlan_id,

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1583,7 +1583,15 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
         snprintf(host_subifname, sizeof(host_subifname), "%s.%u", dev, vlan_id);
 
         /* The host(tap) subinterface is also created as part of the vpp subinterface creation */
-        create_sub_interface(tap_to_hwif_name(dev), vlan_id, vlan_id);
+        const char *parent_hwif;
+        char hw_subif_parent[32];
+        if (ot == SAI_OBJECT_TYPE_LAG) {
+            snprintf(hw_subif_parent, sizeof(hw_subif_parent), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
+            parent_hwif = hw_subif_parent;
+        } else {
+            parent_hwif = tap_to_hwif_name(dev);
+        }
+        create_sub_interface(parent_hwif, vlan_id, vlan_id);
 
         /* Get new list of physical interfaces from VS */
         refresh_interfaces_list();
@@ -1869,7 +1877,18 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
     uint16_t vlan_id = attr.value.u16;
 
     std::string if_name;
-    bool found = getTapNameFromPortId(obj_id, if_name);
+    platform_bond_info_t bond_info;
+    bool found;
+    if (ot == SAI_OBJECT_TYPE_LAG) {
+        status = get_lag_bond_info(obj_id, bond_info);
+        if (status != SAI_STATUS_SUCCESS) {
+            return status;
+        }
+        if_name = std::string(PORTCHANNEL_PREFIX) + std::to_string(bond_info.id);
+        found = true;
+    } else {
+        found = getTapNameFromPortId(obj_id, if_name);
+    }
     if (found == false)
     {
         SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(obj_id).c_str());
@@ -1878,7 +1897,15 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
 
     const char *dev = if_name.c_str();
 
-    delete_sub_interface(tap_to_hwif_name(dev), vlan_id);
+    const char *parent_hwif;
+    char hw_del_parent[32];
+    if (ot == SAI_OBJECT_TYPE_LAG) {
+        snprintf(hw_del_parent, sizeof(hw_del_parent), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
+        parent_hwif = hw_del_parent;
+    } else {
+        parent_hwif = tap_to_hwif_name(dev);
+    }
+    delete_sub_interface(parent_hwif, vlan_id);
     /* Get new list of physical interfaces from VS */
     refresh_interfaces_list();
 

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -343,6 +343,9 @@ bool SwitchVpp::vpp_get_hwif_name (
 {
     SWSS_LOG_ENTER();
 
+    const char *hwifname;
+    char hw_bondifname[32];
+
     if (objectTypeQuery(object_id) == SAI_OBJECT_TYPE_LAG) {
         platform_bond_info_t bond_info;
         sai_status_t status = get_lag_bond_info(object_id, bond_info);
@@ -350,21 +353,22 @@ bool SwitchVpp::vpp_get_hwif_name (
         {
             return false;
         }
-        ifname = std::string(BONDETHERNET_PREFIX) + std::to_string(bond_info.id);
-        return true;
+        snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
+        hwifname = hw_bondifname;
+    } else {
+        std::string if_name;
+        bool found = getTapNameFromPortId(object_id, if_name);
+
+        if (found == false)
+        {
+            SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(object_id).c_str());
+            return false;
+        }
+        hwifname = tap_to_hwif_name(if_name.c_str());
     }
 
-    std::string if_name;
-    bool found = getTapNameFromPortId(object_id, if_name);
 
-    if (found == false)
-    {
-        SWSS_LOG_NOTICE("host interface for port id %s not found", sai_serialize_object_id(object_id).c_str());
-        return false;
-    }
-
-    const char *hwifname = tap_to_hwif_name(if_name.c_str());
-    char hw_subifname[32];
+    char hw_subifname[64];
     const char *hw_ifname;
 
     if (vlan_id) {

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -353,7 +353,7 @@ bool SwitchVpp::vpp_get_hwif_name (
         {
             return false;
         }
-        snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
+        snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%u", BONDETHERNET_PREFIX, bond_info.id);
         hwifname = hw_bondifname;
     } else {
         std::string if_name;
@@ -1590,7 +1590,7 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
         const char *parent_hwif;
         char hw_subif_parent[32];
         if (ot == SAI_OBJECT_TYPE_LAG) {
-            snprintf(hw_subif_parent, sizeof(hw_subif_parent), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
+            snprintf(hw_subif_parent, sizeof(hw_subif_parent), "%s%u", BONDETHERNET_PREFIX, bond_info.id);
             parent_hwif = hw_subif_parent;
         } else {
             parent_hwif = tap_to_hwif_name(dev);
@@ -1904,7 +1904,7 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
     const char *parent_hwif;
     char hw_del_parent[32];
     if (ot == SAI_OBJECT_TYPE_LAG) {
-        snprintf(hw_del_parent, sizeof(hw_del_parent), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
+        snprintf(hw_del_parent, sizeof(hw_del_parent), "%s%u", BONDETHERNET_PREFIX, bond_info.id);
         parent_hwif = hw_del_parent;
     } else {
         parent_hwif = tap_to_hwif_name(dev);

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -343,7 +343,7 @@ bool SwitchVpp::vpp_get_hwif_name (
 {
     SWSS_LOG_ENTER();
 
-    const char *hwifname;
+    const char *hwifname = nullptr;
     char hw_bondifname[32];
 
     if (objectTypeQuery(object_id) == SAI_OBJECT_TYPE_LAG) {
@@ -367,6 +367,7 @@ bool SwitchVpp::vpp_get_hwif_name (
         hwifname = tap_to_hwif_name(if_name.c_str());
     }
 
+    if (!hwifname) return false;
 
     char hw_subifname[64];
     const char *hw_ifname;
@@ -1888,7 +1889,7 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
         if (status != SAI_STATUS_SUCCESS) {
             return status;
         }
-        if_name = std::string(PORTCHANNEL_PREFIX) + std::to_string(bond_info.id);
+        if_name = std::string(BONDETHERNET_PREFIX) + std::to_string(bond_info.id);
         found = true;
     } else {
         found = getTapNameFromPortId(obj_id, if_name);

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -336,6 +336,22 @@ void SwitchVpp::vpp_intf_remove_prefix_entry (const std::string& intf_name)
     m_intf_prefix_map.erase(it);
 }
 
+const char* SwitchVpp::vpp_resolve_parent_hwif(
+      _In_ sai_object_type_t ot,
+      _In_ uint32_t bond_id,
+      _In_ const char *tap_name,
+      _Out_ char *buf,
+      _In_ size_t buflen)
+{
+    SWSS_LOG_ENTER();
+
+    if (ot == SAI_OBJECT_TYPE_LAG) {
+        snprintf(buf, buflen, "%s%d", BONDETHERNET_PREFIX, bond_id);
+        return buf;
+    }
+    return tap_to_hwif_name(tap_name);
+}
+
 bool SwitchVpp::vpp_get_hwif_name (
       _In_ sai_object_id_t object_id,
       _In_ uint32_t vlan_id,
@@ -1587,14 +1603,8 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
         snprintf(host_subifname, sizeof(host_subifname), "%s.%u", dev, vlan_id);
 
         /* The host(tap) subinterface is also created as part of the vpp subinterface creation */
-        const char *parent_hwif;
         char hw_subif_parent[32];
-        if (ot == SAI_OBJECT_TYPE_LAG) {
-            snprintf(hw_subif_parent, sizeof(hw_subif_parent), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
-            parent_hwif = hw_subif_parent;
-        } else {
-            parent_hwif = tap_to_hwif_name(dev);
-        }
+        const char *parent_hwif = vpp_resolve_parent_hwif(ot, bond_info.id, dev, hw_subif_parent, sizeof(hw_subif_parent));
         create_sub_interface(parent_hwif, vlan_id, vlan_id);
 
         /* Get new list of physical interfaces from VS */
@@ -1623,14 +1633,8 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
 
     vpp_add_ip_vrf(vrf_obj_id, vrf_id);
     if (ret == 0 && vrf_id != 0) {
-	const char *hwif_name;
 	char hw_bondifname[32];
-	if (ot == SAI_OBJECT_TYPE_LAG) {
-	    snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
-	    hwif_name = hw_bondifname;
-	} else {
-	    hwif_name = tap_to_hwif_name(dev);
-	}
+	const char *hwif_name = vpp_resolve_parent_hwif(ot, bond_info.id, dev, hw_bondifname, sizeof(hw_bondifname));
 	SWSS_LOG_NOTICE("Setting interface vrf on hwif_name %s", hwif_name);
 	set_interface_vrf(hwif_name, vlan_id, vrf_id, false);
     }
@@ -1786,14 +1790,8 @@ sai_status_t SwitchVpp::vpp_router_interface_remove_vrf(
 
     linux_ifname = if_name.c_str();
 
-    const char *hwif_name;
     char hw_bondifname[32];
-    if (objectTypeQuery(obj_id) == SAI_OBJECT_TYPE_LAG) {
-        snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
-        hwif_name = hw_bondifname;
-    } else {
-        hwif_name = tap_to_hwif_name(if_name.c_str());
-    }
+    const char *hwif_name = vpp_resolve_parent_hwif(objectTypeQuery(obj_id), bond_info.id, if_name.c_str(), hw_bondifname, sizeof(hw_bondifname));
 
     SWSS_LOG_NOTICE("Resetting to default vrf for interface %s, %s", linux_ifname, hwif_name);
 
@@ -1901,14 +1899,8 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
 
     const char *dev = if_name.c_str();
 
-    const char *parent_hwif;
     char hw_del_parent[32];
-    if (ot == SAI_OBJECT_TYPE_LAG) {
-        snprintf(hw_del_parent, sizeof(hw_del_parent), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
-        parent_hwif = hw_del_parent;
-    } else {
-        parent_hwif = tap_to_hwif_name(dev);
-    }
+    const char *parent_hwif = vpp_resolve_parent_hwif(ot, bond_info.id, dev, hw_del_parent, sizeof(hw_del_parent));
     delete_sub_interface(parent_hwif, vlan_id);
     /* Get new list of physical interfaces from VS */
     refresh_interfaces_list();


### PR DESCRIPTION
### Description of PR
LAG subinterfaces (PortChannelX.vlan) are non-functional on SONiC-VPP due to two related bugs:

1. The RIF SUB_PORT create/delete paths call `create_sub_interface(tap_to_hwif_name(dev), vlan_id, vlan_id)` where `dev` is "PortChannelX". Since `sonic_vpp_ifmap.ini` only maps physical Ethernet interfaces, `tap_to_hwif_name("PortChannelX")` returns "Unknown" and the VPP subinterface is never created on the correct BondEthernet parent.

2. `vpp_get_hwif_name()` returns early for LAG objects without appending the `.vlan_id` suffix, causing `vpp_set_interface_mtu` and `vpp_set_interface_state` to target the parent BondEthernet instead of the subinterface.

Changes made:
* In the create/delete paths, check `ot == SAI_OBJECT_TYPE_LAG` and construct the VPP hwif name as `BondEthernetX` from `bond_info.id` instead of calling `tap_to_hwif_name()`
* Fix `vpp_get_hwif_name()` to let the LAG branch fall through to the vlan_id append logic so MTU/state operations target the correct subinterface

Summary:
Fixes https://github.com/sonic-net/sonic-platform-vpp/issues/227
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

LAG subinterfaces are broken on VPP platform. The `test_packet_routed_with_valid_vlan[port_in_lag]` test fails because the VPP subinterface is never created on the correct BondEthernet parent. Additionally, post-creation operations (MTU, admin state) would target the wrong interface due to `vpp_get_hwif_name()` returning the parent bond name without the `.vlan_id` suffix.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

Applied the same LAG-aware hwif resolution pattern already used in the [VRF assignment section](https://github.com/sonic-net/sonic-sairedis/blob/d3ba80722ef9e2f907f748702912d8d6b0dceebd/vslib/vpp/SwitchVppRif.cpp#L1614-L1620) and in [SwitchVppFdb.cpp](https://github.com/sonic-net/sonic-sairedis/blob/d3ba80722ef9e2f907f748702912d8d6b0dceebd/vslib/vpp/SwitchVppFdb.cpp#L137-L145):

1. In the SUB_PORT create/delete paths, check `ot == SAI_OBJECT_TYPE_LAG` and construct `"BondEthernetX"` directly from `bond_info.id` (already populated via `get_lag_bond_info()`) instead of calling `tap_to_hwif_name()`.

2. In `vpp_get_hwif_name()`, restructured the LAG branch to set `hwifname` and fall through to the shared `vlan_id` append logic (the `if (vlan_id) { snprintf(..., "%s.%u", ...) }` block) rather than returning early with just the parent name.

#### How did you verify/test it?

Todo: Run `test_packet_routed_with_valid_vlan[port_in_lag]` in the t1-lag-vpp topology (Platform: kvm, ASIC type: vpp).

#### Any platform specific information?

VPP platform only. Physical port subinterfaces and non-subinterface LAG operations are unaffected (the `else` branches preserve original behavior).

### Documentation

N/A 