### PR TITLE
[syncd] Cache "permanently unsupported" PORT_PHY_ATTR / PORT_PHY_SERD…

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1,6 +1,7 @@
 #include <inttypes.h>
 #include <unordered_map>
 #include <map>
+#include <set>
 #include <vector>
 #include <string>
 #include <mutex>
@@ -1967,6 +1968,13 @@ public:
                 SWSS_LOG_DEBUG("PORT_PHY_ATTR: Removing RID 0x%" PRIx64 " from m_portLaneCountMap", it->second->rid);
                 m_portLaneCountMap.erase(lane_it);
             }
+
+            auto unsupp_it = m_unsupportedAttrs.find(it->second->rid);
+            if (unsupp_it != m_unsupportedAttrs.end())
+            {
+                SWSS_LOG_DEBUG("PORT_PHY_ATTR: Removing RID 0x%" PRIx64 " from m_unsupportedAttrs", it->second->rid);
+                m_unsupportedAttrs.erase(unsupp_it);
+            }
         }
 
         // Clean up lane metadata for this VID
@@ -2002,6 +2010,28 @@ public:
             SWSS_LOG_DEBUG("Collecting %zu port attributes for VID 0x%" PRIx64 ", RID:0x%" PRIx64,
                            attrIds.size(), vid, rid);
 
+            // Skip silently if every attribute in this batch was previously marked
+            // permanently unsupported by the SAI driver for this port (e.g. ports
+            // without optical modules on Arista 720dt). See post-failure caching below.
+            auto unsupp_it = m_unsupportedAttrs.find(rid);
+            if (unsupp_it != m_unsupportedAttrs.end())
+            {
+                bool allSkipped = true;
+                for (const auto &attrId : attrIds)
+                {
+                    if (unsupp_it->second.find(attrId) == unsupp_it->second.end())
+                    {
+                        allSkipped = false;
+                        break;
+                    }
+                }
+                if (allSkipped)
+                {
+                    SWSS_LOG_DEBUG("PORT_PHY_ATTR: All attrs for RID:0x%" PRIx64 " marked unsupported, skipping poll", rid);
+                    continue;
+                }
+            }
+
             bool attrDataInitialized = true;
             for (size_t i = 0; i < attrIds.size(); i++)
             {
@@ -2029,8 +2059,28 @@ public:
 
             if (status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_ERROR("Failed to get port attr for VID 0x%" PRIx64 ", RID:0x%" PRIx64 ": %d",
-                        vid, rid, status);
+                if (status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_INVALID_PORT_NUMBER)
+                {
+                    // SAI driver permanently does not support these attrs on this port
+                    // (e.g. unplugged front ports). Cache so we skip future polls and
+                    // avoid spamming syslog every poll interval.
+                    bool firstTime = (m_unsupportedAttrs.find(rid) == m_unsupportedAttrs.end());
+                    for (const auto &attrId : attrIds)
+                    {
+                        m_unsupportedAttrs[rid].insert(attrId);
+                    }
+                    if (firstTime)
+                    {
+                        SWSS_LOG_NOTICE("PORT_PHY_ATTR: SAI does not support attrs for VID 0x%" PRIx64 ", RID:0x%" PRIx64 " (status %d). "
+                                        "Marking as permanently unsupported; skipping in future polls.",
+                                        vid, rid, status);
+                    }
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to get port attr for VID 0x%" PRIx64 ", RID:0x%" PRIx64 ": %d",
+                            vid, rid, status);
+                }
                 continue;
             }
 
@@ -2190,6 +2240,9 @@ private:
     std::map<sai_object_id_t, std::map<sai_port_attr_t, uint32_t>> m_portLaneCountMap;
     // Map: [VID][attr_id][lane_number] -> metadata
     std::map<sai_object_id_t, std::map<sai_port_attr_t, std::map<uint32_t, LaneMetadata>>> m_laneMetadata;
+    // [RID] -> set of attr IDs the SAI driver permanently doesn't support for that port.
+    // Populated on first sai_get failure with NOT_SUPPORTED / INVALID_PORT_NUMBER.
+    std::map<sai_object_id_t, std::set<sai_port_attr_t>> m_unsupportedAttrs;
 };
 
 const std::unordered_map<sai_port_attr_t, std::string> PortPhyAttrContext::m_attrAliases = {
@@ -2512,6 +2565,14 @@ public:
                 SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Removing port_serdes RID:0x%" PRIx64 " from m_portSerdesTapsCountMap", port_serdes_rid);
                 m_portSerdesTapsCountMap.erase(count_it);
             }
+
+            // Clean up m_unsupportedAttrs
+            auto unsupp_it = m_unsupportedAttrs.find(port_serdes_rid);
+            if (unsupp_it != m_unsupportedAttrs.end())
+            {
+                SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Removing port_serdes RID:0x%" PRIx64 " from m_unsupportedAttrs", port_serdes_rid);
+                m_unsupportedAttrs.erase(unsupp_it);
+            }
         }
 
         // Call base class to remove from m_objectIdsMap
@@ -2540,6 +2601,27 @@ public:
             SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Collecting %zu port serdes attributes with VID 0x%" PRIx64 ", RID:0x%" PRIx64,
                            attrIds.size(), vid, rid);
 
+            // Skip silently if every attribute in this batch was previously marked
+            // permanently unsupported by the SAI driver for this port_serdes.
+            auto unsupp_it = m_unsupportedAttrs.find(rid);
+            if (unsupp_it != m_unsupportedAttrs.end())
+            {
+                bool allSkipped = true;
+                for (const auto &attrId : attrIds)
+                {
+                    if (unsupp_it->second.find(attrId) == unsupp_it->second.end())
+                    {
+                        allSkipped = false;
+                        break;
+                    }
+                }
+                if (allSkipped)
+                {
+                    SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: All attrs for RID:0x%" PRIx64 " marked unsupported, skipping poll", rid);
+                    continue;
+                }
+            }
+
             // Initialize all attributes - if any fail, skip this object
             bool attrDataInitialized = true;
             for (size_t i = 0; i < attrIds.size(); i++)
@@ -2567,8 +2649,27 @@ public:
 
             if (status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to get port serdes attr for VID 0x%" PRIx64 ", status: %d",
-                        vid, status);
+                if (status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_INVALID_PORT_NUMBER)
+                {
+                    // SAI driver permanently does not support these attrs on this port_serdes.
+                    // Cache so we skip future polls and avoid spamming syslog.
+                    bool firstTime = (m_unsupportedAttrs.find(rid) == m_unsupportedAttrs.end());
+                    for (const auto &attrId : attrIds)
+                    {
+                        m_unsupportedAttrs[rid].insert(attrId);
+                    }
+                    if (firstTime)
+                    {
+                        SWSS_LOG_NOTICE("PORT_PHY_SERDES_ATTR: SAI does not support attrs for VID 0x%" PRIx64 ", RID:0x%" PRIx64 " (status %d). "
+                                        "Marking as permanently unsupported; skipping in future polls.",
+                                        vid, rid, status);
+                    }
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to get port serdes attr for VID 0x%" PRIx64 ", status: %d",
+                            vid, status);
+                }
                 continue;
             }
 
@@ -2633,6 +2734,9 @@ private:
     std::map<sai_object_id_t, PortIdInfo> m_portSerdesIdToPortIdMap;
     std::map<sai_object_id_t, uint32_t> m_portSerdesIdToLaneCountMap;
     std::map<sai_object_id_t, std::map<sai_port_serdes_attr_t, uint32_t>> m_portSerdesTapsCountMap;
+    // [RID] -> set of attr IDs the SAI driver permanently doesn't support for that port_serdes.
+    // Populated on first sai_get failure with NOT_SUPPORTED / INVALID_PORT_NUMBER.
+    std::map<sai_object_id_t, std::set<sai_port_serdes_attr_t>> m_unsupportedAttrs;
 };
 
 const std::unordered_map<sai_port_serdes_attr_t, std::string> PortPhySerdesAttrContext::m_attrAliases = {

--- a/unittest/syncd/TestPortPhyAttr.cpp
+++ b/unittest/syncd/TestPortPhyAttr.cpp
@@ -363,3 +363,118 @@ TEST_F(TestPortPhyAttr, CollectDataSkipsWhenInitAttrDataFails)
 
     flexCounter->removeCounter(failPortOid);
 }
+
+
+/**
+ * Test that collectData() caches "permanently unsupported" attrs after the
+ * first sai_get failure with NOT_SUPPORTED (-2) or INVALID_PORT_NUMBER (-9),
+ * so subsequent poll cycles skip the SAI call entirely.
+ *
+ * This simulates the Arista 720dt scenario where m_portLaneCountMap *does*
+ * have lane-count entries (so initAttrData succeeds), but the actual sai_get
+ * call fails because the front port has no module / no signal. Without this
+ * fix, every poll interval (~10s) emits ERR-level syslog spam from both the
+ * BCM SAI driver and the syncd FlexCounter wrapper, generating tens of
+ * thousands of ERR lines per nightly run and breaking loganalyzer.
+ *
+ * Verifies:
+ *   - collectData calls sai_get exactly ONCE (first poll).
+ *   - On subsequent polls, sai_get is NOT called for the cached RID.
+ *   - No data is written to COUNTERS_DB for the unsupported RID.
+ *
+ * Mirrors the pattern introduced by PR #1861 (CollectDataSkipsWhenInitAttrDataFails).
+ *
+ * See: https://github.com/sonic-net/sonic-mgmt/issues/24023
+ */
+TEST_F(TestPortPhyAttr, CollectDataSkipsAfterUnsupportedStatus)
+{
+    sai_object_id_t failPortOid = 0x10000000000aa;
+    sai_object_id_t failPortRid = 0x10000000000aa;
+
+    int laneCountQueries = 0;
+    int multiAttrGets = 0;
+
+    // Mock SAI:
+    //   - For the lane-count probes (attr_count == 1 with list == nullptr) emit
+    //     BUFFER_OVERFLOW with count = MAX_LANES_PER_PORT so updatePortLaneCountMap
+    //     succeeds and m_portLaneCountMap gets populated for each attr.
+    //   - For the actual collectData sai_get (attr_count > 1, lists allocated)
+    //     emit NOT_SUPPORTED. The fix should cache and skip.
+    sai->mock_get = [&](sai_object_type_t object_type,
+                        sai_object_id_t object_id,
+                        uint32_t attr_count,
+                        sai_attribute_t *attr_list) -> sai_status_t
+    {
+        if (object_type != SAI_OBJECT_TYPE_PORT) {
+            return SAI_STATUS_INVALID_PARAMETER;
+        }
+
+        if (attr_count == 1) {
+            // Lane-count probe phase from updatePortLaneCountMap: emit
+            // BUFFER_OVERFLOW + count so the map gets populated.
+            laneCountQueries++;
+            switch (attr_list[0].id) {
+                case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
+                case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
+                    attr_list[0].value.portlanelatchstatuslist.count = MAX_LANES_PER_PORT;
+                    return SAI_STATUS_BUFFER_OVERFLOW;
+                case SAI_PORT_ATTR_RX_SNR:
+                    attr_list[0].value.portsnrlist.count = MAX_LANES_PER_PORT;
+                    return SAI_STATUS_BUFFER_OVERFLOW;
+                default:
+                    return SAI_STATUS_NOT_SUPPORTED;
+            }
+        }
+
+        // attr_count > 1 -> this is the real collectData sai_get.
+        // Return NOT_SUPPORTED to simulate unplugged-port behavior.
+        multiAttrGets++;
+        return SAI_STATUS_NOT_SUPPORTED;
+    };
+
+    vector<swss::FieldValueTuple> portPhyAttrValues;
+    std::string attrIds = "SAI_PORT_ATTR_RX_SIGNAL_DETECT,SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK,SAI_PORT_ATTR_RX_SNR";
+    portPhyAttrValues.emplace_back(PORT_PHY_ATTR_ID_LIST, attrIds);
+
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT);
+
+    flexCounter->addCounter(failPortOid, failPortRid, portPhyAttrValues);
+
+    // Lane-count probes happen during addCounter (one per attr).
+    EXPECT_GE(laneCountQueries, 3)
+        << "addCounter should have probed lane count for each attr";
+    EXPECT_EQ(multiAttrGets, 0)
+        << "collectData should not have run yet";
+
+    vector<swss::FieldValueTuple> pluginValues;
+    pluginValues.emplace_back(POLL_INTERVAL_FIELD, "200");
+    pluginValues.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    pluginValues.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    flexCounter->addCounterPlugin(pluginValues);
+
+    // Wait long enough for at least 3 poll cycles. Without the fix,
+    // multiAttrGets would grow ~once per cycle. With the fix, it should
+    // increment to exactly 1 (the first poll) and stay there.
+    usleep(1000 * 800); // 800ms ~ 4 polls at 200ms
+
+    EXPECT_EQ(multiAttrGets, 1)
+        << "collectData should call sai_get exactly once for an unsupported RID; "
+        << "subsequent polls must use the m_unsupportedAttrs cache to skip. "
+        << "Actual multiAttrGets=" << multiAttrGets;
+
+    // Nothing should have been written to COUNTERS_DB.
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::RedisPipeline pipeline(&db);
+    swss::Table countersTable(&pipeline, PORT_PHY_ATTR_TABLE, false);
+    std::string expectedKey = toOid(failPortOid);
+
+    std::string val;
+    EXPECT_FALSE(countersTable.hget(expectedKey, "phy_rx_signal_detect", val))
+        << "phy_rx_signal_detect should NOT be in COUNTERS_DB when SAI rejects the attr";
+    EXPECT_FALSE(countersTable.hget(expectedKey, "pcs_fec_lane_alignment_lock", val))
+        << "pcs_fec_lane_alignment_lock should NOT be in COUNTERS_DB when SAI rejects the attr";
+    EXPECT_FALSE(countersTable.hget(expectedKey, "rx_snr", val))
+        << "rx_snr should NOT be in COUNTERS_DB when SAI rejects the attr";
+
+    flexCounter->removeCounter(failPortOid);
+}


### PR DESCRIPTION
…ES_ATTR per RID

#### Why I did it
Building on PR #1861 (`Fix PORT_PHY_ATTR::collectData to check initAttrData return value`), there is a remaining gap that still triggers per-poll ERR syslog spam from `PortPhyAttrContext::collectData` and `PortPhySerdesAttrContext::collectData` on Arista 720dt M0/MX testbeds.

PR #1861 short-circuits when `m_portLaneCountMap` has *no* entry for the (rid, attr_id) pair (i.e. when the lane-count probe in `updatePortLaneCountMap` itself fails — Arista 7260CX3 case). For 720dt ports without an optical module, the lane-count probe **succeeds** so `initAttrData()` returns true, then `sai_get_port_attribute` is invoked and BCM SAI returns either:

  * `Feature unavailable (0xfffffff0)` -> SAI_STATUS_NOT_SUPPORTED (-2), or
  * `Invalid port (0xffffffee)` -> SAI_STATUS_INVALID_PORT_NUMBER (-9)

Both BCM SAI driver layer and the syncd FlexCounter wrapper layer emit ERR-level syslog every poll cycle (~10s). On a fresh 720dt with ~24 unplugged front ports this generates 25,000+ ERR lines per nightly run and breaks loganalyzer at teardown — same downstream impact as the bug PR #1861 set out to fix.

#### How I did it
Add a per-context `m_unsupportedAttrs` cache mapping rid -> set of attrs the SAI driver permanently does not support for that port:

  * `PortPhyAttrContext::collectData` and `PortPhySerdesAttrContext::collectData`:
    - Before the `initAttrData` loop: if every attr in this batch is in the cache for this rid, silently `continue`.
    - After `m_vendorSai->get()` returns NOT_SUPPORTED or INVALID_PORT_NUMBER: insert every attr in the batch into the cache, log NOTICE (not ERROR) once, and `continue`.
    - Other (transient/unexpected) failures keep the existing SWSS_LOG_ERROR + `continue`.
  * `removeObject`: clean up the cache for the removed RID, mirroring the existing `m_portLaneCountMap` / `m_portSerdesIdToLaneCountMap` cleanup.

The first poll per rid still emits one BCM SAI driver ERR (we can't suppress the vendor binary), but subsequent polls are completely silent. For 720dt this drops syslog ERR volume from ~25,000 per nightly to ~50 per syncd start (~500x reduction) and removes the FlexCounter wrapper ERRs entirely (demoted to NOTICE on first occurrence).

#### How to verify it
1. Deploy on an Arista 720dt (or any platform with unplugged front ports on a Broadcom ASIC) with the 202511 image.
2. Run `show logging | grep -E "(brcm_sai_get_port_attribute_cmn|collectData: Failed to get port attr)"`.
3. Before the fix: thousands of ERR lines, growing every 10s.
4. After the fix: at most a few NOTICE lines per port at syncd start, then silent.
5. Run any test with loganalyzer enabled — teardown should pass without the temporary `loganalyzer_common_ignore.txt` patches now needed for `collectData ... -2` and `collectData ... -9`.

Unit test added: `TestPortPhyAttr.CollectDataSkipsAfterUnsupportedStatus`
- Mocks SAI to succeed lane-count probe but return NOT_SUPPORTED on collectData's actual sai_get.
- Asserts `multiAttrGets == 1` after multiple poll cycles, proving the cache prevents repeat calls.
- Asserts COUNTERS_DB is empty for the failing RID.

#### Related PRs
- #1861 -- Fix PORT_PHY_ATTR::collectData to check initAttrData return value (extends the same defensive pattern; this PR closes the remaining gap)
- #1799 / #1815 -- Partial fix for PORT_PHY_SERDES_ATTR (same shape)
- sonic-net/sonic-mgmt #21564 -- Temporary loganalyzer ignore for `-9` collectData failures (can be removed once this lands)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
