### PR TITLE
[syncd] PORT_PHY_ATTR: verify the actual data read at probe time

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1846,7 +1846,7 @@ public:
                 continue;
             }
 
-            // Query SAI for lane count (expecting BUFFER_OVERFLOW)
+            // Phase 1: probe SAI for the lane count (expecting BUFFER_OVERFLOW)
             sai_status_t status = Base::m_vendorSai->get(
                     Base::m_objectType,
                     rid,
@@ -1860,6 +1860,78 @@ public:
             }
 
             uint32_t laneCount = extractLaneCount(attr);
+
+            // Phase 2: verify that an actual full-buffer read also succeeds.
+            //
+            // Some BCM SAI implementations succeed at the lane-count probe
+            // (because the lane count is a static port property) but fail the
+            // actual data read with SAI_STATUS_NOT_SUPPORTED /
+            // SAI_STATUS_INVALID_PORT_NUMBER on ports that have no module /
+            // no live signal (observed on Arista 720dt M0/MX). Per the SAI
+            // spec, "no signal" is a valid value (current_status=false on all
+            // lanes), so that vendor mapping is a quirk worth working around.
+            //
+            // To keep probe/poll behavior consistent and avoid spamming syslog
+            // every poll cycle, we test the actual read here and only register
+            // the (rid, attr) pair into m_portLaneCountMap when both phases
+            // succeed. Skipped pairs naturally fall through PR #1861's existing
+            // initAttrData false-return path and collectData skips them.
+            sai_attribute_t verifyAttr;
+            verifyAttr.id = static_cast<sai_port_attr_t>(counter_ids[i]);
+            PortPhyAttributeData verifyData;
+            switch (verifyAttr.id)
+            {
+                case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
+                    verifyData.rxSignalDetectData.resize(laneCount);
+                    verifyAttr.value.portlanelatchstatuslist.count = laneCount;
+                    verifyAttr.value.portlanelatchstatuslist.list = verifyData.rxSignalDetectData.data();
+                    break;
+
+                case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
+                    verifyData.fecAlignmentLockData.resize(laneCount);
+                    verifyAttr.value.portlanelatchstatuslist.count = laneCount;
+                    verifyAttr.value.portlanelatchstatuslist.list = verifyData.fecAlignmentLockData.data();
+                    break;
+
+                case SAI_PORT_ATTR_RX_SNR:
+                    verifyData.rxSnrData.resize(laneCount);
+                    verifyAttr.value.portsnrlist.count = laneCount;
+                    verifyAttr.value.portsnrlist.list = verifyData.rxSnrData.data();
+                    break;
+
+                default:
+                    SWSS_LOG_ERROR("PORT_PHY_ATTR: Unknown attr-id %d during verify-poll setup; skipping registration", verifyAttr.id);
+                    continue;
+            }
+
+            sai_status_t verifyStatus = Base::m_vendorSai->get(
+                    Base::m_objectType,
+                    rid,
+                    1,
+                    &verifyAttr);
+            if (verifyStatus != SAI_STATUS_SUCCESS)
+            {
+                if (verifyStatus == SAI_STATUS_NOT_SUPPORTED ||
+                    verifyStatus == SAI_STATUS_INVALID_PORT_NUMBER)
+                {
+                    SWSS_LOG_NOTICE(
+                            "PORT_PHY_ATTR: SAI does not service attr_id=%d for RID:0x%" PRIx64
+                            " (verify-poll status=%d). Skipping FlexCounter registration; this attr "
+                            "will not be polled for this port until syncd restarts. This is typically "
+                            "expected when the port has no module / no live RX signal.",
+                            verifyAttr.id, rid, verifyStatus);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR(
+                            "PORT_PHY_ATTR: Verify-poll failed for attr_id=%d RID:0x%" PRIx64
+                            " (status=%d). Skipping FlexCounter registration.",
+                            verifyAttr.id, rid, verifyStatus);
+                }
+                continue;
+            }
+
+            // Both phases succeeded; safe to register for FlexCounter polling.
             m_portLaneCountMap[rid][static_cast<sai_port_attr_t>(attr.id)] = laneCount;
             SWSS_LOG_DEBUG("PORT_PHY_ATTR: m_portLaneCountMap[rid:0x%" PRIx64 "][%d] = %u", rid, attr.id, laneCount);
         }

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 0
+personal_ws-1.1 en 6
 acl
 ACL
 ACLs
@@ -498,3 +498,9 @@ ICMP
 UDP
 SIGSEGV
 CX
+Arista
+dt
+loganalyzer
+MX
+PMD
+teardown

--- a/unittest/syncd/TestPortPhyAttr.cpp
+++ b/unittest/syncd/TestPortPhyAttr.cpp
@@ -363,3 +363,138 @@ TEST_F(TestPortPhyAttr, CollectDataSkipsWhenInitAttrDataFails)
 
     flexCounter->removeCounter(failPortOid);
 }
+
+/**
+ * Test that updatePortLaneCountMap() also verifies the actual data read
+ * succeeds before registering an (rid, attr) pair for FlexCounter polling.
+ *
+ * Simulates the Arista 720dt M0/MX scenario where the BCM SAI driver
+ * returns BUFFER_OVERFLOW + count for the lane-count probe (so the port
+ * appears to support the attr), but then returns NOT_SUPPORTED for the
+ * actual full-buffer read because the front port has no optical module
+ * and the BCM PMD layer rejects the live-signal query.
+ *
+ * Without this verify-poll, every FlexCounter poll cycle (~10s) triggers
+ * a SWSS_LOG_ERROR + a BCM SAI driver ERR for each unplugged port, which
+ * generated 25,000+ ERR lines per nightly run on 720dt and broke
+ * loganalyzer at teardown.
+ *
+ * After the verify-poll, the failure is observed exactly once at
+ * addCounter time; the (rid, attr) is not registered, and PR #1861's
+ * existing initAttrData/collectData skip path takes over for all future
+ * polls (silent, no per-poll cost).
+ *
+ * Mirrors the pattern of CollectDataSkipsWhenInitAttrDataFails (PR #1861)
+ * but exercises the new verify-poll filter.
+ *
+ * See:
+ *   https://github.com/sonic-net/sonic-mgmt/issues/24023
+ *   https://github.com/aristanetworks/sonic-qual.msft/issues/<TBD>
+ */
+TEST_F(TestPortPhyAttr, UpdatePortLaneCountMapSkipsWhenVerifyPollFails)
+{
+    sai_object_id_t failPortOid = 0x10000000000aa;
+    sai_object_id_t failPortRid = 0x10000000000aa;
+
+    int probeCalls = 0;       // probe: attr_count==1, list==nullptr  -> BUFFER_OVERFLOW
+    int verifyCalls = 0;      // verify: attr_count==1, list!=nullptr -> NOT_SUPPORTED
+    int pollCalls = 0;        // collectData poll: attr_count>1       -> should never happen
+
+    // Mock SAI:
+    //   - lane-count probe (count==0, list==nullptr): set count=MAX_LANES_PER_PORT
+    //     and return BUFFER_OVERFLOW (port "appears" to support the attr).
+    //   - verify-poll (count==MAX_LANES_PER_PORT, list!=nullptr): return
+    //     NOT_SUPPORTED (the failure mode this test reproduces).
+    //   - real collectData poll (attr_count>1): record and fail loudly so the
+    //     test catches a regression where collectData runs anyway.
+    sai->mock_get = [&](sai_object_type_t object_type,
+                        sai_object_id_t object_id,
+                        uint32_t attr_count,
+                        sai_attribute_t *attr_list) -> sai_status_t
+    {
+        if (object_type != SAI_OBJECT_TYPE_PORT) {
+            return SAI_STATUS_INVALID_PARAMETER;
+        }
+
+        if (attr_count == 1) {
+            const sai_attribute_t &a = attr_list[0];
+            bool isProbe = false;
+            switch (a.id) {
+                case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
+                case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
+                    isProbe = (a.value.portlanelatchstatuslist.list == nullptr);
+                    break;
+                case SAI_PORT_ATTR_RX_SNR:
+                    isProbe = (a.value.portsnrlist.list == nullptr);
+                    break;
+                default:
+                    return SAI_STATUS_NOT_SUPPORTED;
+            }
+
+            if (isProbe) {
+                probeCalls++;
+                switch (a.id) {
+                    case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
+                    case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
+                        attr_list[0].value.portlanelatchstatuslist.count = MAX_LANES_PER_PORT;
+                        break;
+                    case SAI_PORT_ATTR_RX_SNR:
+                        attr_list[0].value.portsnrlist.count = MAX_LANES_PER_PORT;
+                        break;
+                    default:
+                        break;
+                }
+                return SAI_STATUS_BUFFER_OVERFLOW;
+            }
+
+            // verify-poll: real buffer allocated -> simulate "no module" failure
+            verifyCalls++;
+            return SAI_STATUS_NOT_SUPPORTED;
+        }
+
+        // attr_count > 1 -> this is collectData's real read. With this fix it
+        // must NOT happen because verify-poll already rejected the (rid, attr).
+        pollCalls++;
+        return SAI_STATUS_NOT_SUPPORTED;
+    };
+
+    vector<swss::FieldValueTuple> portPhyAttrValues;
+    std::string attrIds = "SAI_PORT_ATTR_RX_SIGNAL_DETECT,SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK,SAI_PORT_ATTR_RX_SNR";
+    portPhyAttrValues.emplace_back(PORT_PHY_ATTR_ID_LIST, attrIds);
+
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT);
+
+    flexCounter->addCounter(failPortOid, failPortRid, portPhyAttrValues);
+
+    // addCounter should have invoked: 3 probes + 3 verify-polls (one of each per attr).
+    EXPECT_EQ(probeCalls, 3) << "Expected one lane-count probe per attr at addCounter time";
+    EXPECT_EQ(verifyCalls, 3) << "Expected one verify-poll per attr at addCounter time";
+    EXPECT_EQ(pollCalls, 0) << "collectData must not have run yet";
+
+    vector<swss::FieldValueTuple> pluginValues;
+    pluginValues.emplace_back(POLL_INTERVAL_FIELD, "200");
+    pluginValues.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    pluginValues.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    flexCounter->addCounterPlugin(pluginValues);
+
+    // Wait for several poll cycles. With the fix, m_portLaneCountMap is empty
+    // for failPortRid, initAttrData returns false on every poll (#1861 path),
+    // and collectData never reaches sai_get.
+    usleep(1000 * 800);  // ~4 polls at 200ms
+
+    EXPECT_EQ(pollCalls, 0)
+        << "collectData should never reach sai_get when verify-poll rejected the (rid, attr). "
+        << "Actual pollCalls=" << pollCalls;
+
+    // Nothing should be in COUNTERS_DB.
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::RedisPipeline pipeline(&db);
+    swss::Table countersTable(&pipeline, PORT_PHY_ATTR_TABLE, false);
+    std::string expectedKey = toOid(failPortOid);
+    std::string val;
+    EXPECT_FALSE(countersTable.hget(expectedKey, "phy_rx_signal_detect", val));
+    EXPECT_FALSE(countersTable.hget(expectedKey, "pcs_fec_lane_alignment_lock", val));
+    EXPECT_FALSE(countersTable.hget(expectedKey, "rx_snr", val));
+
+    flexCounter->removeCounter(failPortOid);
+}


### PR DESCRIPTION
#### Why I did it
After PR #1861 (`Fix PORT_PHY_ATTR::collectData to check initAttrData return value`) there is a remaining gap that still triggers per-poll ERR-level syslog spam from `PortPhyAttrContext::collectData` on Arista 720dt M0/MX testbeds.

PR #1861 short-circuits when `m_portLaneCountMap` has no entry for a given (rid, attr) pair (i.e. when the lane-count probe in `updatePortLaneCountMap` itself fails -- the Arista 7260CX3 case). For 720dt's unplugged front ports the lane-count probe **succeeds** so the map gets populated and `initAttrData()` returns true, then `sai_get_port_attribute` is invoked and BCM SAI returns either:

* `Feature unavailable (0xfffffff0)` -> `SAI_STATUS_NOT_SUPPORTED` (-2), or
* `Invalid port (0xffffffee)` -> `SAI_STATUS_INVALID_PORT_NUMBER` (-9)

Both BCM SAI driver layer and the syncd FlexCounter wrapper layer emit ERR-level syslog every poll cycle (~10s). On a fresh 720dt with ~24 unplugged front ports this generates 25,000+ ERR lines per nightly run and breaks loganalyzer at teardown -- the same downstream impact PR #1861 set out to fix, just on a different platform.

The root cause is a vendor-side inconsistency: per the SAI spec, `SAI_PORT_ATTR_RX_SIGNAL_DETECT` returns `sai_port_lane_latch_status_t` whose `current_status` is a boolean -- "no signal" is a valid value (`current_status = false` on all lanes), not an error. BCM SAI's mapping of "no module / no live signal" to NOT_SUPPORTED / INVALID_PORT_NUMBER is therefore non-spec-compliant. A vendor issue is being filed separately to correct this at the source.

Until that lands, this PR closes the syncd-side gap by aligning the probe and the actual read so they agree at addCounter time.

#### How I did it
In `PortPhyAttrContext::updatePortLaneCountMap`, after the existing lane-count probe (`get` with `count=1, list=nullptr` expecting BUFFER_OVERFLOW), perform a second `get` with a properly sized buffer allocated from the just-discovered lane count. Only register the (rid, attr) pair into `m_portLaneCountMap` when **both** phases succeed.

If the verify-poll fails:
* NOT_SUPPORTED (-2) / INVALID_PORT_NUMBER (-9): log NOTICE once explaining the attr will not be polled for this port until syncd restart, then continue without registering.
* Any other status: log ERROR (preserving existing behavior for unexpected failures), then continue without registering.

Skipped (rid, attr) pairs naturally fall through PR #1861's existing `initAttrData()` false-return path, and `collectData` continues to silently skip them every poll. No new data structure, no per-poll cost.

Cost: one extra SAI `get` per attr per port at addCounter time (syncd startup); for 64 ports x 3 attrs that is 192 additional calls total, all during initialization. Trivial.

#### How to verify it
1. Deploy on an Arista 720dt (or any Broadcom platform with unplugged front ports configured for PORT_PHY_ATTR polling) with the 202511 image.
2. Before the fix:
   ```
   show logging | grep -E "(brcm_sai_get_port_attribute_cmn|collectData: Failed to get port attr)" | wc -l
   ```
   produces thousands of ERR lines, growing every 10s.
3. After the fix: the same command produces at most ~3 NOTICE lines per unplugged port (one per attr) at syncd start, then silent.
4. Run any test with loganalyzer enabled -- teardown passes without the temporary `loganalyzer_common_ignore.txt` patches now needed for `collectData ... -2` and `collectData ... -9`.

Unit test added: `TestPortPhyAttr.UpdatePortLaneCountMapSkipsWhenVerifyPollFails`
- Mocks SAI to return BUFFER_OVERFLOW + count for the lane-count probe (`attr_count==1` with `list==nullptr`) but NOT_SUPPORTED for the verify-poll (`attr_count==1` with `list!=nullptr`).
- Asserts the verify-poll runs exactly once per attr at addCounter.
- Asserts `collectData` never reaches `sai_get` for the rejected (rid, attr) pairs across multiple poll cycles.
- Asserts COUNTERS_DB has no entries for the failing RID.

#### Why this approach (vs caching after the failure)
An earlier draft (PR #1884, now closed) cached failures in a new `m_unsupportedAttrs` map populated inside `collectData` after the first failed read. That worked but added a new data structure and required one wasted poll per (rid, attr) per syncd start before the silence kicked in. The verify-poll approach eliminates the wasted poll, reuses PR #1861's existing skip mechanism, and aligns probe/poll behavior so they cannot disagree at runtime.

#### Related PRs / issues
- #1861 -- Fix PORT_PHY_ATTR::collectData to check initAttrData return value (this PR extends the same defensive pattern by feeding it earlier)
- #1884 -- earlier (now closed) draft of this fix using a per-poll cache approach
- #1799 / #1815 -- Partial fix for PORT_PHY_SERDES_ATTR
- sonic-net/sonic-mgmt#21564 -- Temporary loganalyzer ignore for `-9` collectData failures (can be removed once this lands)
- sonic-net/sonic-mgmt#24023 -- Tracking issue for the loganalyzer impact