### PR TITLE
[test] FlexCounter.bulkChunksize: skip re-probe polls in per-counter assertions

### DIFF
--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -1586,6 +1586,16 @@ TEST(FlexCounter, bulkChunksize)
                     }
                     continue;
                 }
+                // Skip re-probe polls (single-object capability probes
+                // that happen after the merge-back, with object_count==1).
+                // The per-counter assertions below check steady-state
+                // per-prefix chunk sizes, which only apply when
+                // object_count > 1. This matches the documented intent
+                // in the comment above and the unified-path guard.
+                if (object_count == 1)
+                {
+                    continue;
+                }
                 switch (counter_ids[j])
                 {
                 case SAI_PORT_STAT_IF_IN_OCTETS:


### PR DESCRIPTION
## Description

The `FlexCounter.bulkChunksize` unit test occasionally fails on PRs targeting either `master` or `202511` with messages like:

```
TestFlexCounter.cpp:1574: Failure
Expected equality of these values:
  object_count
    Which is: 1
  3
```

PR #1836 added a guard for the **unified** path (`if (unifiedBulkChunkSize > 0)`) so that re-probe polls of bulk capability with `object_count == 1` do not trigger the unified-chunk-size assertion. The comment in the same block also documents the intent to skip re-probe polls for the per-counter switch below:

```cpp
// After the merge-back, FlexCounter also re-probes
// bulk capability with single-object calls (object_count=1)
// that have all counters. Skip the assertion for both
// per-prefix polls and re-probe polls.
```

However the **implementation** only handles the per-prefix-poll case in the unified branch — the per-counter switch still fires `EXPECT_EQ` on re-probe polls, occasionally failing with `object_count=1` vs. expected 3 / 6 / 2.

Recently observed in CI on the 202511 backport build for #1885 (PR #1886) — the same flake fired on the **same identical code** that passed on master.

## Changes

`unittest/syncd/TestFlexCounter.cpp`: add the same `object_count == 1` early-skip before the `switch (counter_ids[j])` block so the implementation matches the documented intent. **No production code change.** Same fix is needed on master and 202511.

## How to verify

Local: `make check && tests/unittest/syncd/syncdtests --gtest_filter=FlexCounter.bulkChunksize --gtest_repeat=20`. Without the patch the test occasionally fails; with the patch it consistently passes.

## Which release branch to backport

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

cc @theasianpianist — follow-up to #1836.