### PR TITLE
[test] Make FlexCounter bulkChunksize setup deterministic

### DIFF
--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -235,7 +235,8 @@ void testAddRemoveCounter(
         bool bulkChunkSizeAfterPort = true,
         const std::string pluginName = "",
         bool immediatelyRemoveBulkChunkSizePerCounter = false,
-        bool forceSingleCreate = false)
+        bool forceSingleCreate = false,
+        bool enableAfterSetup = false)
 {
     SWSS_LOG_ENTER();
 
@@ -248,7 +249,7 @@ void testAddRemoveCounter(
 
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(POLL_INTERVAL_FIELD, "1000");
-    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    values.emplace_back(FLEX_COUNTER_STATUS_FIELD, enableAfterSetup ? "disable" : "enable");
     values.emplace_back(STATS_MODE_FIELD, statsMode);
     std::vector<swss::FieldValueTuple> fcValues = values;
     auto &bulkChunkSizeValues = bulkChunkSizeAfterPort ? fcValues : values;
@@ -298,6 +299,11 @@ void testAddRemoveCounter(
             bulkChunkSizeValues.emplace_back(BULK_CHUNK_SIZE_PER_PREFIX_FIELD, "");
             fc.addCounterPlugin(bulkChunkSizeValues);
         }
+    }
+
+    if (enableAfterSetup)
+    {
+        fc.addCounterPlugin({ swss::FieldValueTuple(FLEX_COUNTER_STATUS_FIELD, "enable") });
     }
 
     EXPECT_EQ(fc.isEmpty(), false);
@@ -1509,7 +1515,7 @@ TEST(FlexCounter, bulkChunksize)
     // non zero unifiedBulkChunkSize indicates all counter IDs share the same bulk chunk size
     uint32_t unifiedBulkChunkSize = 0;
     int32_t initialCheckCount;
-    int32_t partialSupportingBulkObjectFactor;
+    int32_t partialSupportingBulkObjectFactor = 0;
     sai->mock_bulkGetStats = [&](sai_object_id_t,
                                 sai_object_type_t,
                                 uint32_t object_count,
@@ -1646,7 +1652,12 @@ TEST(FlexCounter, bulkChunksize)
         STATS_MODE_READ,
         false,
         "3",
-        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2");
+        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
+        true,
+        "",
+        false,
+        false,
+        true);
     EXPECT_TRUE(allObjectIds.empty());
 
     // set bulk chunk size + per counter bulk chunk size first and then create ports
@@ -1666,6 +1677,7 @@ TEST(FlexCounter, bulkChunksize)
         false,
         PORT_PLUGIN_FIELD,
         false,
+        true,
         true);
     EXPECT_TRUE(allObjectIds.empty());
 
@@ -1688,6 +1700,8 @@ TEST(FlexCounter, bulkChunksize)
         "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
         true,
         "",
+        true,
+        false,
         true);
     EXPECT_TRUE(allObjectIds.empty());
     unifiedBulkChunkSize = 0;
@@ -1705,7 +1719,12 @@ TEST(FlexCounter, bulkChunksize)
         STATS_MODE_READ,
         true,
         "3",
-        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2");
+        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
+        true,
+        "",
+        false,
+        false,
+        true);
     EXPECT_TRUE(allObjectIds.empty());
 
     // set bulk chunk size + per counter bulk chunk size first and then add ports counters in bulk mode
@@ -1723,7 +1742,10 @@ TEST(FlexCounter, bulkChunksize)
         "3",
         "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
         false,
-        PORT_PLUGIN_FIELD);
+        PORT_PLUGIN_FIELD,
+        false,
+        false,
+        true);
     EXPECT_TRUE(allObjectIds.empty());
 
     // add ports counters in bulk mode with some bulk-unsupported counters first and then set bulk chunk size + per counter bulk chunk size
@@ -1746,7 +1768,12 @@ TEST(FlexCounter, bulkChunksize)
         STATS_MODE_READ,
         true,
         "3",
-        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2");
+        "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
+        true,
+        "",
+        false,
+        false,
+        true);
     EXPECT_TRUE(allObjectIds.empty());
     forceSingleCall = false;
 
@@ -1769,6 +1796,13 @@ TEST(FlexCounter, bulkChunksize)
         counterVerifyFunc,
         false,
         STATS_MODE_READ,
+        true,
+        "",
+        "",
+        true,
+        "",
+        false,
+        false,
         true);
     EXPECT_TRUE(allObjectIds.empty());
     bulkUnsupportedCounters.clear();
@@ -1793,7 +1827,10 @@ TEST(FlexCounter, bulkChunksize)
         "3",
         "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
         false,
-        PORT_PLUGIN_FIELD);
+        PORT_PLUGIN_FIELD,
+        false,
+        false,
+        true);
     EXPECT_TRUE(allObjectIds.empty());
 
     // set bulk chunk size + per counter bulk chunk size first and then add ports counters in bulk mode with some bulk-unsupported counters
@@ -1815,7 +1852,10 @@ TEST(FlexCounter, bulkChunksize)
         "3",
         "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:2",
         false,
-        PORT_PLUGIN_FIELD);
+        PORT_PLUGIN_FIELD,
+        false,
+        false,
+        true);
     EXPECT_TRUE(allObjectIds.empty());
 }
 


### PR DESCRIPTION
## Summary
- keep the FlexCounter worker disabled until `bulkChunksize` finishes installing objects and bulk chunk settings
- initialize the partial bulk-support factor explicitly to remove test-side nondeterminism
- use this draft PR as CI validation for the `BuildTrixie amd64` `FlexCounter.bulkChunksize` failure path

## Test plan
- [ ] Azure `BuildTrixie amd64`
- [ ] Confirm whether `FlexCounter.bulkChunksize` still reproduces in CI
- [ ] Compare results with baseline evidence from `#1850`

Made with [Cursor](https://cursor.com)