### PR TITLE
[diagnostic] trigger master baseline CI with doc-only change

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For general questions, setup help, or troubleshooting:
 
 - [sonicproject on Google Groups](https://groups.google.com/g/sonicproject)
 
-For bug reports or feature requests, please open an Issue.
+For bug reports or feature requests, please open an issue.
 
 ## Contribution guide
 


### PR DESCRIPTION
## Summary

This is a draft diagnostic PR created to collect a fresh Azure CI signal from current `master` with a documentation-only change.

There is no intended functional change in this PR. The purpose is to determine whether the current `Azure.sonic-sairedis (Test vstest)` failures reproduce independently of the Broadcom `syncd -l` change under review and independently of the related unit-test experiment.

## Test plan

- Let the normal PR CI run
- Compare the resulting `Azure.sonic-sairedis (Test vstest)` failures with the other relevant CI runs