### PR TITLE
gbsyncdmgrd: remove unnecessary root privilege check

### DIFF
--- a/syncd/scripts/gbsyncdmgrd
+++ b/syncd/scripts/gbsyncdmgrd
@@ -12,7 +12,6 @@ import time
 SYSLOG_IDENTIFIER = os.path.basename(__file__)
 
 EXIT_SUCCESS = 0
-EXIT_INSUFFICIENT_PERMISSIONS = 1
 EXIT_UNKNOWN = 2
 
 running = True
@@ -42,11 +41,6 @@ def physyncd_spawn(gearbox_config):
 
 
 def main():
-    # Only privileged users can run this daemon
-    if os.geteuid() != 0:
-        print('Root privileges required for this operation')
-        return EXIT_INSUFFICIENT_PERMISSIONS
-
     syslog.openlog(SYSLOG_IDENTIFIER)
 
     # Register our signal handlers


### PR DESCRIPTION
#### Why I did it

The gbsyncd container no longer runs with `--privileged` (see sonic-net/sonic-buildimage#27332). The explicit `geteuid() != 0` guard in gbsyncdmgrd is unnecessary — the daemon does not require UID 0 to function.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Remove the `geteuid() != 0` check and the now-unused `EXIT_INSUFFICIENT_PERMISSIONS` constant from `syncd/scripts/gbsyncdmgrd`.

#### How to verify it

1. gbsyncd container starts and gbsyncdmgrd runs normally
2. No regression in gearbox syncd operation

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch

- [ ]

#### Description for the changelog

gbsyncdmgrd: remove unnecessary root privilege check

#### Link to config_db schema for YANG module changes

N/A