### PR TITLE
[DPU] Optimize Flow Sync Notification and fix cleanup for flow dumps

### DIFF
--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -3047,32 +3047,34 @@ std::string sai_serialize_flow_bulk_get_session_event_ntf(
 {
     SWSS_LOG_ENTER();
 
-    if (data == NULL)
-    {
-        SWSS_LOG_THROW("flow_bulk_get_session_event_data_t pointer is null");
-    }
-
     /*
-     * NOTE: Only event_type is serialized here. The flow_entry, attr_count, and attr
-     * fields are NOT serialized as they are only populated for Flow Dump
-     * Due to performance reasons, they are not serialized and are not sent to orchagent.
+     * Only SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED is placed
+     * in data for the SaiRedis client; FLOW_ENTRY handled in syncd. data may be empty.
      */
+
+    json arr = json::array();
+
+    if (data != nullptr && count > 0)
+    {
+        for (int i = static_cast<int>(count) - 1; i >= 0; --i)
+        {
+            if (data[static_cast<uint32_t>(i)].event_type == SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED)
+            {
+                json item;
+
+                item["event_type"] = sai_serialize_flow_bulk_get_session_event(
+                        data[static_cast<uint32_t>(i)].event_type);
+
+                arr.push_back(item);
+
+                break;
+            }
+        }
+    }
 
     json j;
 
     j["bulk_session_id"] = sai_serialize_object_id(flow_bulk_session_id);
-
-    json arr = json::array();
-
-    for (uint32_t i = 0; i < count; ++i)
-    {
-        json item;
-
-        item["event_type"] = sai_serialize_flow_bulk_get_session_event(data[i].event_type);
-
-        arr.push_back(item);
-    }
-
     j["data"] = arr;
 
     return j.dump();

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -101,6 +101,17 @@ function check_warm_boot()
 }
 
 
+function cleanup_stale_flow_dump_files()
+{
+    # Flows are to a file based on their VID. 
+    # Clean up all files in the directory to avoid updates to stale files.
+    local flow_dump_dir=/var/dump/flows
+    if [ -d "$flow_dump_dir" ]; then
+        rm -f "$flow_dump_dir"/*gz 2>/dev/null || true
+    fi
+}
+
+
 function set_start_type()
 {
     if [ x"$WARM_BOOT" == x"true" ]; then
@@ -651,6 +662,7 @@ config_syncd()
 {
     check_warm_boot
 
+    cleanup_stale_flow_dump_files
 
     if [ "$SONIC_ASIC_TYPE" == "cisco-8000" ]; then
         config_syncd_cisco_8000

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -103,7 +103,7 @@ function check_warm_boot()
 
 function cleanup_stale_flow_dump_files()
 {
-    # Flows are to a file based on their VID. 
+    # Flows are to a file based on their VID.
     # Clean up all files in the directory to avoid updates to stale files.
     local flow_dump_dir=/var/dump/flows
     if [ -d "$flow_dump_dir" ]; then

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -1640,7 +1640,19 @@ TEST(SaiSerialize, sai_serialize_flow_bulk_get_session_event_ntf_null_data)
 {
     SWSS_LOG_ENTER();
 
-    EXPECT_THROW(sai_serialize_flow_bulk_get_session_event_ntf(0x123456789abcdef, 1, nullptr), std::runtime_error);
+    const sai_object_id_t flow_bulk_session_id = 0x123456789abcdef;
+    std::string serialized = sai_serialize_flow_bulk_get_session_event_ntf(flow_bulk_session_id, 1, nullptr);
+
+    sai_object_id_t deserialized_session_id;
+    uint32_t deserialized_count;
+    sai_flow_bulk_get_session_event_data_t* deserialized_data;
+
+    sai_deserialize_flow_bulk_get_session_event_ntf(serialized, deserialized_session_id, deserialized_count, &deserialized_data);
+
+    EXPECT_EQ(deserialized_session_id, flow_bulk_session_id);
+    EXPECT_EQ(deserialized_count, 0u);
+
+    sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
 }
 
 TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_single_finished)
@@ -1704,19 +1716,38 @@ TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_mul
     sai_deserialize_flow_bulk_get_session_event_ntf(serialized, deserialized_session_id, deserialized_count, &deserialized_data);
 
     EXPECT_EQ(deserialized_session_id, flow_bulk_session_id);
-    EXPECT_EQ(deserialized_count, count);
+    EXPECT_EQ(deserialized_count, 1u);
 
-    EXPECT_EQ(deserialized_data[0].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY);
+    EXPECT_EQ(deserialized_data[0].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED);
     EXPECT_EQ(deserialized_data[0].attr_count, 0);
     EXPECT_EQ(deserialized_data[0].attr, nullptr);
 
-    EXPECT_EQ(deserialized_data[1].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED);
-    EXPECT_EQ(deserialized_data[1].attr_count, 0);
-    EXPECT_EQ(deserialized_data[1].attr, nullptr);
+    sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
+}
 
-    EXPECT_EQ(deserialized_data[2].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY);
-    EXPECT_EQ(deserialized_data[2].attr_count, 0);
-    EXPECT_EQ(deserialized_data[2].attr, nullptr);
+TEST(SaiSerialize, sai_serialize_flow_bulk_get_session_event_ntf_flow_entry_only_empty_data)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t flow_bulk_session_id = 0xabcdef1234567890;
+    uint32_t count = 2;
+    sai_flow_bulk_get_session_event_data_t event_data[2];
+
+    memset(event_data, 0, sizeof(event_data));
+
+    event_data[0].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY;
+    event_data[1].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY;
+
+    std::string serialized = sai_serialize_flow_bulk_get_session_event_ntf(flow_bulk_session_id, count, event_data);
+
+    sai_object_id_t deserialized_session_id;
+    uint32_t deserialized_count;
+    sai_flow_bulk_get_session_event_data_t* deserialized_data;
+
+    sai_deserialize_flow_bulk_get_session_event_ntf(serialized, deserialized_session_id, deserialized_count, &deserialized_data);
+
+    EXPECT_EQ(deserialized_session_id, flow_bulk_session_id);
+    EXPECT_EQ(deserialized_count, 0u);
 
     sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
 }
@@ -1743,7 +1774,7 @@ TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_emp
     sai_deserialize_flow_bulk_get_session_event_ntf(serialized, deserialized_session_id, deserialized_count, &deserialized_data);
 
     EXPECT_EQ(deserialized_session_id, flow_bulk_session_id);
-    EXPECT_EQ(deserialized_count, 0);
+    EXPECT_EQ(deserialized_count, 0u);
 
     sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On the DPU, the SAI `on_flow_bulk_get_session_event` notification delivers two kinds of events:
- `SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY` — one per flow in the bulk get session.
- `SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED` — terminal marker that the dump (bulk sync or flow dump) is complete.

Two problems with the current path:

1. Every `FLOW_ENTRY` was being serialized into the notification JSON and pushed over to orchagent. The flow entries themselves are already persisted by syncd to per-VID files under `/var/dump/flows/`, so orchagent only needs the `FINISHED` signal. With large flow counts on a DPU this payload becomes very large and is pure overhead. Order of flow can be in millions.
2. Flow dump files are named by VID. VIDs will repeat after a syncd restart, so stale `*.gz` files from a previous run could be re-opened/appended to, leading to mixed or stale dumps that look valid to tooling.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. `meta/SaiSerialize.cpp` — `sai_serialize_flow_bulk_get_session_event_ntf`
   - Drop all `FLOW_ENTRY` events from the serialized payload 
   - Walk `data` in reverse and emit a single entry for the first `FINISHED` event encountered
   - Net result: the notification payload to orchagent is bounded and tiny regardless of the number of flows in the session.

2. `syncd/scripts/syncd_init_common.sh` — new `cleanup_stale_flow_dump_files`
   - On every `config_syncd`, immediately after `check_warm_boot`, remove `/var/dump/flows/*gz` so syncd starts with a clean directory and cannot reuse stale per-VID dump files from the previous run.

#### How to verify it

- Unit tests in `unittest/meta/TestSaiSerialize.cpp` were updated/added to cover the new semantics:

Dump 1300 flows but only one notification is recieved on orchagent (SaiRedis Client)

```
# tail -f /var/log/swss/sairedis.rec 
2026-05-19.21:07:54.047431|c|SAI_OBJECT_TYPE_FLOW_ENTRY_BULK_GET_SESSION:oid:0x18008000000029|SAI_FLOW_ENTRY_BULK_GET_SESSION_ATTR_DASH_FLOW_ENTRY_BULK_GET_SESSION_MODE=SAI_DASH_FLOW_ENTRY_BULK_GET_SESSION_MODE_SAI_DASH_FLOW_ENTRY_BULK_GET_SESSION_MODE_EVENT_WITHOUT_FLOW_STATE|SAI_FLOW_ENTRY_BULK_GET_SESSION_ATTR_BULK_GET_ENTRY_LIMITATION=1362
2026-05-19.21:07:55.186006|n|flow_bulk_get_session_event|{"bulk_session_id":"oid:0x18008000000029","data":[{"event_type":"SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED"}]}|
2026-05-19.21:07:55.188617|r|SAI_OBJECT_TYPE_FLOW_ENTRY_BULK_GET_SESSION:oid:0x18008000000029

# gzip -d /var/dump/flows/flow_dump_0x0018008000000029.jsonl.gz

# wc -l /var/dump/flows/flow_dump_0x0018008000000029.jsonl
1361 /var/dump/flows/flow_dump_0x0018008000000029.jsonl
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

[DPU] Skip per-flow `FLOW_ENTRY` events in the flow bulk get session notification (only forward `FINISHED` to orchagent) and clean up stale `/var/dump/flows/*gz` on syncd start.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A — no config_db / YANG changes.

#### A picture of a cute animal (not mandatory but encouraged)