### PR TITLE
[vpp]: Program sub-interface IP addresses directly into VPP

### DIFF
--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -364,7 +364,7 @@ bool SwitchVpp::vpp_get_hwif_name (
     }
 
     const char *hwifname = tap_to_hwif_name(if_name.c_str());
-    char hw_subifname[32];
+    char hw_subifname[64];
     const char *hw_ifname;
 
     if (vlan_id) {
@@ -785,7 +785,7 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr (
     }
 
     const char *hwifname = tap_to_hwif_name(if_name.c_str());
-    char hw_subifname[32];
+    char hw_subifname[64];
     const char *hw_ifname;
 
     if (vlan_id) {
@@ -1001,7 +1001,7 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
     }
 
     const char *hwifname;
-    char hw_subifname[32];
+    char hw_subifname[64];
     char hw_bviifname[32];
     char hw_bondifname[32];
     const char *hw_ifname;
@@ -1011,7 +1011,11 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
        hw_ifname = hw_bviifname;
     } else if (full_if_name.compare(0, strlen(PORTCHANNEL_PREFIX), PORTCHANNEL_PREFIX) == 0) {
         uint32_t bond_id = std::stoi(full_if_name.substr(strlen(PORTCHANNEL_PREFIX)));
-        snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d", BONDETHERNET_PREFIX, bond_id);
+        if (vlan_id) {
+            snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d.%u", BONDETHERNET_PREFIX, bond_id, vlan_id);
+        } else {
+            snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d", BONDETHERNET_PREFIX, bond_id);
+        }
         hw_ifname = hw_bondifname;
     } else {
        hwifname = tap_to_hwif_name(if_name.c_str());
@@ -1367,7 +1371,7 @@ sai_status_t SwitchVpp::vpp_get_router_intf_name (
     }
 
     const char *hwifname = tap_to_hwif_name(if_name.c_str());
-    char hw_subifname[32];
+    char hw_subifname[64];
     const char *hw_ifname;
 
     if (vlan_id) {

--- a/vslib/vpp/SwitchVppRoute.cpp
+++ b/vslib/vpp/SwitchVppRoute.cpp
@@ -147,7 +147,17 @@ sai_status_t SwitchVpp::IpRouteAddRemove(
 
     if (SAI_OBJECT_TYPE_ROUTER_INTERFACE == RealObjectIdManager::objectTypeQuery(next_hop_oid))
     {
-        // vpp_add_del_intf_ip_addr(route_entry.destination, next_hop_oid, is_add);
+        /* For SUB_PORT RIFs, program the IP directly since LCP doesn't sync sub-interface IPs.
+         * Use _norif variant which handles both PORT and LAG sub-interface name resolution. */
+        sai_attribute_t rif_attr;
+        rif_attr.id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
+        sai_status_t rif_status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, next_hop_oid, 1, &rif_attr);
+
+        if (rif_status == SAI_STATUS_SUCCESS &&
+            rif_attr.value.s32 == SAI_ROUTER_INTERFACE_TYPE_SUB_PORT)
+        {
+            vpp_add_del_intf_ip_addr_norif(serializedObjectId, route_entry, is_add);
+        }
     }
     else if (SAI_OBJECT_TYPE_PORT == RealObjectIdManager::objectTypeQuery(next_hop_oid))
     {


### PR DESCRIPTION
### Description of PR

Summary:
Sub-interface IP addresses are not programmed into VPP, causing VPP to be unable to respond to packets destined to its own sub-interface IPs (e.g., ICMP echo-request to a gateway address on Ethernet64.20 or PortChannel1.20). Inter-VLAN L3 forwarding through VPP works, but local-delivery is broken.

The root cause is that `vpp_add_del_intf_ip_addr` was commented out in the `ROUTER_INTERFACE` route case during the Debian Bullseye migration because the original function hard-rejected non-PORT interface types. VPP's LCP plugin handles IP sync for regular ports, but does not handle sub-interfaces. Additionally, the PortChannel branch in `vpp_add_del_intf_ip_addr_norif` never appended the `.vlan_id` suffix, so LAG sub-interfaces would get the IP on the parent bond instead of the sub-interface.

Fixes https://github.com/sonic-net/sonic-platform-vpp/issues/227

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

`test_packet_routed_with_valid_vlan[port]` and `test_packet_routed_with_valid_vlan[port_in_lag]` both fail on VPP because VPP sub-interfaces have no IP programmed — they can forward traffic between sub-ports but cannot reply to packets destined to themselves.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

* Wire `vpp_add_del_intf_ip_addr_norif` into the ROUTER_INTERFACE route case for SUB_PORT RIFs
* Fix PortChannel branch in `vpp_add_del_intf_ip_addr_norif` to append `.vlan_id` for sub-interfaces
* Bump all `hw_subifname` buffers from [32] to [64] to prevent truncation on long hwif names

#### How did you verify/test it?

Todo: Run `test_packet_routed_with_valid_vlan[port]` and `test_packet_routed_with_valid_vlan[port_in_lag]` in the t1-lag-vpp topology (Platform: kvm, ASIC type: vpp).

#### Any platform specific information?

VPP platform only. Regular PORT RIFs are unaffected (gated by `SAI_ROUTER_INTERFACE_TYPE_SUB_PORT` check). LCP-based IP sync for non-sub-interface ports remains unchanged.

### Documentation

N/A