### PR TITLE
[vslib/vpp] Opt in to inner-aware flow hash on default + non-default VRFs

### DIFF
--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -679,9 +679,18 @@ sai_status_t SwitchVpp::vpp_create_lag(
         return SAI_STATUS_FAILURE;
     }
 
-    // Set mode and lb. SONiC config does not have provision to pass mode and load balancing algorithm
+    // Set mode and lb. SONiC config does not have provision to pass mode and load balancing algorithm.
+    // Select VPP's new opt-in inner-aware LAG hash algorithm (BOND_API_LB_ALGO_L34_INNER, value 6,
+    // CLI keyword "l34-inner") so that LAG distribution stays balanced for IPinIP / 6in4 / 4in6 /
+    // 6in6 / GRE / NVGRE transit tunnel traffic.  The existing BOND_API_LB_ALGO_L34 (= 1) and the
+    // registered hash function "hash-eth-l34" are byte-for-byte unchanged on the VPP side, so a
+    // libsaivs that selects value 1 keeps the legacy outer-only hashing behaviour; libsaivs that
+    // selects value 6 (this code) gets the inner-aware hash function "hash-eth-l34-inner".
+    // ABI compatibility with stock libvppinfra is preserved because the new enum value carries the
+    // [backwards_compatible] annotation in src/vnet/bonding/bond.api -- vppapigen excludes it from
+    // the CRC of every bond_create* / sw_interface_bond_details / sw_bond_interface_details message.
     mode = VPP_BOND_API_MODE_XOR;
-    lb = VPP_BOND_API_LB_ALGO_L34;
+    lb = VPP_BOND_API_LB_ALGO_L34_INNER;
 
     create_bond_interface(bond_id, mode, lb, &swif_idx);
     if (swif_idx == static_cast<uint32_t>(~0))

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1408,10 +1408,13 @@ int SwitchVpp::vpp_add_ip_vrf (_In_ sai_object_id_t objectId, uint32_t vrf_id)
 
         uint32_t hash_mask =  VPP_IP_API_FLOW_HASH_SRC_IP | VPP_IP_API_FLOW_HASH_DST_IP | \
             VPP_IP_API_FLOW_HASH_SRC_PORT | VPP_IP_API_FLOW_HASH_DST_PORT | \
-            VPP_IP_API_FLOW_HASH_PROTO;
+            VPP_IP_API_FLOW_HASH_PROTO | VPP_IP_API_FLOW_HASH_PEEK_INNER;
 
         int ret = vpp_ip_flow_hash_set(vrf_id, hash_mask, AF_INET);
         SWSS_LOG_NOTICE("ip flow hash set for VRF %s with vrf_id %u in VS, status %d",
+                        sai_serialize_object_id(objectId).c_str(), vrf_id, ret);
+        ret = vpp_ip_flow_hash_set(vrf_id, hash_mask, AF_INET6);
+        SWSS_LOG_NOTICE("ip6 flow hash set for VRF %s with vrf_id %u in VS, status %d",
                         sai_serialize_object_id(objectId).c_str(), vrf_id, ret);
     }
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -105,6 +105,8 @@ extern "C" {
         VPP_IP_API_FLOW_HASH_REVERSE = 32,
         VPP_IP_API_FLOW_HASH_SYMETRIC = 64,
         VPP_IP_API_FLOW_HASH_FLOW_LABEL = 128,
+        VPP_IP_API_FLOW_HASH_GTPV1_TEID = 256,
+        VPP_IP_API_FLOW_HASH_PEEK_INNER = 512,
     } vpp_ip_flow_hash_mask_e;
 
     typedef enum {
@@ -246,6 +248,15 @@ typedef enum {
   VPP_BOND_API_LB_ALGO_RR = 3,
   VPP_BOND_API_LB_ALGO_BC = 4,
   VPP_BOND_API_LB_ALGO_AB = 5,
+  /*
+   * VPP's inner-aware LAG hash algorithm (added in
+   * sonic-platform-vpp patch 0010-sonic-inner-aware-flow-hash).
+   * Mirrors BOND_API_LB_ALGO_L34_INNER in src/vnet/bonding/bond.api,
+   * which is annotated [backwards_compatible] so adding this value
+   * does not change the CRC of any bond_create* /
+   * sw_interface_bond_details / sw_bond_interface_details message.
+   */
+  VPP_BOND_API_LB_ALGO_L34_INNER = 6,
 }  vpp_bond_lb_algo;
 
     typedef struct  _vpp_vxlan_tunnel {


### PR DESCRIPTION
### Description of PR

Summary: Wire SONiC's `vslib/vpp` adapter to the new VPP **inner-aware flow-hash** primitives so that LAG and ECMP distribution stay balanced for IPinIP / 6in4 / 4in6 / 6in6 / GRE / NVGRE transit tunnel traffic, without altering the hash for plain (non-tunnelled) flows.

The new VPP knobs are strictly **opt-in** — stock VPP behaviour, and any libsaivs built against the new headers but running on a stock libvppinfra, both keep byte-for-byte legacy outer-only hashing.

Fixes # (issue) — N/A (no GitHub issue; tracked via the design doc and companion PRs below)

Companion PRs (must be applied together):

- [sonic-net/sonic-platform-vpp#234](https://github.com/sonic-net/sonic-platform-vpp/pull/234) — vendors VPP patch `0010-sonic-inner-aware-flow-hash.patch` (defines `hash-eth-l34-inner`, `BOND_API_LB_ALGO_L34_INNER`, and the `FLOW_HASH_PEEK_INNER` bit).
- [sonic-net/sonic-mgmt#24721](https://github.com/sonic-net/sonic-mgmt/pull/24721) — enables the tunnel-hash sweep tests on `t1-lag-vpp`.
- `sonic-net/sonic-buildimage` — submodule bump (TBD) after this PR merges.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?

The sonic-vpp software-only platform currently hashes every transit tunnel (IPinIP / 6in4 / 4in6 / 6in6 / GRE / NVGRE) on its **outer** 5-tuple only. When many distinct inner flows share an outer 5-tuple — the common case for SONiC T1 LAG topologies — they collapse onto a single LAG member and a single ECMP next-hop, and `sonic-mgmt`'s `tests/fib/test_fib.py` tunnel-hash sweep (`test_ipinip_hash`, `test_nvgre_hash`, `test_vxlan_hash`) deviates by more than the 5% balance threshold.

The companion sonic-platform-vpp PR adds the upstream VPP-side fix (a new `hash-eth-l34-inner` function and a new `BOND_API_LB_ALGO_L34_INNER = 6` bond algorithm, plus a `FLOW_HASH_PEEK_INNER` FIB bit).  This PR is the libsaivs half: it actually opts the sonic-vpp LAG and FIB into the new inner-aware path.

##### Work item tracking

- Microsoft ADO **(number only)**:

#### How did you do it?

Three small changes in `vslib/vpp/`, total **3 files, +26/−3**:

| File | Change |
|---|---|
| `vslib/vpp/vppxlate/SaiVppXlate.h` | Add `VPP_IP_API_FLOW_HASH_GTPV1_TEID = 256` and `VPP_IP_API_FLOW_HASH_PEEK_INNER = 512` to `vpp_ip_flow_hash_mask_e` so the enum stays a 1:1 mirror of `ip_flow_hash_config_v2_t` in `src/vnet/ip/ip.api`. Add `VPP_BOND_API_LB_ALGO_L34_INNER = 6` to `vpp_bond_lb_algo` to mirror the new `BOND_API_LB_ALGO_L34_INNER` in `src/vnet/bonding/bond.api`. |
| `vslib/vpp/SwitchVppRif.cpp` | In `SwitchVpp::vpp_add_ip_vrf`, OR `VPP_IP_API_FLOW_HASH_PEEK_INNER` into the hash mask and add a second `vpp_ip_flow_hash_set` call for `AF_INET6` so v6 traffic in the same VRF gets the same treatment as v4. |
| `vslib/vpp/SwitchVppFdb.cpp` | In `SwitchVpp::vpp_create_lag`, select `VPP_BOND_API_LB_ALGO_L34_INNER` instead of `VPP_BOND_API_LB_ALGO_L34` so the bond's load-balance function becomes the inner-aware `hash-eth-l34-inner`. This is the **only** call site in `sonic-sairedis` that selects the new algorithm. |

ABI compatibility with stock libvppinfra is preserved because the new bond LB enum value carries the `[backwards_compatible]` annotation in `src/vnet/bonding/bond.api` — `vppapigen` excludes it from the CRC of every `bond_create` / `bond_create2` / `sw_interface_bond_details` / `sw_bond_interface_details` message.  Similarly the `PEEK_INNER` bit is silently rejected by stock VPP's `ip_flow_hash_config_v2_t` validation, so a libsaivs built against the new headers but loaded against a stock libvppinfra simply falls back to the legacy outer-only hash — no crash, no test regression.

Compatibility matrix:

| sonic-sairedis | libvppinfra (VPP headers) | VPP runtime | Result |
|:---|:---|:---|:---|
| this PR | stock | stock | LAG falls back to legacy outer L34 (runtime rejects `lb=6`); FIB falls back to legacy outer hash (runtime rejects `PEEK_INNER` bit). No crash, no regression. |
| this PR | patched (PR #234 vendored headers) | stock | Same as above — CRCs match because of `[backwards_compatible]`. |
| this PR | patched | patched | **Inner-aware LAG + ECMP active**; tunnel-hash sweep passes. |
| master   | any | patched | LAG and FIB stay on legacy outer hash (no `lb=6` selected, no `PEEK_INNER` bit set). Inner-aware code paths in VPP are dormant. |

#### How did you verify/test it?

End-to-end on `vms-kvm-vpp-t1-lag` (`vlab-vpp-01`) with the matching VPP patch installed:

```
cd sonic-mgmt/tests
pytest fib/test_fib.py --topology=t1-lag-vpp --testbed=vms-kvm-vpp-t1-lag
```

Result: **16 / 16 PASS** — `test_ipv4_fib`, `test_ipv6_fib`, `test_basic_fib`, and the inner-hash sweep (`test_ipinip_hash`, `test_nvgre_hash`, `test_vxlan_hash` for both v4 and v6 outer/inner combinations).

Spot-checked on stock VPP (no companion patch) to confirm the fallback story: `lb=6` is rejected at runtime and the LAG silently uses legacy outer-only L34; no crash, no log spam.

#### Any platform specific information?

This PR only affects `vslib/vpp/` — the sonic-vpp software-only platform.  All other SAI vendor adapters (`vslib`, `SwitchSAI*`, `meta/`, `syncd/`) are untouched.

### Documentation

HLD: [sonic-net/SONiC#1860](https://github.com/sonic-net/SONiC/pull/1860) — *Inner-aware flow hash for VPP-based platforms* (v0.3, opt-in design).