### PR TITLE
Improve smartswitch memory scaling by conditionally caching high volu…

### DIFF
--- a/meta/DashMeta.cpp
+++ b/meta/DashMeta.cpp
@@ -1,6 +1,7 @@
 #include "DashMeta.h"
 
 #include "swss/logger.h"
+#include "sai_serialize.h"
 
 extern "C" {
 #include "saiextensions.h"
@@ -35,7 +36,7 @@ bool saimeta::isDashObjectType(sai_object_type_t ot)
     {
         if (t == ot)
         {
-            SWSS_LOG_NOTICE("DASH policy active for object type %d", (int)ot);
+            SWSS_LOG_DEBUG("DASH policy active for object type %d", (int)ot);
             return true;
         }
     }
@@ -45,10 +46,8 @@ bool saimeta::isDashObjectType(sai_object_type_t ot)
 DashCacheMode saimeta::getDashCacheMode()
 {
     static const DashCacheMode mode = []() {
-        SWSS_LOG_NOTICE(
-            "Meta DASH cache policy: NONE "
-            "(hardcoded, no caching or validation for DASH objects)");
-        return DashCacheMode::NONE;
+        SWSS_LOG_DEBUG("Meta DASH cache policy: EXISTENCE_REFCOUNT");
+        return DashCacheMode::EXISTENCE_REFCOUNT;
     }();
     return mode;
 }

--- a/meta/DashMeta.cpp
+++ b/meta/DashMeta.cpp
@@ -1,0 +1,54 @@
+#include "DashMeta.h"
+
+#include "swss/logger.h"
+
+extern "C" {
+#include "saiextensions.h"
+}
+
+using namespace saimeta;
+
+/*
+ * Hard-coded allow-list of DASH object types this policy applies to.
+ *
+ * Scoped to the three high-volume DASH entry types that dominate
+ * orchagent's meta-cache footprint at smart-switch scale (see
+ * sonic-buildimage issue #26683):
+ *
+ *   - OUTBOUND_CA_TO_PA_ENTRY
+ *   - OUTBOUND_ROUTING_ENTRY
+ *   - INBOUND_ROUTING_ENTRY
+ *
+ * All other object types (DASH or not) are unaffected and always behave
+ * as DashCacheMode::FULL.
+ */
+static const sai_object_type_t kDashTypes[] =
+{
+    (sai_object_type_t) SAI_OBJECT_TYPE_OUTBOUND_CA_TO_PA_ENTRY,
+    (sai_object_type_t) SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY,
+    (sai_object_type_t) SAI_OBJECT_TYPE_INBOUND_ROUTING_ENTRY,
+};
+
+bool saimeta::isDashObjectType(sai_object_type_t ot)
+{
+    for (auto t : kDashTypes)
+    {
+        if (t == ot)
+        {
+            SWSS_LOG_NOTICE("DASH policy active for object type %d", (int)ot);
+            return true;
+        }
+    }
+    return false;
+}
+
+DashCacheMode saimeta::getDashCacheMode()
+{
+    static const DashCacheMode mode = []() {
+        SWSS_LOG_NOTICE(
+            "Meta DASH cache policy: NONE "
+            "(hardcoded, no caching or validation for DASH objects)");
+        return DashCacheMode::NONE;
+    }();
+    return mode;
+}

--- a/meta/DashMeta.h
+++ b/meta/DashMeta.h
@@ -18,10 +18,9 @@ namespace saimeta
      *                       (parents can't be removed while DASH children
      *                       reference them) but non-OID attribute payloads
      *                       are not deep-copied.
-     * NONE                - Meta is a passthrough for DASH objects: no
-     *                       pre-validation, no post bookkeeping, no caching.
+     * NONE                - Meta is a passthrough for DASH objects
      *
-    * Policy is currently hardcoded to NONE.
+     * Policy is currently hardcoded to EXISTENCE_REFCOUNT.
      */
     enum class DashCacheMode
     {

--- a/meta/DashMeta.h
+++ b/meta/DashMeta.h
@@ -1,0 +1,77 @@
+#pragma once
+
+extern "C" {
+#include "saimetadata.h"
+}
+
+namespace saimeta
+{
+    /**
+     * @brief Meta-cache policy for DASH SAI object types only.
+     *
+     * Non-DASH object types are unaffected and always behave as FULL.
+     *
+     * FULL                - Default. Meta caches every attribute (today's
+     *                       behavior).
+     * EXISTENCE_REFCOUNT  - Meta caches the object key + only OID-typed
+     *                       attributes, so OidRefCounter keeps working
+     *                       (parents can't be removed while DASH children
+     *                       reference them) but non-OID attribute payloads
+     *                       are not deep-copied.
+     * NONE                - Meta is a passthrough for DASH objects: no
+     *                       pre-validation, no post bookkeeping, no caching.
+     *
+    * Policy is currently hardcoded to NONE.
+     */
+    enum class DashCacheMode
+    {
+        FULL,
+        EXISTENCE_REFCOUNT,
+        NONE,
+    };
+
+    DashCacheMode getDashCacheMode();
+
+    bool isDashObjectType(sai_object_type_t ot);
+
+    /**
+     * @brief Whether Meta should skip all pre/post validation and
+     *        bookkeeping for this object type.
+     *
+    * True only when the object type is a DASH object type AND the
+    * configured DashCacheMode is NONE.
+     */
+    inline bool bypassValidation(sai_object_type_t ot)
+    {
+        return isDashObjectType(ot)
+            && getDashCacheMode() == DashCacheMode::NONE;
+    }
+
+    /**
+     * @brief Whether Meta should deep-copy this attribute into
+     *        m_saiObjectCollection for the given (object_type, attr).
+     *
+     * Always true for non-DASH object types.
+     * For DASH object types it depends on the mode (see DashCacheMode).
+     *
+     * NOTE: callers should already short-circuit on DashCacheMode::NONE
+     * before invoking the post-validation paths; this helper is only used
+     * to gate the per-attribute deep copy inside post_create/post_set.
+     */
+    inline bool shouldCacheAttribute(
+            sai_object_type_t ot,
+            const sai_attr_metadata_t& md)
+    {
+        if (!isDashObjectType(ot))
+        {
+            return true;
+        }
+        switch (getDashCacheMode())
+        {
+            case DashCacheMode::FULL:               return true;
+            case DashCacheMode::EXISTENCE_REFCOUNT: return md.isoidattribute;
+            case DashCacheMode::NONE:               return false;
+        }
+        return true;
+    }
+}

--- a/meta/Makefile.am
+++ b/meta/Makefile.am
@@ -55,6 +55,7 @@ libsaimeta_la_SOURCES = \
 				SaiInterface.cpp \
 				SaiObject.cpp \
 				SaiObjectCollection.cpp \
+				DashMeta.cpp \
 				SaiSerialize.cpp \
 				SelectableChannel.cpp \
 				DummySaiInterface.cpp \

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1,5 +1,6 @@
 #include "Meta.h"
 
+#include "DashMeta.h"
 #include "swss/logger.h"
 #include "sai_serialize.h"
 
@@ -1572,6 +1573,11 @@ sai_status_t Meta::meta_generic_validation_remove(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     if (!m_saiObjectCollection.objectExists(meta_key))
     {
         SWSS_LOG_ERROR("object key %s doesn't exist",
@@ -1868,6 +1874,11 @@ void Meta::meta_generic_validation_post_remove(
         _In_ const sai_object_meta_key_t& meta_key)
 {
     SWSS_LOG_ENTER();
+
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return;
+    }
 
     if (meta_key.objecttype == SAI_OBJECT_TYPE_SWITCH)
     {
@@ -3329,6 +3340,11 @@ sai_status_t Meta::meta_generic_validation_create(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     if (attr_count > MAX_LIST_COUNT)
     {
         SWSS_LOG_ERROR("create attribute count %u > max list count %u", attr_count, MAX_LIST_COUNT);
@@ -4068,6 +4084,11 @@ sai_status_t Meta::meta_generic_validation_set(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     if (attr == NULL)
     {
         SWSS_LOG_ERROR("attribute pointer is NULL");
@@ -4576,6 +4597,11 @@ sai_status_t Meta::meta_generic_validation_get(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     if (attr_count < 1)
     {
         SWSS_LOG_ERROR("expected at least 1 attribute when calling get, zero given");
@@ -4916,6 +4942,11 @@ void Meta::meta_generic_validation_post_get(
         _In_ const sai_attribute_t *attr_list)
 {
     SWSS_LOG_ENTER();
+
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return;
+    }
 
     switch_id = meta_extract_switch_id(meta_key, switch_id);
 
@@ -5766,6 +5797,11 @@ void Meta::meta_generic_validation_post_create(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return;
+    }
+
     bool connectToSwitch = false;
 
     if (meta_key.objecttype == SAI_OBJECT_TYPE_SWITCH)
@@ -6070,7 +6106,13 @@ void Meta::meta_generic_validation_post_create(
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
         }
 
-        m_saiObjectCollection.setObjectAttr(meta_key, md, attr);
+        // DASH meta-cache policy: in EXISTENCE_REFCOUNT mode for DASH
+        // object types only cache OID-typed attributes (needed by
+        // OidRefCounter); drop deep-copies of everything else.
+        if (saimeta::shouldCacheAttribute(meta_key.objecttype, md))
+        {
+            m_saiObjectCollection.setObjectAttr(meta_key, md, attr);
+        }
     }
 
     if (haskeys)
@@ -6088,6 +6130,11 @@ void Meta::meta_generic_validation_post_set(
         _In_ const sai_attribute_t *attr)
 {
     SWSS_LOG_ENTER();
+
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return;
+    }
 
     auto mdp = sai_metadata_get_attr_metadata(meta_key.objecttype, attr->id);
 
@@ -6314,7 +6361,13 @@ void Meta::meta_generic_validation_post_set(
     // only on create we need to increase entry object types members
     // save actual attributes and values to local db
 
-    m_saiObjectCollection.setObjectAttr(meta_key, md, attr);
+    // DASH meta-cache policy: in EXISTENCE_REFCOUNT mode for DASH
+    // object types only cache OID-typed attributes (needed by
+    // OidRefCounter); drop deep-copies of everything else.
+    if (saimeta::shouldCacheAttribute(meta_key.objecttype, md))
+    {
+        m_saiObjectCollection.setObjectAttr(meta_key, md, attr);
+    }
 }
 
 bool Meta::meta_unittests_get_and_erase_set_readonly_flag(


### PR DESCRIPTION
Improve SmartSwitch memory scaling by conditionally caching high volume Dash objects

Addresses Issue #26683 - in SmartSwitch Dash scenarios, orchagent uses several GiB of memory

### Approach
#### What is the motivation for this PR?
SmartSwitch involves a much higher scale than regular SONiC scenarios. The relatively small overhead of objects such as outbound routes when cached in SaiObjectCollection accumulate to large overhead at scale. 
The caching of such objects is not particularly useful for SmartSwitch scenarios since vendor SAI implementations include checks that this caching was originally intended for - e.g., existence verification during CRUD operations, prevention of deletion of parent objects with active child objects.

#### How did you do it?
Implemented a per object-type check for caching. Three types of caching was introduced:
1. Full caching (current behavior)
2. Partial caching for existence and refcount checking (default)
3. No caching (testing purposes, not currenly used)

The above default of #2 is applied to 3 of the highest memory overhead object types:
1. Outbound CA-PA mapping
2. Inbound routing entry
3. Outbound routing entry

#### How did you verify/test it?
1. DVS tests to measure and compare memory savings in orchagent
2. Real SmartSwitch testbed tests with simulated neighbors to measure and compare memory savings
3. Regression suites to verify no effect on non-SmartSwitch use-cases

#### Any platform specific information?
Intended change should only affect SmartSwitch use-cases

