### PR TITLE
[CI] Add libnexthopgroup to CI pipeline for swss compilation

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -63,6 +63,17 @@ jobs:
     inputs:
       source: specific
       project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      artifact: common-lib
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/debs/*/libnexthopgroup_*.deb'
+    displayName: "Download sonic-buildimage libnexthopgroup package"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
       pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
@@ -106,6 +117,7 @@ jobs:
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
       cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
+      find $(Build.ArtifactStagingDirectory)/download -name 'libnexthopgroup_*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
 
       pushd .azure-pipelines
 

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -73,6 +73,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-route*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
         target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup-dev_*.deb
         target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
         target/debs/${{ parameters.debian_version }}/libprotoc*.deb
         target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -11,7 +11,7 @@ COPY ["debs", "/debs"]
 # same, even though contents have changed) are checked between the previous and current layer.
 RUN dpkg --remove --force-all libswsscommon
 RUN apt --fix-broken install -y
-RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi
+RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi libnexthopgroup
 
 RUN apt-get update
 
@@ -44,6 +44,7 @@ RUN apt install -y /debs/libdashapi_1.0.0_amd64.deb \
             /debs/libsairedis_1.0.0_amd64.deb \
             /debs/libsaivs_1.0.0_amd64.deb \
             /debs/syncd-vs_1.0.0_amd64.deb \
+            /debs/libnexthopgroup_1.0.0_amd64.deb \
             /debs/swss_1.0.0_amd64.deb
 
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/libsairedis-dbgsym_1.0.0_amd64.deb ; fi


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

__Summary:__
[sonic-swss PR #4394](https://github.com/sonic-net/sonic-swss/pull/4394) added -lnexthopgroup to fpmsyncd link dependencies, but only updated swss's own CI pipeline. This causes sairedis CI to fail when compiling swss because libnexthopgroup is missing from the build environment, with the error message:
```
2026-05-25T05:56:13.7258134Z /usr/bin/ld: cannot find -lnexthopgroup: No such file or directory 
```

To fix this, let's add libnexthopgroup deb download and installation to:
- build-swss-template.yml (swss compilation environment)
- build-docker-sonic-vs-template.yml (VS image build)
- docker-sonic-vs/Dockerfile (VS image runtime)

__Fix:__
This PR will fix the CI building.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
   - Fixing the CI building.

#### How did you do it?
   - Add libnexthopgroup deb download and installation to CI pipeline.

#### How did you verify/test it?
   - Verified the changes match the pattern used in [sonic-swss PR #4394](https://github.com/sonic-net/sonic-swss/pull/4394)
   - Will be validated by CI pipeline of this PR

#### Any platform specific information?
   - None
