### PR TITLE
[syncd] Survive transient redis disconnect in FlexCounter and notification threads

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -3535,9 +3535,32 @@ void FlexCounter::flexCounterThreadRunFunction()
     // (a partially-drained pipeline leaves m_remaining nonzero and would loop
     // on the same error forever), and let the thread keep polling so it
     // recovers naturally when redis comes back.
-    auto db = std::make_unique<swss::DBConnector>(m_dbCounters, 0, m_isTcpConn);
-    auto pipeline = std::make_unique<swss::RedisPipeline>(db.get());
-    auto countersTable = std::make_unique<swss::Table>(pipeline.get(), COUNTERS_TABLE, true);
+    std::unique_ptr<swss::DBConnector> db;
+    std::unique_ptr<swss::RedisPipeline> pipeline;
+    std::unique_ptr<swss::Table> countersTable;
+
+    auto recreateRedisObjects = [&]() -> bool {
+        try
+        {
+            countersTable.reset();
+            pipeline.reset();
+            db.reset();
+            db = std::make_unique<swss::DBConnector>(m_dbCounters, 0, m_isTcpConn);
+            pipeline = std::make_unique<swss::RedisPipeline>(db.get());
+            countersTable = std::make_unique<swss::Table>(pipeline.get(), COUNTERS_TABLE, true);
+            return true;
+        }
+        catch (const std::exception &re)
+        {
+            SWSS_LOG_ERROR("FlexCounter %s: failed to (re)create redis pipeline: %s",
+                           m_instanceId.c_str(), re.what());
+            return false;
+        }
+    };
+
+    // Initial creation. If it fails (e.g. database not yet up), the loop will
+    // keep retrying via recreateRedisObjects() before each collection cycle.
+    recreateRedisObjects();
 
     while (m_runFlexCounterThread)
     {
@@ -3547,6 +3570,24 @@ void FlexCounter::flexCounterThreadRunFunction()
         {
             auto start = std::chrono::steady_clock::now();
 
+            // Ensure redis objects are live before use. A previous iteration's
+            // exception handler tore them down; if recreate still fails (redis
+            // is still down), skip this poll and try again next iteration.
+            // Never call collectCounters/runPlugins with a null countersTable
+            // or null db - dereferencing a null unique_ptr is undefined
+            // behaviour and segfaults inside the callee.
+            if ((!db || !pipeline || !countersTable) && !recreateRedisObjects())
+            {
+                // Snapshot poll interval under the mutex before sleeping; the
+                // setter is guarded by m_mtx, so reading it here keeps the
+                // wait synchronized.
+                uint32_t sleepMs = m_pollInterval;
+                MUTEX_UNLOCK; // explicit unlock before sleeping
+                std::unique_lock<std::mutex> lk(m_mtxSleep);
+                m_cvSleep.wait_for(lk, std::chrono::milliseconds(sleepMs));
+                continue;
+            }
+
             try
             {
                 collectCounters(*countersTable);
@@ -3555,23 +3596,15 @@ void FlexCounter::flexCounterThreadRunFunction()
             }
             catch (const std::exception &e)
             {
-                SWSS_LOG_ERROR("FlexCounter %s: exception during counter collection: %s, recreating redis pipeline",
+                SWSS_LOG_ERROR("FlexCounter %s: exception during counter collection: %s, will recreate redis pipeline",
                                m_instanceId.c_str(), e.what());
 
-                try
-                {
-                    countersTable.reset();
-                    pipeline.reset();
-                    db.reset();
-                    db = std::make_unique<swss::DBConnector>(m_dbCounters, 0, m_isTcpConn);
-                    pipeline = std::make_unique<swss::RedisPipeline>(db.get());
-                    countersTable = std::make_unique<swss::Table>(pipeline.get(), COUNTERS_TABLE, true);
-                }
-                catch (const std::exception &re)
-                {
-                    SWSS_LOG_ERROR("FlexCounter %s: failed to recreate redis pipeline: %s",
-                                   m_instanceId.c_str(), re.what());
-                }
+                // Tear down only. Recreate happens at the top of the next
+                // iteration so a failed recreate does not leave us with a
+                // half-initialised state that segfaults on the next poll.
+                countersTable.reset();
+                pipeline.reset();
+                db.reset();
             }
 
             auto finish = std::chrono::steady_clock::now();

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <mutex>
+#include <memory>
 
 #include "FlexCounter.h"
 #include "VidManager.h"
@@ -3527,9 +3528,16 @@ void FlexCounter::flexCounterThreadRunFunction()
 {
     SWSS_LOG_ENTER();
 
-    swss::DBConnector db(m_dbCounters, 0, m_isTcpConn);
-    swss::RedisPipeline pipeline(&db);
-    swss::Table countersTable(&pipeline, COUNTERS_TABLE, true);
+    // Counter collection writes to COUNTERS_DB via RedisPipeline. If redis
+    // becomes unreachable (e.g. database container restart), RedisPipeline::pop()
+    // throws swss::RedisError. Without a catch here the unhandled exception
+    // terminates syncd via std::terminate(). Catch, recreate the redis objects
+    // (a partially-drained pipeline leaves m_remaining nonzero and would loop
+    // on the same error forever), and let the thread keep polling so it
+    // recovers naturally when redis comes back.
+    auto db = std::make_unique<swss::DBConnector>(m_dbCounters, 0, m_isTcpConn);
+    auto pipeline = std::make_unique<swss::RedisPipeline>(db.get());
+    auto countersTable = std::make_unique<swss::Table>(pipeline.get(), COUNTERS_TABLE, true);
 
     while (m_runFlexCounterThread)
     {
@@ -3539,9 +3547,32 @@ void FlexCounter::flexCounterThreadRunFunction()
         {
             auto start = std::chrono::steady_clock::now();
 
-            collectCounters(countersTable);
+            try
+            {
+                collectCounters(*countersTable);
 
-            runPlugins(db);
+                runPlugins(*db);
+            }
+            catch (const std::exception &e)
+            {
+                SWSS_LOG_ERROR("FlexCounter %s: exception during counter collection: %s, recreating redis pipeline",
+                               m_instanceId.c_str(), e.what());
+
+                try
+                {
+                    countersTable.reset();
+                    pipeline.reset();
+                    db.reset();
+                    db = std::make_unique<swss::DBConnector>(m_dbCounters, 0, m_isTcpConn);
+                    pipeline = std::make_unique<swss::RedisPipeline>(db.get());
+                    countersTable = std::make_unique<swss::Table>(pipeline.get(), COUNTERS_TABLE, true);
+                }
+                catch (const std::exception &re)
+                {
+                    SWSS_LOG_ERROR("FlexCounter %s: failed to recreate redis pipeline: %s",
+                                   m_instanceId.c_str(), re.what());
+                }
+            }
 
             auto finish = std::chrono::steady_clock::now();
 

--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -1121,7 +1121,19 @@ void NotificationProcessor::ntf_process_function()
 
         while (m_notificationQueue->tryDequeue(item))
         {
-            processNotification(item);
+            // processNotification publishes to redis via RedisChannel. If the
+            // database (redis) becomes unreachable, the underlying RedisPipeline
+            // throws swss::RedisError; without a catch here the unhandled
+            // exception terminates syncd via std::terminate(). Log and continue
+            // so the thread recovers naturally when redis comes back.
+            try
+            {
+                processNotification(item);
+            }
+            catch (const std::exception &e)
+            {
+                SWSS_LOG_ERROR("exception while processing notification: %s", e.what());
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of PR

`syncd-vpp` does not survive a transient redis (database container) disconnect: it dies with `SIGABRT` from `std::terminate`, originating in two `std::thread` bodies that have no top-level `try/catch`.

Reproducer (sonic-platform-vpp, vlab-vpp-01):
```bash
# inside syncd container, before patch:
docker exec database kill -SIGKILL $(docker exec database pgrep -f /usr/bin/redis-server)
# supervisord log inside syncd container:
WARN exited: syncd (terminated by SIGABRT (core dumped); not expected)
```

The exception that escapes is `swss::RedisError("RedisError: Failed to redisGetReply in RedisPipeline::pop, err=1: errstr=Broken pipe")` thrown by `RedisPipeline::pop()` ([sonic-swss-common/common/redispipeline.h:124](https://github.com/sonic-net/sonic-swss-common/blob/master/common/redispipeline.h#L124)). The two unprotected thread bodies are:

1. `FlexCounter::flexCounterThreadRunFunction` — calls `collectCounters(...)` / `runPlugins(...)`, both of which write to the FlexCounter `RedisPipeline` and then `flush()`. If redis is gone mid-flush, `pop()` throws.
2. `NotificationProcessor::ntf_process_function` — calls `processNotification(item)`, which in turn writes to the notification redis channel.

On Broadcom platforms this isn't visible because `dummy_syncd` doesn't drive these code paths the same way; on VPP, `saivpp` does, so the bug surfaces immediately.

This PR catches `std::exception` at the top of both `std::thread` bodies (the same `catch(std::exception)` pattern already used elsewhere in syncd — `Syncd.cpp:4896, 5527, 5562, 5860, 6004`). For the FlexCounter thread, the catch also **recreates** `DBConnector` + `RedisPipeline` + `Table`, because a `pop()` throw leaves `m_remaining > 0` in the pipeline and the next loop iteration would just throw the same error forever once redis is back.

This unblocks the `test_critical_process_monitoring` test on VPP (sonic-mgmt#25821).

Summary:
Fixes the SIGABRT half of https://github.com/sonic-net/sonic-buildimage/issues/25821 (the `process_monitoring` test failure on VPP). The remaining `database`-container-restart concerns (rsyslog/script restart) are addressed in sonic-mgmt / sonic-platform-vpp follow-ups, not here.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

`syncd` should not abort when its redis connection is briefly lost. The current behavior makes any redis hiccup a fatal crash, which is overly aggressive: redis losing a connection (e.g. supervisord-restarting redis-server inside the `database` container) is a *transient* condition that the rest of SONiC is expected to ride through.

#### How did you do it?

`syncd/FlexCounter.cpp` — `flexCounterThreadRunFunction`:
- Convert raw `db`, `pipeline`, `countersTable` pointers/locals to `std::unique_ptr` so they can be reset and recreated.
- Wrap the per-iteration `collectCounters(...)` + `runPlugins(...)` calls in `try/catch (const std::exception &e)`.
- On catch, log the error and **recreate** the unique_ptrs. This drops the broken pipeline (and its non-zero `m_remaining`) so the next iteration starts clean. A nested `try/catch` around the recreate avoids tight-looping if redis is still unreachable.

`syncd/NotificationProcessor.cpp` — `ntf_process_function`:
- Wrap `processNotification(item)` in `try/catch (const std::exception &e)`.
- On catch, log and continue. No state recreation needed — `processNotification` uses short-lived redis writers per call.

#### How did you verify/test it?

On a `sonic-platform-vpp` testbed (`vlab-vpp-01`, KVM, t1-lag):

1. Built `syncd-vs_1.0.0_amd64.deb` from this branch via `sonic-buildimage` (`BLDENV=bookworm SONIC_BUILD_JOBS=1 make -f Makefile.work target/debs/bookworm/syncd-vs_1.0.0_amd64.deb`).
2. Extracted the patched `/usr/bin/syncd` and hot-swapped it into the running `syncd` container on the DUT.
3. Reproduced the kill: `docker exec database kill -SIGKILL <redis-server pids>` (both 6379 and 6400).
4. Observed: **no SIGABRT**, syncd's PID stayed unchanged through redis death and through supervisord respawning `redis-server`.

Before patch:
```
WARN exited: syncd (terminated by SIGABRT (core dumped); not expected)
```

After patch:
```
syncd  RUNNING  pid 71, uptime 0:02:31    # same PID across redis kill+restart cycle
>>> SUCCESS: syncd (pid 71) survived redis SIGKILL <<<
>>> OVERALL SUCCESS: syncd (pid 71) survived redis-server restart cycle <<<
```

No new tests added — existing `test_critical_process_monitoring` in sonic-mgmt is the integration coverage; this PR unblocks the syncd half of it.

#### Any platform specific information?

The bug is visible on `sonic-platform-vpp` because `saivpp` implements real counter collection and the FlexCounter pipeline has pending writes when redis dies. On platforms whose SAI doesn't drive the same FlexCounter / notification paths under load, the throw site can go unhit, which is why this hasn't been noticed before.

The fix is platform-neutral — it hardens the `std::thread` bodies for all syncd consumers.
