### PR TITLE
[meta]: Add SAI_OBJECT_TYPE_METER_BUCKET_ENTRY to MetaKeyHasher

### DIFF
--- a/meta/MetaKeyHasher.cpp
+++ b/meta/MetaKeyHasher.cpp
@@ -357,6 +357,15 @@ static bool operator==(
     return a.switch_id == b.switch_id && a.eni_id == b.eni_id && a.vni_range == b.vni_range;
 }
 
+static bool operator==(
+        _In_ const sai_meter_bucket_entry_t& a,
+        _In_ const sai_meter_bucket_entry_t& b)
+{
+    // SWSS_LOG_ENTER(); // disabled for performance reasons
+
+    return a.switch_id == b.switch_id && a.eni_id == b.eni_id && a.meter_class == b.meter_class;
+}
+
 bool MetaKeyHasher::operator()(
         _In_ const sai_object_meta_key_t& a,
         _In_ const sai_object_meta_key_t& b) const
@@ -427,6 +436,9 @@ bool MetaKeyHasher::operator()(
 
     if ((sai_object_type_extensions_t)a.objecttype == SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY)
         return a.objectkey.key.eni_trusted_vni_entry == b.objectkey.key.eni_trusted_vni_entry;
+
+    if ((sai_object_type_extensions_t)a.objecttype == SAI_OBJECT_TYPE_METER_BUCKET_ENTRY)
+        return a.objectkey.key.meter_bucket_entry == b.objectkey.key.meter_bucket_entry;
 
     SWSS_LOG_THROW("not implemented: %s",
             sai_serialize_object_meta_key(a).c_str());
@@ -783,6 +795,18 @@ static inline std::size_t sai_get_hash(
     return hash;
 }
 
+static inline std::size_t sai_get_hash(
+        _In_ const sai_meter_bucket_entry_t & oe)
+{
+    // SWSS_LOG_ENTER(); // disabled for performance reasons
+
+    std::size_t hash = 0;
+    boost::hash_combine(hash, oe.eni_id);
+    boost::hash_combine(hash, oe.meter_class);
+
+    return hash;
+}
+
 std::size_t MetaKeyHasher::operator()(
         _In_ const sai_object_meta_key_t& k) const
 {
@@ -860,6 +884,9 @@ std::size_t MetaKeyHasher::operator()(
 
         case SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY:
             return sai_get_hash(k.objectkey.key.eni_trusted_vni_entry);
+
+        case SAI_OBJECT_TYPE_METER_BUCKET_ENTRY:
+            return sai_get_hash(k.objectkey.key.meter_bucket_entry);
 
         default:
             SWSS_LOG_THROW("not handled: %s", sai_serialize_object_type(k.objecttype).c_str());

--- a/unittest/meta/TestMetaKeyHasher.cpp
+++ b/unittest/meta/TestMetaKeyHasher.cpp
@@ -150,3 +150,29 @@ TEST(MetaKeyHasher, operator_eq_ipck)
 
     EXPECT_TRUE(mh.operator()(ma, mb));
 }
+
+TEST(MetaKeyHasher, operator_eq_meter_bucket_entry)
+{
+    sai_object_meta_key_t ma;
+    sai_object_meta_key_t mb;
+
+    memset(&ma, 0, sizeof(ma));
+    memset(&mb, 0, sizeof(mb));
+
+    ma.objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_METER_BUCKET_ENTRY;
+    mb.objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_METER_BUCKET_ENTRY;
+
+    ma.objectkey.key.meter_bucket_entry.eni_id = 0x1;
+    ma.objectkey.key.meter_bucket_entry.meter_class = 7;
+
+    mb.objectkey.key.meter_bucket_entry.eni_id = 0x1;
+    mb.objectkey.key.meter_bucket_entry.meter_class = 7;
+
+    MetaKeyHasher mh;
+
+    EXPECT_TRUE(mh.operator()(ma, mb));
+    EXPECT_NO_THROW(mh.operator()(ma));
+
+    mb.objectkey.key.meter_bucket_entry.meter_class = 8;
+    EXPECT_FALSE(mh.operator()(ma, mb));
+}


### PR DESCRIPTION
### What I did

* Microsoft ADO (number only): 38615565

Added handling for `SAI_OBJECT_TYPE_METER_BUCKET_ENTRY` in [meta/MetaKeyHasher.cpp](meta/MetaKeyHasher.cpp):
- `operator==` overload for `sai_meter_bucket_entry_t` comparing `(switch_id, eni_id, meter_class)`.
- `sai_get_hash` for the same struct.
- `case` in the extension switch of both `MetaKeyHasher::operator()` (hash) and `MetaKeyHasher::operator()` (equality).
- Unit test `MetaKeyHasher.operator_eq_meter_bucket_entry` in [unittest/meta/TestMetaKeyHasher.cpp](unittest/meta/TestMetaKeyHasher.cpp).

### Why I did it

`MetaKeyHasher::operator()` / `operator==` are the hasher/comparator used by the unordered containers keyed by `sai_object_meta_key_t` inside [meta/Meta.cpp](meta/Meta.cpp) (e.g. `m_saiObjectCollection`). Any meta-key whose object type isn't enumerated in the two switch statements falls through to `SWSS_LOG_THROW("not handled: ...")`.

`SAI_OBJECT_TYPE_METER_BUCKET_ENTRY` is a DASH extension entry type already supported by `sai_serialize_meter_bucket_entry` / `sai_deserialize_meter_bucket_entry` in [meta/SaiSerialize.cpp](meta/SaiSerialize.cpp), but it was never added to the hasher. As a result, unit tests `Meta.quad_mcast_fdb_entry` and `Meta.quad_impc_entry` started failing with:

```
:- operator(): not handled: SAI_OBJECT_TYPE_METER_BUCKET_ENTRY
```

when the meta layer iterated extension entry metadata while validating create/get/remove on mcast_fdb / ipmc entries. The companion test `Meta.remove_meter_bucket_entry` passes because its code path does not exercise the hasher branch.

### How I verified it

- New unit test `MetaKeyHasher.operator_eq_meter_bucket_entry` exercises both `operator()` overloads (hash + equality) with `SAI_OBJECT_TYPE_METER_BUCKET_ENTRY` keys.
- Existing meta unit tests `Meta.quad_mcast_fdb_entry` / `Meta.quad_impc_entry` should now pass on CI.

### Details if related

Hash is computed from `(eni_id, meter_class)`, matching the pattern used for other extension entries such as `SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY`. `switch_id` is intentionally not folded into the hash (consistent with other entry hashers) but is included in the equality check.