### PR TITLE
[DPU] Increase hugepages to 16000 for nvidia-bluefield kernel

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -597,7 +597,7 @@ config_syncd_nvidia_bluefield()
         mkdir -p "$SDK_DUMP_PATH"
     fi
 
-    echo 11700 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+    echo 16000 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
     mkdir -p /mnt/huge
     mount -t hugetlbfs pagesize=1GB /mnt/huge
 


### PR DESCRIPTION
#### Why I did it
Bump the hugepages allocation on NVIDIA BlueField DPU syncd from 11700 to 16000 (2 MiB pages) to
meet the requirements of the latest NVIDIA BlueField SDN release, which calls for a larger
hugepage reservation to support the maximum SDN configuration of 64 ENIs.

#### How I did it
- In `syncd/scripts/syncd_init_common.sh`, inside `config_syncd_nvidia_bluefield()`, increase the
  value written to `/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages` from `11700` to
  `16000`.

#### How to verify it
- Boot syncd on an NVIDIA BlueField DPU running the latest NVIDIA BlueField SDN release.
- Verify the new value is applied:
  `cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages` should report `16000`.
- Bring up the maximum supported SDN configuration of 64 ENIs and confirm syncd and the SDN apply configuration as expected

#### Tested branch (Please provide the tested image version)
- [x] master

#### Description for the changelog
Increase hugepages to 16000 for nvidia-bluefield kernel