### PR TITLE
[azp] Download and install libyang3 instead of libyang, add libnexthopgroup

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -63,6 +63,17 @@ jobs:
     inputs:
       source: specific
       project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      artifact: common-lib
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/debs/*/libnexthopgroup_*.deb'
+    displayName: "Download sonic-buildimage libnexthopgroup package"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
       pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
@@ -106,6 +117,7 @@ jobs:
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
       cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
+      find $(Build.ArtifactStagingDirectory)/download -name 'libnexthopgroup_*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
 
       pushd .azure-pipelines
 

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -73,6 +73,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-route*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup-dev_*.deb
         target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
         target/debs/${{ parameters.debian_version }}/libprotoc*.deb
         target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -72,7 +72,7 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-genl*.deb
         target/debs/${{ parameters.debian_version }}/libnl-route*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
         target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
         target/debs/${{ parameters.debian_version }}/libprotoc*.deb
         target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb
@@ -172,7 +172,7 @@ jobs:
   - script: |
       set -ex
       # install libyang before install libswsscommon
-      sudo env VPP_INSTALL_SKIP_SYSCTL=1 dpkg -i $(find ./download -name libyang_*.deb)
+      sudo env VPP_INSTALL_SKIP_SYSCTL=1 dpkg -i $(find ./download -name libyang3_*.deb)
       sudo env VPP_INSTALL_SKIP_SYSCTL=1 dpkg -i $(find ./download -name *.deb)
       rm -rf download || true
       cat /etc/apt/sources.list

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -140,7 +140,7 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
     displayName: "Download libyang from amd64 common lib"
   - task: DownloadPipelineArtifact@2
     condition: and(ne('${{ parameters.debian_version }}', 'trixie'), ne('${{ parameters.arch }}', 'amd64'))
@@ -153,7 +153,7 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
   - task: DownloadPipelineArtifact@2
     condition: and(eq('${{ parameters.debian_version }}', 'trixie'), eq('${{ parameters.arch }}', 'amd64'))
     inputs:
@@ -165,7 +165,7 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
         target/debs/${{ parameters.debian_version }}/libpcre3_*.deb
     displayName: "Download libyang from amd64 common lib"
   - task: DownloadPipelineArtifact@2
@@ -179,7 +179,7 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
         target/debs/${{ parameters.debian_version }}/libpcre3_*.deb
     displayName: "Download libyang from common lib"
   - script: |

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -11,7 +11,7 @@ COPY ["debs", "/debs"]
 # same, even though contents have changed) are checked between the previous and current layer.
 RUN dpkg --remove --force-all libswsscommon
 RUN apt --fix-broken install -y
-RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi
+RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi libnexthopgroup
 
 RUN apt-get update
 
@@ -44,6 +44,7 @@ RUN apt install -y /debs/libdashapi_1.0.0_amd64.deb \
             /debs/libsairedis_1.0.0_amd64.deb \
             /debs/libsaivs_1.0.0_amd64.deb \
             /debs/syncd-vs_1.0.0_amd64.deb \
+            /debs/libnexthopgroup_1.0.0_amd64.deb \
             /debs/swss_1.0.0_amd64.deb
 
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/libsairedis-dbgsym_1.0.0_amd64.deb ; fi

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -68,10 +68,8 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb
-        target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
-        target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
-        target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang-dev_3*.deb
     displayName: "Download libyang from common lib"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -107,11 +105,22 @@ jobs:
 
       sudo sonic-sairedis/.azure-pipelines/build_and_install_module.sh
 
-      # Install libyang packages from downloaded artifacts
-      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+      # Install libyang packages from downloaded artifacts. Use apt rather
+      # than `dpkg -i` so libyang-dev's libpcre2-dev dep is auto-resolved
+      # from the host repos.
+      sudo apt-get install -y \
+          $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_*.deb \
+          $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-dev_3*.deb
+
+      # python3-libyang's bookworm .deb pins python3 (>= 3.11~, << 3.12)
+      # and the sonictest pool host runs Ubuntu 22.04 (python 3.10), so the
+      # .deb won't install regardless of resolver. Build the Python bindings
+      # from PyPI instead — same fallback as the inline amd64/ubuntu-22.04
+      # job. --no-build-isolation + apt's python3-cffi sidesteps a cffi
+      # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
+      # env otherwise triggers.
+      sudo apt-get install -y python3-cffi
+      sudo pip3 install --no-build-isolation 'libyang==3.3.0'
 
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Installing libyang3 in the CI pipeline. Also incorporate changes from https://github.com/sonic-net/sonic-sairedis/pull/1908 to avoid circular dependency with this PR.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-swss-common/pull/973 changed swss-common to depend on libyang3

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
When building in the PR check pipeline, download and install libyang3. A similar change was made for sonic-swss: https://github.com/sonic-net/sonic-swss/pull/4618

#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
