### PR TITLE
[smartswitch][meta] add cache policy for specific DASH entry types

### DIFF
--- a/meta/DashMeta.cpp
+++ b/meta/DashMeta.cpp
@@ -1,0 +1,107 @@
+#include "DashMeta.h"
+
+#include "swss/logger.h"
+#include "sai_serialize.h"
+
+extern "C" {
+#include "saiextensions.h"
+}
+
+using namespace saimeta;
+
+namespace
+{
+    /*
+     * Meta-cache policy for DASH SAI entry types only. Non-DASH object
+     * types are unaffected and always behave as FULL.
+     *
+     *   FULL                cache every attribute (upstream default)
+     *   EXISTENCE_REFCOUNT  cache key + OID attrs only (OidRefCounter
+     *                       still works; non-OID payloads not deep-copied)
+     *   NONE                pass-through, skip all meta bookkeeping
+     */
+    enum class DashCacheMode
+    {
+        FULL,
+        EXISTENCE_REFCOUNT,
+        NONE,
+    };
+
+    constexpr DashCacheMode kDashCacheMode = DashCacheMode::EXISTENCE_REFCOUNT;
+
+    /*
+     * Hard-coded allow-list of DASH object types this policy applies to.
+     *
+     * Scoped to the three high-volume DASH entry types that dominate
+     * orchagent's meta-cache footprint at smart-switch scale (issue #26683):
+     *
+     *   - OUTBOUND_CA_TO_PA_ENTRY
+     *   - OUTBOUND_ROUTING_ENTRY
+     *   - INBOUND_ROUTING_ENTRY
+     */
+    constexpr sai_object_type_t kDashTypes[] =
+    {
+        (sai_object_type_t) SAI_OBJECT_TYPE_OUTBOUND_CA_TO_PA_ENTRY,
+        (sai_object_type_t) SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY,
+        (sai_object_type_t) SAI_OBJECT_TYPE_INBOUND_ROUTING_ENTRY,
+    };
+}
+
+bool saimeta::isDashObjectType(sai_object_type_t ot)
+{
+    // SWSS_LOG_ENTER() is disabled for performance reasons
+    for (auto t : kDashTypes)
+    {
+        if (t == ot)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool saimeta::bypassValidation(sai_object_type_t ot)
+{
+    // SWSS_LOG_ENTER() is disabled for performance reasons
+    if (!isDashObjectType(ot))
+    {
+        return false;
+    }
+
+    SWSS_LOG_DEBUG("DASH policy active for object type %s (mode=%s)",
+            sai_serialize_object_type(ot).c_str(),
+            dashCacheModeName());
+
+    return kDashCacheMode == DashCacheMode::NONE;
+}
+
+bool saimeta::shouldCacheAttribute(
+        sai_object_type_t ot,
+        const sai_attr_metadata_t& md)
+{
+    // SWSS_LOG_ENTER() is disabled for performance reasons
+    if (!isDashObjectType(ot))
+    {
+        return true;
+    }
+
+    switch (kDashCacheMode)
+    {
+        case DashCacheMode::FULL:               return true;
+        case DashCacheMode::EXISTENCE_REFCOUNT: return md.isoidattribute;
+        case DashCacheMode::NONE:               return false;
+    }
+    return true;
+}
+
+const char* saimeta::dashCacheModeName()
+{
+    // SWSS_LOG_ENTER() is disabled for performance reasons
+    switch (kDashCacheMode)
+    {
+        case DashCacheMode::FULL:               return "FULL";
+        case DashCacheMode::EXISTENCE_REFCOUNT: return "EXISTENCE_REFCOUNT";
+        case DashCacheMode::NONE:               return "NONE";
+    }
+    return "UNKNOWN";
+}

--- a/meta/DashMeta.cpp
+++ b/meta/DashMeta.cpp
@@ -68,10 +68,6 @@ bool saimeta::bypassValidation(sai_object_type_t ot)
         return false;
     }
 
-    SWSS_LOG_DEBUG("DASH policy active for object type %s (mode=%s)",
-            sai_serialize_object_type(ot).c_str(),
-            dashCacheModeName());
-
     return kDashCacheMode == DashCacheMode::NONE;
 }
 
@@ -104,4 +100,19 @@ const char* saimeta::dashCacheModeName()
         case DashCacheMode::NONE:               return "NONE";
     }
     return "UNKNOWN";
+}
+
+void saimeta::logDashPolicy()
+{
+    SWSS_LOG_ENTER();
+
+    std::string types;
+    for (auto t : kDashTypes)
+    {
+        types += sai_serialize_object_type(t) + " ";
+    }
+
+    SWSS_LOG_NOTICE("DASH meta-cache policy: mode=%s, object_types=[ %s]",
+            dashCacheModeName(),
+            types.c_str());
 }

--- a/meta/DashMeta.h
+++ b/meta/DashMeta.h
@@ -1,0 +1,34 @@
+#pragma once
+
+extern "C" {
+#include "saimetadata.h"
+}
+
+namespace saimeta
+{
+    /**
+     * @brief Whether the given object type is a DASH type subject to the
+     *        DASH meta-cache policy.
+     */
+    bool isDashObjectType(sai_object_type_t ot);
+
+    /**
+     * @brief Whether Meta should skip all pre/post validation and
+     *        bookkeeping for this object type.
+     */
+    bool bypassValidation(sai_object_type_t ot);
+
+    /**
+     * @brief Whether Meta should deep-copy this attribute into
+     *        m_saiObjectCollection for the given (object_type, attr).
+     */
+    bool shouldCacheAttribute(
+            sai_object_type_t ot,
+            const sai_attr_metadata_t& md);
+
+    /**
+     * @brief Human-readable name of the currently configured DASH
+     *        meta-cache mode (e.g. "FULL", "EXISTENCE_REFCOUNT", "NONE").
+     */
+    const char* dashCacheModeName();
+}

--- a/meta/DashMeta.h
+++ b/meta/DashMeta.h
@@ -31,4 +31,6 @@ namespace saimeta
      *        meta-cache mode (e.g. "FULL", "EXISTENCE_REFCOUNT", "NONE").
      */
     const char* dashCacheModeName();
+
+    void logDashPolicy();
 }

--- a/meta/Makefile.am
+++ b/meta/Makefile.am
@@ -55,6 +55,7 @@ libsaimeta_la_SOURCES = \
 				SaiInterface.cpp \
 				SaiObject.cpp \
 				SaiObjectCollection.cpp \
+				DashMeta.cpp \
 				SaiSerialize.cpp \
 				SelectableChannel.cpp \
 				DummySaiInterface.cpp \

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -167,7 +167,7 @@ Meta::Meta(
 
     m_warmBoot = false;
 
-    SWSS_LOG_NOTICE("DASH meta-cache policy: %s", saimeta::dashCacheModeName());
+    saimeta::logDashPolicy();
 }
 
 sai_status_t Meta::apiInitialize(

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -1,5 +1,6 @@
 #include "Meta.h"
 
+#include "DashMeta.h"
 #include "swss/logger.h"
 #include "sai_serialize.h"
 
@@ -165,6 +166,8 @@ Meta::Meta(
     // then warm boot must be per each switch
 
     m_warmBoot = false;
+
+    SWSS_LOG_NOTICE("DASH meta-cache policy: %s", saimeta::dashCacheModeName());
 }
 
 sai_status_t Meta::apiInitialize(
@@ -1572,6 +1575,11 @@ sai_status_t Meta::meta_generic_validation_remove(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     if (!m_saiObjectCollection.objectExists(meta_key))
     {
         SWSS_LOG_ERROR("object key %s doesn't exist",
@@ -1868,6 +1876,11 @@ void Meta::meta_generic_validation_post_remove(
         _In_ const sai_object_meta_key_t& meta_key)
 {
     SWSS_LOG_ENTER();
+
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return;
+    }
 
     if (meta_key.objecttype == SAI_OBJECT_TYPE_SWITCH)
     {
@@ -3037,6 +3050,11 @@ sai_status_t Meta::meta_sai_validate_inbound_routing_entry(
         return SAI_STATUS_INVALID_PARAMETER;
     }
 
+    if (saimeta::bypassValidation((sai_object_type_t)SAI_OBJECT_TYPE_INBOUND_ROUTING_ENTRY))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     sai_object_meta_key_t meta_key_inbound_routing_entry = {
         .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_INBOUND_ROUTING_ENTRY,
         .objectkey = {
@@ -3129,6 +3147,11 @@ sai_status_t Meta::meta_sai_validate_outbound_routing_entry(
         return SAI_STATUS_INVALID_PARAMETER;
     }
 
+    if (saimeta::bypassValidation((sai_object_type_t)SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     sai_object_meta_key_t meta_key_outbound_routing_entry = {
         .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_OUTBOUND_ROUTING_ENTRY,
         .objectkey = {
@@ -3173,6 +3196,11 @@ sai_status_t Meta::meta_sai_validate_outbound_ca_to_pa_entry(
         SWSS_LOG_ERROR("outbound_ca_to_pa_entry pointer is NULL");
 
         return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    if (saimeta::bypassValidation((sai_object_type_t)SAI_OBJECT_TYPE_OUTBOUND_CA_TO_PA_ENTRY))
+    {
+        return SAI_STATUS_SUCCESS;
     }
 
     sai_object_meta_key_t meta_key_outbound_ca_to_pa_entry = {
@@ -3328,6 +3356,11 @@ sai_status_t Meta::meta_generic_validation_create(
         _In_ const sai_attribute_t *attr_list)
 {
     SWSS_LOG_ENTER();
+
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
 
     if (attr_count > MAX_LIST_COUNT)
     {
@@ -4068,6 +4101,11 @@ sai_status_t Meta::meta_generic_validation_set(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     if (attr == NULL)
     {
         SWSS_LOG_ERROR("attribute pointer is NULL");
@@ -4576,6 +4614,11 @@ sai_status_t Meta::meta_generic_validation_get(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     if (attr_count < 1)
     {
         SWSS_LOG_ERROR("expected at least 1 attribute when calling get, zero given");
@@ -4916,6 +4959,11 @@ void Meta::meta_generic_validation_post_get(
         _In_ const sai_attribute_t *attr_list)
 {
     SWSS_LOG_ENTER();
+
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return;
+    }
 
     switch_id = meta_extract_switch_id(meta_key, switch_id);
 
@@ -5766,6 +5814,11 @@ void Meta::meta_generic_validation_post_create(
 {
     SWSS_LOG_ENTER();
 
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return;
+    }
+
     bool connectToSwitch = false;
 
     if (meta_key.objecttype == SAI_OBJECT_TYPE_SWITCH)
@@ -6070,7 +6123,10 @@ void Meta::meta_generic_validation_post_create(
                 META_LOG_THROW(md, "serialization type is not supported yet FIXME");
         }
 
-        m_saiObjectCollection.setObjectAttr(meta_key, md, attr);
+        if (saimeta::shouldCacheAttribute(meta_key.objecttype, md))
+        {
+            m_saiObjectCollection.setObjectAttr(meta_key, md, attr);
+        }
     }
 
     if (haskeys)
@@ -6088,6 +6144,11 @@ void Meta::meta_generic_validation_post_set(
         _In_ const sai_attribute_t *attr)
 {
     SWSS_LOG_ENTER();
+
+    if (saimeta::bypassValidation(meta_key.objecttype))
+    {
+        return;
+    }
 
     auto mdp = sai_metadata_get_attr_metadata(meta_key.objecttype, attr->id);
 
@@ -6314,7 +6375,10 @@ void Meta::meta_generic_validation_post_set(
     // only on create we need to increase entry object types members
     // save actual attributes and values to local db
 
-    m_saiObjectCollection.setObjectAttr(meta_key, md, attr);
+    if (saimeta::shouldCacheAttribute(meta_key.objecttype, md))
+    {
+        m_saiObjectCollection.setObjectAttr(meta_key, md, attr);
+    }
 }
 
 bool Meta::meta_unittests_get_and_erase_set_readonly_flag(

--- a/unittest/lib/TestClientServerSai.cpp
+++ b/unittest/lib/TestClientServerSai.cpp
@@ -2,6 +2,8 @@
 
 #include "sairedis.h"
 
+#include "DashMeta.h"
+
 #include "swss/logger.h"
 
 #include <gtest/gtest.h>
@@ -216,6 +218,10 @@ TEST(ClientServerSai, bulkGetClearStats)
 #define TEST_ENTRY(OT,ot)                                                \
 TEST(ClientServerSai, OT)                                                \
 {                                                                        \
+    if (saimeta::bypassValidation((sai_object_type_t)SAI_OBJECT_TYPE_ ## OT)) \
+    {                                                                    \
+        GTEST_SKIP() << "meta validation bypassed for " #OT;             \
+    }                                                                    \
     auto css = std::make_shared<ClientServerSai>();                      \
     sai_ ## ot ## _t e = {};                                             \
     EXPECT_EQ(SAI_STATUS_SUCCESS, css->apiInitialize(0, &test_services));   \
@@ -237,6 +243,10 @@ SAIREDIS_DECLARE_EVERY_ENTRY(TEST_ENTRY)
 #define TEST_BULK_ENTRY(OT,ot)                                                                                               \
 TEST(ClientServerSai, bulk_ ## OT)                                                                                           \
 {                                                                                                                            \
+    if (saimeta::bypassValidation((sai_object_type_t)SAI_OBJECT_TYPE_ ## OT))                                                \
+    {                                                                                                                        \
+        GTEST_SKIP() << "meta validation bypassed for " #OT;                                                                 \
+    }                                                                                                                        \
     auto css = std::make_shared<ClientServerSai>();                                                                          \
     sai_ ## ot ## _t e[2] = {};                                                                                              \
     EXPECT_EQ(SAI_STATUS_SUCCESS, css->apiInitialize(0, &test_services));                                                       \

--- a/unittest/meta/TestMetaDash.cpp
+++ b/unittest/meta/TestMetaDash.cpp
@@ -1377,3 +1377,217 @@ TEST(Meta, bulk_dash_outbound_ca_to_pa_entry)
     remove_counter(m, counter0);
     remove_counter(m, counter1);
 }
+
+
+// ---------------------------------------------------------------------------
+// DashMeta behavior tests.
+// ---------------------------------------------------------------------------
+
+#include "DashMeta.h"
+
+namespace
+{
+    constexpr sai_object_type_t kDashEntryType =
+        (sai_object_type_t)SAI_OBJECT_TYPE_INBOUND_ROUTING_ENTRY;
+
+    bool dashBypassActive()
+    {
+        // SWSS_LOG_ENTER() is disabled for performance reasons
+        return bypassValidation(kDashEntryType);
+    }
+}
+
+TEST(DashMeta, dashEntryCreate_ObjectCachingMatchesPolicy)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchid = create_switch(m);
+    sai_object_id_t vnet = create_vnet(m, switchid, 10);
+    sai_object_id_t eni = create_eni(m, switchid, vnet);
+
+    sai_ip_address_t sip, sip_mask;
+    sip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "192.168.0.1", &sip.addr.ip4);
+    sip_mask.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "255.255.255.0", &sip_mask.addr.ip4);
+
+    sai_inbound_routing_entry_t entry = {
+        .switch_id = switchid, .eni_id = eni, .vni = 10,
+        .sip = sip, .sip_mask = sip_mask, .priority = 1
+    };
+
+    sai_attribute_t attr;
+    attr.id = SAI_INBOUND_ROUTING_ENTRY_ATTR_ACTION;
+    attr.value.s32 = SAI_INBOUND_ROUTING_ENTRY_ACTION_VXLAN_DECAP;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(&entry, 1, &attr));
+
+    sai_object_meta_key_t meta_key = {
+        .objecttype = kDashEntryType,
+        .objectkey = { .key = { .inbound_routing_entry = entry } }
+    };
+
+    EXPECT_EQ(!dashBypassActive(), m.objectExists(meta_key))
+            << "policy=" << dashCacheModeName();
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(&entry));
+
+    EXPECT_FALSE(m.objectExists(meta_key));
+
+    remove_eni(m, eni);
+    remove_vnet(m, vnet);
+}
+
+TEST(DashMeta, dashEntryCreate_OidReferenceCountMatchesPolicy)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchid = create_switch(m);
+    sai_object_id_t vnet = create_vnet(m, switchid, 10);
+    sai_object_id_t eni = create_eni(m, switchid, vnet);
+
+    const int32_t vnet_refs_before = m.getObjectReferenceCount(vnet);
+    EXPECT_EQ(1, vnet_refs_before);
+
+    sai_ip_address_t sip, sip_mask;
+    sip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "192.168.0.1", &sip.addr.ip4);
+    sip_mask.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "255.255.255.0", &sip_mask.addr.ip4);
+
+    sai_inbound_routing_entry_t entry = {
+        .switch_id = switchid, .eni_id = eni, .vni = 10,
+        .sip = sip, .sip_mask = sip_mask, .priority = 1
+    };
+
+    sai_attribute_t attrs[2];
+    attrs[0].id = SAI_INBOUND_ROUTING_ENTRY_ATTR_ACTION;
+    attrs[0].value.s32 = SAI_INBOUND_ROUTING_ENTRY_ACTION_VXLAN_DECAP_PA_VALIDATE;
+    attrs[1].id = SAI_INBOUND_ROUTING_ENTRY_ATTR_SRC_VNET_ID;
+    attrs[1].value.oid = vnet;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(&entry, 2, attrs));
+
+    const int32_t expected_delta = dashBypassActive() ? 0 : 1;
+    EXPECT_EQ(vnet_refs_before + expected_delta, m.getObjectReferenceCount(vnet))
+            << "policy=" << dashCacheModeName();
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(&entry));
+
+    EXPECT_EQ(vnet_refs_before, m.getObjectReferenceCount(vnet));
+
+    remove_eni(m, eni);
+    remove_vnet(m, vnet);
+}
+
+TEST(DashMeta, dashEntryRemove_MissingResultMatchesPolicy)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchid = create_switch(m);
+    sai_object_id_t vnet = create_vnet(m, switchid, 99);
+    sai_object_id_t eni = create_eni(m, switchid, vnet);
+
+    sai_ip_address_t sip, sip_mask;
+    sip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "10.0.0.1", &sip.addr.ip4);
+    sip_mask.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "255.255.255.255", &sip_mask.addr.ip4);
+
+    sai_inbound_routing_entry_t entry = {
+        .switch_id = switchid, .eni_id = eni, .vni = 99,
+        .sip = sip, .sip_mask = sip_mask, .priority = 1
+    };
+
+    const sai_status_t expected = dashBypassActive()
+        ? SAI_STATUS_SUCCESS
+        : SAI_STATUS_ITEM_NOT_FOUND;
+
+    EXPECT_EQ(expected, m.remove(&entry))
+            << "policy=" << dashCacheModeName();
+
+    remove_eni(m, eni);
+    remove_vnet(m, vnet);
+}
+
+TEST(DashMeta, dashEntryCreate_DuplicateResultMatchesPolicy)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchid = create_switch(m);
+    sai_object_id_t vnet = create_vnet(m, switchid, 10);
+    sai_object_id_t eni = create_eni(m, switchid, vnet);
+
+    sai_ip_address_t sip, sip_mask;
+    sip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "192.168.0.1", &sip.addr.ip4);
+    sip_mask.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "255.255.255.0", &sip_mask.addr.ip4);
+
+    sai_inbound_routing_entry_t entry = {
+        .switch_id = switchid, .eni_id = eni, .vni = 10,
+        .sip = sip, .sip_mask = sip_mask, .priority = 1
+    };
+
+    sai_attribute_t attr;
+    attr.id = SAI_INBOUND_ROUTING_ENTRY_ATTR_ACTION;
+    attr.value.s32 = SAI_INBOUND_ROUTING_ENTRY_ACTION_VXLAN_DECAP;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(&entry, 1, &attr));
+
+    const sai_status_t expected = dashBypassActive()
+        ? SAI_STATUS_SUCCESS
+        : SAI_STATUS_ITEM_ALREADY_EXISTS;
+
+    EXPECT_EQ(expected, m.create(&entry, 1, &attr))
+            << "policy=" << dashCacheModeName();
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(&entry));
+    remove_eni(m, eni);
+    remove_vnet(m, vnet);
+}
+
+TEST(DashMeta, dashEntryVnetRemoveProtectionMatchesPolicy)
+{
+    Meta m(std::make_shared<MetaTestSaiInterface>());
+
+    sai_object_id_t switchid = create_switch(m);
+    sai_object_id_t vnet = create_vnet(m, switchid, 10);
+    sai_object_id_t eni = create_eni(m, switchid, vnet);
+
+    sai_ip_address_t sip, sip_mask;
+    sip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "192.168.0.1", &sip.addr.ip4);
+    sip_mask.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    inet_pton(AF_INET, "255.255.255.0", &sip_mask.addr.ip4);
+
+    sai_inbound_routing_entry_t entry = {
+        .switch_id = switchid, .eni_id = eni, .vni = 10,
+        .sip = sip, .sip_mask = sip_mask, .priority = 1
+    };
+
+    sai_attribute_t attrs[2];
+    attrs[0].id = SAI_INBOUND_ROUTING_ENTRY_ATTR_ACTION;
+    attrs[0].value.s32 = SAI_INBOUND_ROUTING_ENTRY_ACTION_VXLAN_DECAP_PA_VALIDATE;
+    attrs[1].id = SAI_INBOUND_ROUTING_ENTRY_ATTR_SRC_VNET_ID;
+    attrs[1].value.oid = vnet;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.create(&entry, 2, attrs));
+
+    const int32_t expected_refs_with_entry = dashBypassActive() ? 1 : 2;
+    EXPECT_EQ(expected_refs_with_entry, m.getObjectReferenceCount(vnet))
+            << "policy=" << dashCacheModeName();
+
+    EXPECT_EQ(SAI_STATUS_OBJECT_IN_USE,
+              m.remove((sai_object_type_t)SAI_OBJECT_TYPE_VNET, vnet));
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, m.remove(&entry));
+
+    EXPECT_EQ(1, m.getObjectReferenceCount(vnet));
+    EXPECT_EQ(SAI_STATUS_OBJECT_IN_USE,
+              m.remove((sai_object_type_t)SAI_OBJECT_TYPE_VNET, vnet));
+
+    remove_eni(m, eni);
+    EXPECT_EQ(0, m.getObjectReferenceCount(vnet));
+    remove_vnet(m, vnet);
+}


### PR DESCRIPTION
#### Summary
Addresses [#26683 ](https://github.com/sonic-net/sonic-buildimage/issues/26683)

#### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

#### What is the motivation for this PR?
 Issue #26683 exposed a memory scaling issue in smartswitch when large number
 of Dash objects are created.

#### How did you do it?
 All SAI objects and attributes are cached in SaiObjectCollection for validation
 although vendors typically do the same as well. This PR introduces a framework
 to control the cache-policy of an allow-list of SmartSwitch objects. The initial
 default policy is conservative caching of a small set of objects identified in
 Issue #26683 as particularly problematic.

#### How did you verify/test it?
 Verified with Virtual DVS testbeds, as well as real Pensando-based SmartSwitch
 testbeds. Orchagent RSS memory measured for all cases during test runs using
 same scale as originating issue - up to 16 ENIs, 125000 CA-PA mappings, and
 100000 outbound routes.

#### Any platform specific information?
  Impacts only SmartSwitch platforms

### Test Results
#### Virtual Testbed
32 ENIS, 100k outbound routes, and 12k CA-PA mappings
<img width="1916" height="1109" alt="virtual" src="https://github.com/user-attachments/assets/bce7e530-4653-4983-ae18-96bd7f1d3c46" />


#### Real Testbed
8 ENIS, 100k outbound routes, and 12k CA-PA mappings
<img width="2346" height="1296" alt="real" src="https://github.com/user-attachments/assets/d2eccef0-fc42-4c1c-ab66-8fc96ccfe3ad" />



