### PR TITLE
Make ZMQ fields optional in context_config.json

### DIFF
--- a/lib/ContextConfig.cpp
+++ b/lib/ContextConfig.cpp
@@ -17,8 +17,7 @@ ContextConfig::ContextConfig(
     m_dbCounters(dbCounters),
     m_dbFlex(dbFlex),
     m_dbState(dbState),
-    m_zmqEnable(false),
-    m_loadedFromJson(false),
+    m_zmqEnable(CONTEXT_CONFIG_ZMQ_EMPTY),
     m_zmqEndpoint("tcp://127.0.0.1:5555"),
     m_zmqNtfEndpoint("tcp://127.0.0.1:5556")
 {
@@ -79,16 +78,46 @@ bool ContextConfig::hasConflict(
 
     // state database can be shared
 
+    // When both contexts have CONTEXT_CONFIG_ZMQ_EMPTY, neither one has
+    // expressed an opinion about ZMQ in the config file. Matching
+    // endpoints are usually the shared constructor defaults from an
+    // ordinary non-ZMQ multi-context layout that omits the optional
+    // zmq_endpoint fields, so the loader must not reject the file. The
+    // match is still worth flagging in the log: if a cmdline override
+    // later promotes both contexts to ZMQ they will collide at bind
+    // time, and an operator scanning startup logs gets a hint at why.
+    bool bothZmqEmpty =
+            m_zmqEnable == CONTEXT_CONFIG_ZMQ_EMPTY
+            && ctx->m_zmqEnable == CONTEXT_CONFIG_ZMQ_EMPTY;
+
     if (m_zmqEndpoint == ctx->m_zmqEndpoint)
     {
-        SWSS_LOG_ERROR("zmqEndpoint %s conflict", m_zmqEndpoint.c_str());
-        return true;
+        if (bothZmqEmpty)
+        {
+            SWSS_LOG_WARN("zmqEndpoint %s matches between EMPTY contexts; "
+                    "cmdline ZMQ promotion would collide at bind",
+                    m_zmqEndpoint.c_str());
+        }
+        else
+        {
+            SWSS_LOG_ERROR("zmqEndpoint %s conflict", m_zmqEndpoint.c_str());
+            return true;
+        }
     }
 
     if (m_zmqNtfEndpoint == ctx->m_zmqNtfEndpoint)
     {
-        SWSS_LOG_ERROR("zmqNtfEndpoint %s conflict", m_zmqNtfEndpoint.c_str());
-        return true;
+        if (bothZmqEmpty)
+        {
+            SWSS_LOG_WARN("zmqNtfEndpoint %s matches between EMPTY contexts; "
+                    "cmdline ZMQ promotion would collide at bind",
+                    m_zmqNtfEndpoint.c_str());
+        }
+        else
+        {
+            SWSS_LOG_ERROR("zmqNtfEndpoint %s conflict", m_zmqNtfEndpoint.c_str());
+            return true;
+        }
     }
 
     return false;

--- a/lib/ContextConfig.cpp
+++ b/lib/ContextConfig.cpp
@@ -90,7 +90,17 @@ bool ContextConfig::hasConflict(
             m_zmqEnable == CONTEXT_CONFIG_ZMQ_EMPTY
             && ctx->m_zmqEnable == CONTEXT_CONFIG_ZMQ_EMPTY;
 
-    if (m_zmqEndpoint == ctx->m_zmqEndpoint)
+    // A context locked to Redis (CONTEXT_CONFIG_ZMQ_DISABLED) never binds or
+    // connects ZMQ sockets, so a shared endpoint with such a context can
+    // never collide at bind time. Flagging it as a conflict would make
+    // ContextConfigContainer::insert() throw, which loadFromFile() catches by
+    // discarding the entire parsed context_config.json and falling back to the
+    // default container, so a DISABLED context must not trigger that path.
+    bool eitherZmqDisabled =
+            m_zmqEnable == CONTEXT_CONFIG_ZMQ_DISABLED
+            || ctx->m_zmqEnable == CONTEXT_CONFIG_ZMQ_DISABLED;
+
+    if (m_zmqEndpoint == ctx->m_zmqEndpoint && !eitherZmqDisabled)
     {
         if (bothZmqEmpty)
         {
@@ -105,7 +115,7 @@ bool ContextConfig::hasConflict(
         }
     }
 
-    if (m_zmqNtfEndpoint == ctx->m_zmqNtfEndpoint)
+    if (m_zmqNtfEndpoint == ctx->m_zmqNtfEndpoint && !eitherZmqDisabled)
     {
         if (bothZmqEmpty)
         {

--- a/lib/ContextConfig.cpp
+++ b/lib/ContextConfig.cpp
@@ -78,57 +78,65 @@ bool ContextConfig::hasConflict(
 
     // state database can be shared
 
-    // When both contexts have CONTEXT_CONFIG_ZMQ_EMPTY, neither one has
-    // expressed an opinion about ZMQ in the config file. Matching
-    // endpoints are usually the shared constructor defaults from an
-    // ordinary non-ZMQ multi-context layout that omits the optional
-    // zmq_endpoint fields, so the loader must not reject the file. The
-    // match is still worth flagging in the log: if a cmdline override
-    // later promotes both contexts to ZMQ they will collide at bind
-    // time, and an operator scanning startup logs gets a hint at why.
-    bool bothZmqEmpty =
-            m_zmqEnable == CONTEXT_CONFIG_ZMQ_EMPTY
-            && ctx->m_zmqEnable == CONTEXT_CONFIG_ZMQ_EMPTY;
-
-    // A context locked to Redis (CONTEXT_CONFIG_ZMQ_DISABLED) never binds or
-    // connects ZMQ sockets, so a shared endpoint with such a context can
-    // never collide at bind time. Flagging it as a conflict would make
-    // ContextConfigContainer::insert() throw, which loadFromFile() catches by
-    // discarding the entire parsed context_config.json and falling back to the
-    // default container, so a DISABLED context must not trigger that path.
-    bool eitherZmqDisabled =
-            m_zmqEnable == CONTEXT_CONFIG_ZMQ_DISABLED
-            || ctx->m_zmqEnable == CONTEXT_CONFIG_ZMQ_DISABLED;
-
-    if (m_zmqEndpoint == ctx->m_zmqEndpoint && !eitherZmqDisabled)
+    if (zmqEndpointConflict(m_zmqEndpoint, ctx->m_zmqEndpoint,
+            m_zmqEnable, ctx->m_zmqEnable, "zmqEndpoint"))
     {
-        if (bothZmqEmpty)
-        {
-            SWSS_LOG_WARN("zmqEndpoint %s matches between EMPTY contexts; "
-                    "cmdline ZMQ promotion would collide at bind",
-                    m_zmqEndpoint.c_str());
-        }
-        else
-        {
-            SWSS_LOG_ERROR("zmqEndpoint %s conflict", m_zmqEndpoint.c_str());
-            return true;
-        }
+        return true;
     }
 
-    if (m_zmqNtfEndpoint == ctx->m_zmqNtfEndpoint && !eitherZmqDisabled)
+    if (zmqEndpointConflict(m_zmqNtfEndpoint, ctx->m_zmqNtfEndpoint,
+            m_zmqEnable, ctx->m_zmqEnable, "zmqNtfEndpoint"))
     {
-        if (bothZmqEmpty)
-        {
-            SWSS_LOG_WARN("zmqNtfEndpoint %s matches between EMPTY contexts; "
-                    "cmdline ZMQ promotion would collide at bind",
-                    m_zmqNtfEndpoint.c_str());
-        }
-        else
-        {
-            SWSS_LOG_ERROR("zmqNtfEndpoint %s conflict", m_zmqNtfEndpoint.c_str());
-            return true;
-        }
+        return true;
     }
 
     return false;
+}
+
+bool ContextConfig::zmqEndpointConflict(
+        _In_ const std::string& endpoint,
+        _In_ const std::string& otherEndpoint,
+        _In_ context_config_zmq_state_t zmqEnable,
+        _In_ context_config_zmq_state_t otherZmqEnable,
+        _In_ const char* label)
+{
+    SWSS_LOG_ENTER();
+
+    // Different endpoints can never collide at bind time.
+    if (endpoint != otherEndpoint)
+    {
+        return false;
+    }
+
+    // A context locked to Redis (CONTEXT_CONFIG_ZMQ_DISABLED) never binds or
+    // connects ZMQ sockets, so a shared endpoint with such a context can never
+    // collide at bind time. Flagging it as a conflict would make
+    // ContextConfigContainer::insert() throw, which loadFromFile() catches by
+    // discarding the entire parsed context_config.json and falling back to the
+    // default container, so a DISABLED context must not trigger that path.
+    if (zmqEnable == CONTEXT_CONFIG_ZMQ_DISABLED
+            || otherZmqEnable == CONTEXT_CONFIG_ZMQ_DISABLED)
+    {
+        return false;
+    }
+
+    // When both contexts have CONTEXT_CONFIG_ZMQ_EMPTY, neither one has
+    // expressed an opinion about ZMQ in the config file. Matching endpoints are
+    // usually the shared constructor defaults from an ordinary non-ZMQ
+    // multi-context layout that omits the optional zmq_endpoint fields, so the
+    // loader must not reject the file. The match is still worth flagging in the
+    // log: if a cmdline override later promotes both contexts to ZMQ they will
+    // collide at bind time, and an operator scanning startup logs gets a hint
+    // at why.
+    if (zmqEnable == CONTEXT_CONFIG_ZMQ_EMPTY
+            && otherZmqEnable == CONTEXT_CONFIG_ZMQ_EMPTY)
+    {
+        SWSS_LOG_WARN("%s %s matches between EMPTY contexts; "
+                "cmdline ZMQ promotion would collide at bind",
+                label, endpoint.c_str());
+        return false;
+    }
+
+    SWSS_LOG_ERROR("%s %s conflict", label, endpoint.c_str());
+    return true;
 }

--- a/lib/ContextConfig.h
+++ b/lib/ContextConfig.h
@@ -55,6 +55,21 @@ namespace sairedis
             bool hasConflict(
                     _In_ std::shared_ptr<const ContextConfig> ctx) const;
 
+        private:
+
+            /**
+             * @brief Decide whether two contexts sharing a ZMQ endpoint collide.
+             *
+             * Shared by the zmqEndpoint and zmqNtfEndpoint checks in
+             * hasConflict() so the same decision logic is not duplicated.
+             */
+            static bool zmqEndpointConflict(
+                    _In_ const std::string& endpoint,
+                    _In_ const std::string& otherEndpoint,
+                    _In_ context_config_zmq_state_t zmqEnable,
+                    _In_ context_config_zmq_state_t otherZmqEnable,
+                    _In_ const char* label);
+
         public: // TODO to private
 
             uint32_t m_guid;

--- a/lib/ContextConfig.h
+++ b/lib/ContextConfig.h
@@ -1,9 +1,38 @@
 #pragma once
 
+#include <cstdint>
+
 #include "SwitchConfigContainer.h"
 
 namespace sairedis
 {
+    /**
+     * @brief Per-context ZMQ enablement intent expressed in context_config.json.
+     *
+     * Three states are required because a context can set zmq_enable to true,
+     * set it to false, or omit the key entirely. The omitted case must remain
+     * distinguishable from an explicit false so reconciliation can defer to
+     * the command-line mode (-z zmq_sync) instead of overriding it.
+     */
+    typedef enum _context_config_zmq_state_t : uint8_t {
+
+        /**
+         * @brief Key absent in JSON. Defer to the command-line mode.
+         */
+        CONTEXT_CONFIG_ZMQ_EMPTY,
+
+        /**
+         * @brief zmq_enable: true. Lock to ZMQ; the command line cannot downgrade.
+         */
+        CONTEXT_CONFIG_ZMQ_ENABLED,
+
+        /**
+         * @brief zmq_enable: false. Lock to Redis; the command line cannot upgrade.
+         */
+        CONTEXT_CONFIG_ZMQ_DISABLED,
+
+    } context_config_zmq_state_t;
+
     class ContextConfig
     {
         public:
@@ -40,9 +69,7 @@ namespace sairedis
 
             std::string m_dbState;
 
-            bool m_zmqEnable;
-
-            bool m_loadedFromJson;
+            context_config_zmq_state_t m_zmqEnable;
 
             std::string m_zmqEndpoint;
 

--- a/lib/ContextConfigContainer.cpp
+++ b/lib/ContextConfigContainer.cpp
@@ -123,13 +123,30 @@ std::shared_ptr<ContextConfigContainer> ContextConfigContainer::loadFromFile(
 
             auto cc = std::make_shared<ContextConfig>(guid, name, dbAsic, dbCounters, dbFlex, dbState);
 
-            cc->m_zmqEnable = item["zmq_enable"];
-            cc->m_zmqEndpoint = item["zmq_endpoint"];
-            cc->m_zmqNtfEndpoint = item["zmq_ntf_endpoint"];
-            cc->m_loadedFromJson = true;
+            if (item.contains("zmq_enable"))
+            {
+                // .get<bool>() enforces the JSON boolean type. A numeric or
+                // string value throws type_error.302, which the outer
+                // try/catch turns into a fallback to the default container.
+                cc->m_zmqEnable = item["zmq_enable"].get<bool>() ? CONTEXT_CONFIG_ZMQ_ENABLED : CONTEXT_CONFIG_ZMQ_DISABLED;
+            }
+
+            if (item.contains("zmq_endpoint"))
+            {
+                cc->m_zmqEndpoint = item["zmq_endpoint"];
+            }
+
+            if (item.contains("zmq_ntf_endpoint"))
+            {
+                cc->m_zmqNtfEndpoint = item["zmq_ntf_endpoint"];
+            }
+
+            const char* zmqEnabledState = (cc->m_zmqEnable == CONTEXT_CONFIG_ZMQ_ENABLED) ? "true"
+                                        : (cc->m_zmqEnable == CONTEXT_CONFIG_ZMQ_DISABLED) ? "false"
+                                        : "empty";
 
             SWSS_LOG_NOTICE("contextConfig zmq enable %s, endpoint: %s, ntf endpoint: %s",
-                    (cc->m_zmqEnable) ? "true" : "false",
+                    zmqEnabledState,
                     cc->m_zmqEndpoint.c_str(),
                     cc->m_zmqNtfEndpoint.c_str());
 

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -81,7 +81,7 @@ sai_status_t RedisRemoteSaiInterface::apiInitialize(
     m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
     m_zmqResponseBufferSize = SAI_ZMQ_DEFAULT_RESPONSE_BUFFER_SIZE;
 
-    if (m_contextConfig->m_loadedFromJson && m_contextConfig->m_zmqEnable)
+    if (m_contextConfig->m_zmqEnable == CONTEXT_CONFIG_ZMQ_ENABLED)
     {
         // context_config.json is authoritative: lock this context to ZMQ at init
         SWSS_LOG_NOTICE("context %u: JSON zmq_enable=true, creating ZMQ channel at init",
@@ -354,7 +354,11 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
             m_syncMode = attr->value.booldata;
 
-            if (m_contextConfig->m_zmqEnable)
+            // Force sync mode when the active channel is ZMQ (ZMQ implies sync).
+            // Read the resolved channel state rather than the file's opinion so
+            // a context promoted to ZMQ at runtime via COMMUNICATION_MODE attr
+            // is treated the same as one locked to ZMQ by context_config.json.
+            if (m_redisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
             {
                 SWSS_LOG_NOTICE("zmq enabled, forcing sync mode");
 
@@ -372,8 +376,8 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
         case SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE:
 
-            // JSON zmq_enable=true: transport locked to ZMQ at init; ignore attr
-            if (m_contextConfig->m_loadedFromJson && m_contextConfig->m_zmqEnable)
+            // JSON zmq_enable=true: transport locked to ZMQ at init ignore attr
+            if (m_contextConfig->m_zmqEnable == CONTEXT_CONFIG_ZMQ_ENABLED)
             {
                 if (attr->value.s32 == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
                 {
@@ -430,7 +434,7 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
                 case SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC:
                     // If context_config.json explicitly set zmq_enable=false,
                     // respect it and fall back to RedisChannel
-                    if (m_contextConfig->m_loadedFromJson && !m_contextConfig->m_zmqEnable)
+                    if (m_contextConfig->m_zmqEnable == CONTEXT_CONFIG_ZMQ_DISABLED)
                     {
                         SWSS_LOG_NOTICE("context %u: zmq_enable=false in context config, falling back to Redis sync",
                                 m_contextConfig->m_guid);
@@ -453,7 +457,11 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
                     SWSS_LOG_NOTICE("ZMQ sync mode enabled for context %u", m_contextConfig->m_guid);
 
-                    m_contextConfig->m_zmqEnable = true;
+                    // m_zmqEnable is left untouched: it carries the file's
+                    // opinion (parsed once), not the resolved channel state.
+                    // The resolved state lives in m_redisCommunicationMode,
+                    // which the assignment above set to attr->value.s32; this
+                    // case label is reached only when that value is ZMQ_SYNC.
 
                     m_communicationChannel = std::make_shared<ZeroMQChannel>(
                             m_contextConfig->m_zmqEndpoint,

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -84,14 +84,20 @@ Syncd::Syncd(
         SWSS_LOG_THROW("no context config defined at global context %u", m_commandLineOptions->m_globalContext);
     }
 
-    if (m_commandLineOptions->m_enableSyncMode
-            && !(m_contextConfig->m_loadedFromJson && m_contextConfig->m_zmqEnable))
+    // Resolved per-process transport decision. Derived from the file's
+    // opinion (m_zmqEnable) and then adjusted by the deprecated -s and
+    // the -z command-line reconciles below. m_zmqEnable itself stays at
+    // the parsed value so any future code that needs the file's intent
+    // can still ask for it.
+    bool zmqActive = (m_contextConfig->m_zmqEnable == sairedis::CONTEXT_CONFIG_ZMQ_ENABLED);
+
+    if (m_commandLineOptions->m_enableSyncMode && m_contextConfig->m_zmqEnable != sairedis::CONTEXT_CONFIG_ZMQ_ENABLED)
     {
         SWSS_LOG_WARN("enable sync mode is deprecated, please use communication mode, FORCING redis sync mode");
 
         m_enableSyncMode = true;
 
-        m_contextConfig->m_zmqEnable = false;
+        zmqActive = false;
 
         m_commandLineOptions->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
     }
@@ -100,12 +106,14 @@ Syncd::Syncd(
     {
         // If context_config.json explicitly set zmq_enable=false,
         // respect it and fall back to Redis sync
-        if (m_contextConfig->m_loadedFromJson && !m_contextConfig->m_zmqEnable)
+        if (m_contextConfig->m_zmqEnable == sairedis::CONTEXT_CONFIG_ZMQ_DISABLED)
         {
             SWSS_LOG_NOTICE("context %u: zmq_enable=false in context config, falling back to Redis sync",
                     m_contextConfig->m_guid);
 
             m_enableSyncMode = true;
+
+            zmqActive = false;
 
             m_commandLineOptions->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
         }
@@ -113,7 +121,7 @@ Syncd::Syncd(
         {
             SWSS_LOG_NOTICE("zmq sync mode enabled via cmd line for context %u", m_contextConfig->m_guid);
 
-            m_contextConfig->m_zmqEnable = true;
+            zmqActive = true;
 
             m_enableSyncMode = true;
         }
@@ -136,7 +144,7 @@ Syncd::Syncd(
     m_dbAsic = std::make_shared<swss::DBConnector>(m_contextConfig->m_dbAsic, 0);
     m_mdioIpcServer = std::make_shared<MdioIpcServer>(m_vendorSai, m_commandLineOptions->m_globalContext);
 
-    if (m_contextConfig->m_zmqEnable)
+    if (zmqActive)
     {
         m_notifications = std::make_shared<ZeroMQNotificationProducer>(m_contextConfig->m_zmqNtfEndpoint);
 
@@ -170,8 +178,9 @@ Syncd::Syncd(
 
     bool isDpuSwitch = switchType == "dpu";
 
-    if (m_contextConfig->m_zmqEnable && isDpuSwitch && !isVirtualSwitch)
+    if (zmqActive && isDpuSwitch && !isVirtualSwitch)
     {
+        // For DPU switches, disable Redis writes to maintain backwards compatibility with PR #1694
         m_client = std::make_shared<DisabledRedisClient>();
     }
     else

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -516,3 +516,13 @@ setOpAllowList
 setStatsLabel
 HWM
 allowlist
+Cmdline
+cmdline
+codebase
+enablement
+guid
+hasn
+ifstream
+nlohmann
+reconciler
+truthy

--- a/unittest/lib/TestContextConfig.cpp
+++ b/unittest/lib/TestContextConfig.cpp
@@ -10,6 +10,13 @@ TEST(ContextConfig, hasConflict)
 {
     auto cc = std::make_shared<ContextConfig>(0, "syncd", "ASIC_DB", "COUNTERS_DB","FLEX_DB", "STATE_DB");
 
+    // hasConflict() suppresses the endpoint-equality check when both
+    // contexts are still in the constructor-default CONTEXT_CONFIG_ZMQ_EMPTY
+    // state, since the matching endpoints in that case are unspecified
+    // defaults rather than a real collision. Marking cc as ENABLED keeps
+    // the assertions below that depend on endpoint conflict detection.
+    cc->m_zmqEnable = CONTEXT_CONFIG_ZMQ_ENABLED;
+
     EXPECT_TRUE(cc->hasConflict(std::make_shared<ContextConfig>(0, "syncd", "ASIC_DB", "COUNTERS_DB","FLEX_DB", "STATE_DB")));
     EXPECT_TRUE(cc->hasConflict(std::make_shared<ContextConfig>(1, "syncd", "ASIC_DB", "COUNTERS_DB","FLEX_DB", "STATE_DB")));
     EXPECT_TRUE(cc->hasConflict(std::make_shared<ContextConfig>(1, "syncb", "ASIC_DB", "COUNTERS_DB","FLEX_DB", "STATE_DB")));
@@ -29,3 +36,40 @@ TEST(ContextConfig, hasConflict)
     EXPECT_FALSE(cc->hasConflict(aa));
 }
 
+// A freshly constructed ContextConfig has the EMPTY zmq state, meaning
+// "the operator has not expressed an opinion." The reconciliation layer
+// must then defer to the command-line mode.
+TEST(ContextConfig, defaultZmqStateIsEmpty)
+{
+    auto cc = std::make_shared<ContextConfig>(0, "syncd", "ASIC_DB", "COUNTERS_DB", "FLEX_DB", "STATE_DB");
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// The constructor seeds the canonical endpoint strings used when
+// context_config.json omits the endpoint fields. These constants are the
+// upstream defaults documented in the SAI redis communication mode header.
+TEST(ContextConfig, defaultZmqEndpointsMatchSpec)
+{
+    auto cc = std::make_shared<ContextConfig>(0, "syncd", "ASIC_DB", "COUNTERS_DB", "FLEX_DB", "STATE_DB");
+
+    EXPECT_EQ(cc->m_zmqEndpoint, "tcp://127.0.0.1:5555");
+    EXPECT_EQ(cc->m_zmqNtfEndpoint, "tcp://127.0.0.1:5556");
+}
+
+// The three enum values have stable distinct integer representations.
+// Several reads in the codebase (the SWSS_LOG_NOTICE label mapping in the
+// parser, for instance) depend on EMPTY/ENABLED/DISABLED being recognizable.
+TEST(ContextConfig, zmqStateEnumValuesAreDistinct)
+{
+    EXPECT_NE(CONTEXT_CONFIG_ZMQ_EMPTY, CONTEXT_CONFIG_ZMQ_ENABLED);
+    EXPECT_NE(CONTEXT_CONFIG_ZMQ_EMPTY, CONTEXT_CONFIG_ZMQ_DISABLED);
+    EXPECT_NE(CONTEXT_CONFIG_ZMQ_ENABLED, CONTEXT_CONFIG_ZMQ_DISABLED);
+}
+
+// EMPTY is the zero value of the enum so a default-constructed
+// ContextConfig (or any zero-initialized memory) lands on it.
+TEST(ContextConfig, zmqEmptyIsZero)
+{
+    EXPECT_EQ(static_cast<uint8_t>(CONTEXT_CONFIG_ZMQ_EMPTY), 0u);
+}

--- a/unittest/lib/TestContextConfigContainer.cpp
+++ b/unittest/lib/TestContextConfigContainer.cpp
@@ -275,6 +275,26 @@ TEST(ContextConfigContainer, hasConflict_twoEmptyContextsWithDefaultEndpointsDoN
     EXPECT_FALSE(a->hasConflict(b));
 }
 
+// An ENABLED context sharing endpoints with a DISABLED context is not a
+// conflict. The DISABLED context is locked to Redis and never binds a ZMQ
+// socket, so there is nothing for the ENABLED context to collide with. The
+// check is symmetric, so it holds regardless of which side is DISABLED.
+TEST(ContextConfigContainer, hasConflict_enabledAndDisabledShareEndpointsDoNotConflict)
+{
+    auto a = std::make_shared<ContextConfig>(0, "a", "ASIC_DB_A", "COUNTERS_DB_A", "FLEX_DB_A", "STATE_DB");
+    auto b = std::make_shared<ContextConfig>(1, "b", "ASIC_DB_B", "COUNTERS_DB_B", "FLEX_DB_B", "STATE_DB");
+
+    a->m_zmqEnable = CONTEXT_CONFIG_ZMQ_ENABLED;
+    b->m_zmqEnable = CONTEXT_CONFIG_ZMQ_DISABLED;
+
+    // both keep the shared constructor default endpoints
+    EXPECT_EQ(a->m_zmqEndpoint, b->m_zmqEndpoint);
+    EXPECT_EQ(a->m_zmqNtfEndpoint, b->m_zmqNtfEndpoint);
+
+    EXPECT_FALSE(a->hasConflict(b));
+    EXPECT_FALSE(b->hasConflict(a));
+}
+
 // loadFromFile is idempotent for the same file (no global state leak).
 TEST(ContextConfigContainer, loadFromFile_isIdempotent)
 {

--- a/unittest/lib/TestContextConfigContainer.cpp
+++ b/unittest/lib/TestContextConfigContainer.cpp
@@ -13,35 +13,285 @@ TEST(ContextConfigContainer, get)
     EXPECT_EQ(ccc.get(0), nullptr);
 }
 
-TEST(ContextConfigContainer, loadFromFile)
+// A malformed file (not JSON) is caught by the outer try/catch and falls
+// back to the default container with a single default context at guid 0.
+TEST(ContextConfigContainer, loadFromFile_malformedReturnsDefault)
 {
-    ContextConfigContainer ccc;
-
-    EXPECT_NE(ccc.loadFromFile("files/ccc_bad.txt"), nullptr);
-}
-
-TEST(ContextConfigContainer, loadFromFileSetLoadedFromJson)
-{
-    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_container_ok.json");
+    auto ccc = ContextConfigContainer::loadFromFile("files/ccc_bad.txt");
 
     ASSERT_NE(ccc, nullptr);
 
     auto cc = ccc->get(0);
-
     ASSERT_NE(cc, nullptr);
-    EXPECT_TRUE(cc->m_loadedFromJson);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+    EXPECT_EQ(cc->m_name, "syncd");
+    EXPECT_EQ(cc->m_dbAsic, "ASIC_DB");
 }
 
-TEST(ContextConfigContainer, defaultDoesNotSetLoadedFromJson)
+// A null path argument is treated as "no file specified" and returns the
+// default container immediately. Mirrors how syncd starts when -x is omitted.
+TEST(ContextConfigContainer, loadFromFile_nullPathReturnsDefault)
 {
     auto ccc = ContextConfigContainer::loadFromFile(nullptr);
 
     ASSERT_NE(ccc, nullptr);
 
     auto cc = ccc->get(0);
-
     ASSERT_NE(cc, nullptr);
-    EXPECT_FALSE(cc->m_loadedFromJson);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// A nonexistent file path fails the ifstream::good() check before any
+// parsing happens, and falls back to the default container.
+TEST(ContextConfigContainer, loadFromFile_nonexistentPathReturnsDefault)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/does_not_exist.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// The static default container has the EMPTY zmq state on its sole context.
+// This is what the reconciliation layer reads when no file is loaded.
+TEST(ContextConfigContainer, getDefault_zmqStateIsEmpty)
+{
+    auto ccc = ContextConfigContainer::getDefault();
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// JSON zmq_enable:true maps to CONTEXT_CONFIG_ZMQ_ENABLED. Endpoints from
+// the file override the constructor defaults.
+TEST(ContextConfigContainer, loadFromFile_zmqEnableTrueMapsToEnabled)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_container_ok.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_ENABLED);
+    EXPECT_EQ(cc->m_zmqEndpoint, "ipc:///tmp/test_zmq_ep");
+    EXPECT_EQ(cc->m_zmqNtfEndpoint, "ipc:///tmp/test_zmq_ntf_ep");
+}
+
+// JSON zmq_enable:false maps to CONTEXT_CONFIG_ZMQ_DISABLED. This must
+// remain distinguishable from "absent" so the reconciler can demote the
+// command line's request.
+TEST(ContextConfigContainer, loadFromFile_zmqEnableFalseMapsToDisabled)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_zmq_false.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_DISABLED);
+}
+
+// A valid file that omits zmq_enable leaves the field at EMPTY while the
+// rest of the context is preserved. This is the case that codifies "field
+// absent is a first-class state, not a silent reset."
+TEST(ContextConfigContainer, loadFromFile_zmqEnableAbsentLeavesEmpty)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_zmq_absent.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+
+    // Required fields and the present endpoints all survive the parse.
+    EXPECT_EQ(cc->m_name, "syncd");
+    EXPECT_EQ(cc->m_dbAsic, "ASIC_DB");
+    EXPECT_EQ(cc->m_dbCounters, "COUNTERS_DB");
+    EXPECT_EQ(cc->m_dbFlex, "FLEX_COUNTER_DB");
+    EXPECT_EQ(cc->m_dbState, "STATE_DB");
+    EXPECT_EQ(cc->m_zmqEndpoint, "ipc:///tmp/test_zmq_ep");
+    EXPECT_EQ(cc->m_zmqNtfEndpoint, "ipc:///tmp/test_zmq_ntf_ep");
+}
+
+// All three zmq fields absent: state stays EMPTY, both endpoints stay at
+// their constructor defaults, required fields still parse cleanly.
+TEST(ContextConfigContainer, loadFromFile_allZmqFieldsAbsentLeavesDefaults)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_all_zmq_absent.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+    EXPECT_EQ(cc->m_zmqEndpoint, "tcp://127.0.0.1:5555");
+    EXPECT_EQ(cc->m_zmqNtfEndpoint, "tcp://127.0.0.1:5556");
+
+    EXPECT_EQ(cc->m_name, "syncd");
+    EXPECT_EQ(cc->m_dbAsic, "ASIC_DB");
+}
+
+// A wrong-type value for zmq_enable (string instead of bool) cannot be
+// converted by nlohmann to a JSON bool, which throws type_error. The outer
+// try/catch then collapses the entire load to the default container. This
+// preserves the design's "malformed required structure → default" rule.
+TEST(ContextConfigContainer, loadFromFile_zmqEnableWrongTypeFallsBackToDefault)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_zmq_wrong_type.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    // The default container has name "syncd" but no relationship to the
+    // fixture's values. The single observable invariant is that the
+    // resulting zmq state is EMPTY rather than ENABLED or DISABLED.
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+    EXPECT_EQ(cc->m_zmqEndpoint, "tcp://127.0.0.1:5555");
+}
+
+// An integer value for zmq_enable is also rejected. Without the explicit
+// .get<bool>() call, nlohmann's contextual conversion in a ternary would
+// silently truthy-coerce 1 to ENABLED and 0 to DISABLED, bypassing strict
+// type checking. The parser uses .get<bool>() so any non-boolean JSON
+// value, integer included, throws type_error.302 and falls back to the
+// default container.
+TEST(ContextConfigContainer, loadFromFile_zmqEnableIntegerFallsBackToDefault)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_zmq_integer.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// A genuinely required field (guid) is missing. nlohmann's bracket access
+// throws, the outer try/catch collapses to default. Codifies that required
+// structure is strict even after the ZMQ fields became optional.
+TEST(ContextConfigContainer, loadFromFile_missingRequiredFieldFallsBackToDefault)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_missing_required.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc = ccc->get(0);
+    ASSERT_NE(cc, nullptr);
+
+    EXPECT_EQ(cc->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// Two contexts in one file with independent zmq states is the gearbox
+// configuration: main ASIC at guid 0 with zmq_enable:true, gbsyncd at
+// guid 1 with zmq_enable:false. Each context's field is honored
+// independently, which is the entire point of per-field precedence.
+TEST(ContextConfigContainer, loadFromFile_gearboxTwoContextsHaveIndependentZmqState)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_gearbox.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc0 = ccc->get(0);
+    auto cc1 = ccc->get(1);
+
+    ASSERT_NE(cc0, nullptr);
+    ASSERT_NE(cc1, nullptr);
+
+    EXPECT_EQ(cc0->m_zmqEnable, CONTEXT_CONFIG_ZMQ_ENABLED);
+    EXPECT_EQ(cc0->m_name, "syncd_main");
+
+    EXPECT_EQ(cc1->m_zmqEnable, CONTEXT_CONFIG_ZMQ_DISABLED);
+    EXPECT_EQ(cc1->m_name, "gbsyncd");
+}
+
+// Two contexts that both omit zmq_enable and the endpoint fields land
+// in CONTEXT_CONFIG_ZMQ_EMPTY with identical constructor-default
+// endpoints. The endpoint conflict check must skip this case so the
+// loader does not collapse the file to the single-context default.
+TEST(ContextConfigContainer, loadFromFile_twoEmptyContextsWithDefaultEndpointsDoNotConflict)
+{
+    auto ccc = ContextConfigContainer::loadFromFile("files/context_config_two_empty_no_endpoints.json");
+
+    ASSERT_NE(ccc, nullptr);
+
+    auto cc0 = ccc->get(0);
+    auto cc1 = ccc->get(1);
+
+    ASSERT_NE(cc0, nullptr);
+    ASSERT_NE(cc1, nullptr);
+
+    EXPECT_EQ(cc0->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+    EXPECT_EQ(cc1->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+
+    EXPECT_EQ(cc0->m_zmqEndpoint, cc1->m_zmqEndpoint);
+    EXPECT_EQ(cc0->m_zmqNtfEndpoint, cc1->m_zmqNtfEndpoint);
+
+    EXPECT_EQ(cc0->m_name, "syncd_main");
+    EXPECT_EQ(cc1->m_name, "gbsyncd");
+}
+
+// Two contexts that both opt into ZMQ but share the same endpoint
+// remain a real conflict: the bind sites collide. hasConflict() must
+// flag this and the container falls back to the default.
+TEST(ContextConfigContainer, hasConflict_twoEnabledContextsWithSameEndpointConflict)
+{
+    auto a = std::make_shared<ContextConfig>(0, "a", "ASIC_DB_A", "COUNTERS_DB_A", "FLEX_DB_A", "STATE_DB");
+    auto b = std::make_shared<ContextConfig>(1, "b", "ASIC_DB_B", "COUNTERS_DB_B", "FLEX_DB_B", "STATE_DB");
+
+    a->m_zmqEnable = CONTEXT_CONFIG_ZMQ_ENABLED;
+    b->m_zmqEnable = CONTEXT_CONFIG_ZMQ_ENABLED;
+
+    EXPECT_TRUE(a->hasConflict(b));
+}
+
+// Two contexts both EMPTY with identical defaults do not conflict; the
+// direct hasConflict() call codifies the same rule the loader relies
+// on, so the skip cannot regress without breaking this test.
+TEST(ContextConfigContainer, hasConflict_twoEmptyContextsWithDefaultEndpointsDoNotConflict)
+{
+    auto a = std::make_shared<ContextConfig>(0, "a", "ASIC_DB_A", "COUNTERS_DB_A", "FLEX_DB_A", "STATE_DB");
+    auto b = std::make_shared<ContextConfig>(1, "b", "ASIC_DB_B", "COUNTERS_DB_B", "FLEX_DB_B", "STATE_DB");
+
+    EXPECT_EQ(a->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+    EXPECT_EQ(b->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+
+    EXPECT_FALSE(a->hasConflict(b));
+}
+
+// loadFromFile is idempotent for the same file (no global state leak).
+TEST(ContextConfigContainer, loadFromFile_isIdempotent)
+{
+    auto first  = ContextConfigContainer::loadFromFile("files/context_config_container_ok.json");
+    auto second = ContextConfigContainer::loadFromFile("files/context_config_container_ok.json");
+
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+
+    auto a = first->get(0);
+    auto b = second->get(0);
+
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+
+    EXPECT_EQ(a->m_zmqEnable, b->m_zmqEnable);
+    EXPECT_EQ(a->m_zmqEndpoint, b->m_zmqEndpoint);
 }
 
 TEST(ContextConfigContainer, insert)

--- a/unittest/lib/TestRedisRemoteSaiInterface.cpp
+++ b/unittest/lib/TestRedisRemoteSaiInterface.cpp
@@ -2,6 +2,7 @@
 #include "ContextConfigContainer.h"
 #include "ContextConfig.h"
 #include "RedisChannel.h"
+#include "ZeroMQChannel.h"
 #include "sairediscommon.h"
 
 #include <gtest/gtest.h>
@@ -35,6 +36,22 @@ public:
   function<sai_status_t(const string &command, KeyOpFieldsValuesTuple &kco)> m_wait_mock;
 };
 
+// Helper: build a ContextConfig with a given zmq state and unique IPC
+// endpoints, so each test stands up its own ZMQ socket files without
+// colliding with siblings under /tmp.
+static std::shared_ptr<ContextConfig> makeCtx(
+        context_config_zmq_state_t state,
+        const std::string& tag)
+{
+    SWSS_LOG_ENTER();
+
+    auto cc = std::make_shared<ContextConfig>(
+            0, "syncd", "ASIC_DB", "COUNTERS_DB", "FLEX_COUNTER_DB", "STATE_DB");
+    cc->m_zmqEnable = state;
+    cc->m_zmqEndpoint    = "ipc:///tmp/test_rrsi_" + tag + "_ep";
+    cc->m_zmqNtfEndpoint = "ipc:///tmp/test_rrsi_" + tag + "_ntf_ep";
+    return cc;
+}
 
 TEST(RedisRemoteSaiInterface, queryStatsCapabilityNegative)
 {
@@ -91,14 +108,223 @@ TEST(RedisRemoteSaiInterface, queryStatsStCapability)
                                          &stats_capability));
 }
 
+// -------- Init scenarios: file opinion drives the initial channel choice --------
+
+// File explicitly enables ZMQ: init creates a ZeroMQChannel and the
+// resolved communication mode locks to ZMQ_SYNC.
+TEST(RedisRemoteSaiInterface, initSetsUpZmqChannelWhenJsonEnablesZmq)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_ENABLED, "init_enabled");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    EXPECT_NE(dynamic_cast<ZeroMQChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+    EXPECT_TRUE(sai.m_syncMode);
+}
+
+// File is silent on zmq_enable (EMPTY): init falls to the default Redis
+// channel; the resolved mode stays at the constructor default REDIS_ASYNC.
+TEST(RedisRemoteSaiInterface, initSetsUpRedisChannelWhenJsonZmqIsEmpty)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_EMPTY, "init_empty");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC);
+}
+
+// File explicitly disables ZMQ: init falls to Redis (file authoritative).
+TEST(RedisRemoteSaiInterface, initSetsUpRedisChannelWhenJsonDisablesZmq)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_DISABLED, "init_disabled");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC);
+}
+
+// -------- COMM_MODE attr: file ENABLED is authoritative, attr is ignored --------
+
+// File ENABLED + attr requesting ZMQ_SYNC: redundant, the early-return
+// guard fires; nothing changes.
+TEST(RedisRemoteSaiInterface, commModeIgnoredWhenJsonEnabledAndAttrIsZmqSync)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_ENABLED, "ignored_zmq");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    ASSERT_NE(dynamic_cast<ZeroMQChannel*>(sai.m_communicationChannel.get()), nullptr);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<ZeroMQChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+}
+
+// File ENABLED + attr requesting REDIS_ASYNC: caller's attempt to downgrade
+// the transport is rejected; the file's intent wins.
+TEST(RedisRemoteSaiInterface, commModeIgnoredWhenJsonEnabledAndAttrIsRedisAsync)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_ENABLED, "ignored_async");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<ZeroMQChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+}
+
+// File ENABLED + attr requesting REDIS_SYNC: same. File authoritative.
+TEST(RedisRemoteSaiInterface, commModeIgnoredWhenJsonEnabledAndAttrIsRedisSync)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_ENABLED, "ignored_sync");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<ZeroMQChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+}
+
+// -------- COMM_MODE attr: file EMPTY, caller drives --------
+
+// File EMPTY + attr ZMQ_SYNC: caller promotes the transport to ZMQ.
+// m_zmqEnable stays EMPTY: the file did not enable ZMQ, the caller did.
+TEST(RedisRemoteSaiInterface, commModePromotesToZmqWhenJsonEmpty)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_EMPTY, "empty_to_zmq");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    ASSERT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<ZeroMQChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+
+    // The file's opinion is not mutated by a runtime caller. That
+    // invariant is what lets a subsequent attr toggle work; see
+    // commModeCanSwitchBackWhenJsonEmpty below.
+    EXPECT_EQ(sai.m_contextConfig->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// File EMPTY + attr REDIS_ASYNC: just takes the attr value.
+TEST(RedisRemoteSaiInterface, commModeRedisAsyncWhenJsonEmpty)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_EMPTY, "empty_async");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC);
+    EXPECT_FALSE(sai.m_syncMode);
+}
+
+// File EMPTY + attr REDIS_SYNC: just takes the attr value, sync mode on.
+TEST(RedisRemoteSaiInterface, commModeRedisSyncWhenJsonEmpty)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_EMPTY, "empty_sync");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC);
+    EXPECT_TRUE(sai.m_syncMode);
+}
+
+// With a file-silent context, the caller can toggle the communication
+// mode back and forth via the COMM_MODE attr. The COMM_MODE handler keys
+// its file-authoritative early return off m_zmqEnable; as long as that
+// field reflects only what the file said (EMPTY here) and is not mutated
+// by runtime callers, the early return never fires for a runtime-driven
+// transition, and every toggle is honored.
+TEST(RedisRemoteSaiInterface, commModeCanSwitchBackWhenJsonEmpty)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_EMPTY, "toggle");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+
+    // Step 1: upgrade to ZMQ_SYNC.
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+    EXPECT_NE(dynamic_cast<ZeroMQChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+
+    // Step 2: downgrade back to REDIS_ASYNC. The COMM_MODE handler must
+    // honor this even after a prior runtime promotion to ZMQ on a
+    // file-silent context.
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC);
+
+    // Step 3: do it again, REDIS_SYNC this time, to make sure m_zmqEnable
+    // hasn't been quietly mutated.
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC);
+
+    // Step 4: back to ZMQ once more, confirming the runtime path is
+    // bidirectional through repeated toggles.
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+    EXPECT_NE(dynamic_cast<ZeroMQChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+
+    // Through every toggle, the file's opinion is preserved.
+    EXPECT_EQ(sai.m_contextConfig->m_zmqEnable, CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// -------- COMM_MODE attr: file DISABLED, file demotes ZMQ requests --------
+
+// File DISABLED + attr ZMQ_SYNC: demote to REDIS_SYNC. This is the
+// pre-existing test, updated to use the new enum.
 TEST(RedisRemoteSaiInterface, zmqSyncFallsBackToRedisSyncWhenJsonDisablesZmq)
 {
     SWSS_LOG_ENTER();
 
-    auto cc = std::make_shared<ContextConfig>(0, "syncd", "ASIC_DB", "COUNTERS_DB", "FLEX_COUNTER_DB", "STATE_DB");
-    cc->m_loadedFromJson = true;
-    cc->m_zmqEnable = false;
-
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_DISABLED, "disabled_demote");
     auto rec = make_shared<Recorder>();
     RedisRemoteSaiInterface sai(cc, nullptr, rec);
 
@@ -111,4 +337,116 @@ TEST(RedisRemoteSaiInterface, zmqSyncFallsBackToRedisSyncWhenJsonDisablesZmq)
     EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
     EXPECT_TRUE(sai.m_syncMode);
     EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC);
+
+    // The file's opinion is unchanged.
+    EXPECT_EQ(sai.m_contextConfig->m_zmqEnable, CONTEXT_CONFIG_ZMQ_DISABLED);
+}
+
+// File DISABLED + attr REDIS_ASYNC: caller's request matches the file's
+// "no ZMQ" intent, so it goes through normally.
+TEST(RedisRemoteSaiInterface, commModeRedisAsyncHonoredWhenJsonDisablesZmq)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_DISABLED, "disabled_async");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC);
+}
+
+// File DISABLED + attr REDIS_SYNC: similarly honored.
+TEST(RedisRemoteSaiInterface, commModeRedisSyncHonoredWhenJsonDisablesZmq)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_DISABLED, "disabled_sync");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_NE(dynamic_cast<RedisChannel*>(sai.m_communicationChannel.get()), nullptr);
+    EXPECT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC);
+    EXPECT_TRUE(sai.m_syncMode);
+}
+
+// -------- SYNC_MODE attr: forced sync depends on the resolved channel --------
+
+// Channel is ZMQ (file ENABLED, init took the ZMQ path). The deprecated
+// SYNC_MODE attr is overridden to force sync regardless of the value the
+// caller passes. The guard reads m_redisCommunicationMode, not the file's
+// opinion, so this works whether ZMQ came from the file or from a runtime
+// attr promotion.
+TEST(RedisRemoteSaiInterface, syncModeForcesSyncWhenChannelIsZmq)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_ENABLED, "syncmode_zmq");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    ASSERT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_MODE;
+    attr.value.booldata = false;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_TRUE(sai.m_syncMode);
+}
+
+// Channel is Redis (file EMPTY, init took the Redis path). The deprecated
+// SYNC_MODE attr is taken at face value: no override.
+TEST(RedisRemoteSaiInterface, syncModeAcceptsValueWhenChannelIsRedis)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_EMPTY, "syncmode_redis");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    ASSERT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC);
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_MODE;
+    attr.value.booldata = false;
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr));
+
+    EXPECT_FALSE(sai.m_syncMode);
+}
+
+// A context promoted to ZMQ at runtime via the COMM_MODE attr must still
+// have the SYNC_MODE override applied, the same as a context locked to
+// ZMQ by the file. The override keys off the resolved channel state
+// (m_redisCommunicationMode), not the file's opinion (m_zmqEnable),
+// so both promotion paths reach the same SYNC_MODE behavior.
+TEST(RedisRemoteSaiInterface, syncModeForcedAfterRuntimePromotionToZmq)
+{
+    auto cc = makeCtx(CONTEXT_CONFIG_ZMQ_EMPTY, "syncmode_promoted");
+    auto rec = make_shared<Recorder>();
+    RedisRemoteSaiInterface sai(cc, nullptr, rec);
+
+    // Promote to ZMQ via attr.
+    sai_attribute_t commAttr;
+    commAttr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+    commAttr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &commAttr));
+
+    ASSERT_EQ(sai.m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+
+    // Try to clear sync mode via the deprecated attr.
+    sai_attribute_t syncAttr;
+    syncAttr.id = SAI_REDIS_SWITCH_ATTR_SYNC_MODE;
+    syncAttr.value.booldata = false;
+    EXPECT_EQ(SAI_STATUS_SUCCESS, sai.set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &syncAttr));
+
+    // ZMQ implies sync: the override fires because the resolved channel is
+    // ZMQ, regardless of how it became ZMQ.
+    EXPECT_TRUE(sai.m_syncMode);
 }

--- a/unittest/lib/files/context_config_all_zmq_absent.json
+++ b/unittest/lib/files/context_config_all_zmq_absent.json
@@ -1,0 +1,18 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/lib/files/context_config_gearbox.json
+++ b/unittest/lib/files/context_config_gearbox.json
@@ -1,0 +1,38 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd_main",
+            "dbAsic": "ASIC_DB_MAIN",
+            "dbCounters": "COUNTERS_DB_MAIN",
+            "dbFlex": "FLEX_DB_MAIN",
+            "dbState": "STATE_DB",
+            "zmq_enable": true,
+            "zmq_endpoint": "ipc:///tmp/main_zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///tmp/main_zmq_ntf_ep",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        },
+        {
+            "guid": 1,
+            "name": "gbsyncd",
+            "dbAsic": "ASIC_DB_GB",
+            "dbCounters": "COUNTERS_DB_GB",
+            "dbFlex": "FLEX_DB_GB",
+            "dbState": "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "ipc:///tmp/gb_zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///tmp/gb_zmq_ntf_ep",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": "gb"
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/lib/files/context_config_missing_required.json
+++ b/unittest/lib/files/context_config_missing_required.json
@@ -1,0 +1,17 @@
+{
+    "CONTEXTS": [
+        {
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/lib/files/context_config_two_empty_no_endpoints.json
+++ b/unittest/lib/files/context_config_two_empty_no_endpoints.json
@@ -1,0 +1,32 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd_main",
+            "dbAsic": "ASIC_DB_MAIN",
+            "dbCounters": "COUNTERS_DB_MAIN",
+            "dbFlex": "FLEX_DB_MAIN",
+            "dbState": "STATE_DB",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        },
+        {
+            "guid": 1,
+            "name": "gbsyncd",
+            "dbAsic": "ASIC_DB_GB",
+            "dbCounters": "COUNTERS_DB_GB",
+            "dbFlex": "FLEX_DB_GB",
+            "dbState": "STATE_DB",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": "gb"
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/lib/files/context_config_zmq_absent.json
+++ b/unittest/lib/files/context_config_zmq_absent.json
@@ -1,0 +1,20 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "zmq_endpoint": "ipc:///tmp/test_zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///tmp/test_zmq_ntf_ep",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/lib/files/context_config_zmq_false.json
+++ b/unittest/lib/files/context_config_zmq_false.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "ipc:///tmp/test_zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///tmp/test_zmq_ntf_ep",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/lib/files/context_config_zmq_integer.json
+++ b/unittest/lib/files/context_config_zmq_integer.json
@@ -1,0 +1,19 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "zmq_enable": 1,
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/lib/files/context_config_zmq_wrong_type.json
+++ b/unittest/lib/files/context_config_zmq_wrong_type.json
@@ -1,0 +1,19 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "zmq_enable": "not_a_bool",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -27,7 +27,7 @@ tests_SOURCES = main.cpp \
 				TestVendorSai.cpp \
 				TestFlowDump.cpp
 
-tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
+tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) -fno-access-control
 tests_LDFLAGS = -Wl,-rpath,$(top_srcdir)/lib/.libs -Wl,-rpath,$(top_srcdir)/meta/.libs
 tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/syncd/libSyncdRequestShutdown.a $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/vslib/libSaiVS.a $(top_srcdir)/syncd/libMdioIpcClient.a \
 			  -lhiredis -lswsscommon -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 -lpthread -L$(top_srcdir)/lib/.libs -lsairedis -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq -lz $(CODE_COVERAGE_LIBS) $(VPP_LIBS)

--- a/unittest/syncd/TestSyncd.cpp
+++ b/unittest/syncd/TestSyncd.cpp
@@ -239,6 +239,82 @@ TEST(Syncd, zmqSyncWithJsonEnabledUsesZmq)
     EXPECT_TRUE(syncd->m_enableSyncMode);
 }
 
+// Cmdline requests ZMQ_SYNC and the context file omits zmq_enable.
+// The reconciler defers to the command line and the resolved mode
+// stays at ZMQ_SYNC. An absent zmq_enable means "no opinion from the
+// file," distinct from an explicit false (which demotes to REDIS_SYNC,
+// covered by zmqSyncWithJsonDisabledFallsBackToRedisSync).
+TEST(Syncd, zmqSyncWithJsonEmptyDefersToCmdline)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_contextConfig = "files/ctx_zmq_empty.json";
+
+    auto syncd = std::make_shared<Syncd>(sai, cmd, false);
+
+    EXPECT_EQ(cmd->m_redisCommunicationMode, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC);
+    EXPECT_TRUE(syncd->m_enableSyncMode);
+}
+
+// The reconciliation in Syncd's constructor must not mutate
+// m_zmqEnable. That field reflects what context_config.json said at
+// parse time and stays that way for the life of the ContextConfig, so
+// future consumers (warm boot, diagnostic dumps, per-context override
+// logic) can still distinguish "the file said ZMQ" from "the operator
+// passed -z zmq_sync on a file-silent context." This is the same
+// invariant the orchagent-side RedisRemoteSaiInterface code honors.
+TEST(Syncd, contextConfigZmqEnablePreservedAfterCmdlinePromotion)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_contextConfig = "files/ctx_zmq_empty.json";
+
+    auto syncd = std::make_shared<Syncd>(sai, cmd, false);
+
+    // The cmdline promoted the transport to ZMQ_SYNC, but the parsed
+    // file opinion remains untouched.
+    EXPECT_EQ(syncd->m_contextConfig->m_zmqEnable, sairedis::CONTEXT_CONFIG_ZMQ_EMPTY);
+}
+
+// Symmetric assertion for the demote path: file explicitly disables
+// ZMQ, cmdline requests ZMQ_SYNC. The reconciler demotes to REDIS_SYNC,
+// but m_zmqEnable still reflects the file's explicit false rather than
+// being overwritten by the resolved decision.
+TEST(Syncd, contextConfigZmqEnablePreservedAfterCmdlineDemote)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_contextConfig = "files/ctx_zmq_disabled.json";
+
+    auto syncd = std::make_shared<Syncd>(sai, cmd, false);
+
+    EXPECT_EQ(syncd->m_contextConfig->m_zmqEnable, sairedis::CONTEXT_CONFIG_ZMQ_DISABLED);
+}
+
+// And the file-authoritative-ZMQ case: file says zmq_enable: true, no
+// cmdline override. m_zmqEnable stays ENABLED, which is what the file
+// said and also what the reconciler resolved to. The point of this
+// assertion is that the value matches even though the reconcile blocks
+// did not fire.
+TEST(Syncd, contextConfigZmqEnablePreservedForFileEnabled)
+{
+    auto sai = std::make_shared<MockableSaiInterface>();
+    auto cmd = std::make_shared<CommandLineOptions>();
+
+    cmd->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC;
+    cmd->m_contextConfig = "files/ctx_zmq_enabled.json";
+
+    auto syncd = std::make_shared<Syncd>(sai, cmd, false);
+
+    EXPECT_EQ(syncd->m_contextConfig->m_zmqEnable, sairedis::CONTEXT_CONFIG_ZMQ_ENABLED);
+}
+
 using namespace syncd;
 
 #ifdef MOCK_METHOD

--- a/unittest/syncd/files/ctx_zmq_empty.json
+++ b/unittest/syncd/files/ctx_zmq_empty.json
@@ -1,0 +1,20 @@
+{
+    "CONTEXTS": [
+        {
+            "guid": 0,
+            "name": "syncd",
+            "dbAsic": "ASIC_DB",
+            "dbCounters": "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState": "STATE_DB",
+            "zmq_endpoint": "ipc:///tmp/test_syncd_zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///tmp/test_syncd_zmq_ntf_ep",
+            "switches": [
+                {
+                    "index": 0,
+                    "hwinfo": ""
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Description of PR
Currently the runtime knob for southbound ZMQ is authoritative at file granularity instead of field granularity. The ContextConfig data model uses one boolean for "a context_config.json was loaded" (`m_loadedFromJson`) and a plain bool `m_zmqEnable` for the value, so a file that loads successfully but omits zmq_enable is indistinguishable from one that explicitly sets `zmq_enable`: false: both land on the bool's false default. A plain bool only has two inhabitants, so it cannot represent the third case, "operator said nothing, defer to the command line."

The ZMQ fields are read with unchecked nlohmann::json::operator[], which throws when a key is absent. That throw is caught by a single outer try/catch that returns the hardcoded default container, so omitting `zmq_enable` (or an endpoint) does not just lose the ZMQ opinion: it discards the entire context definition (guid, DB names, switch list), silently degrading a partial config to no config.

With this change `zmq_enable` becomes truly optional. When the field is omitted from context_config.json, the command-line argument (-z zmq_sync) decides the transport between orchagent and syncd. When the field is present, the file still wins over the command line, in both directions.

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
The `m_loadedFromJson` flag conflates two different questions, "did we load a file?" and "did the operator express a ZMQ opinion?", into one signal gated on file presence. The system needs a three-state model gated on field presence. This matters concretely for gearbox: a gearbox box has two contexts (main ASIC and gbsyncd), but the command line is process-wide and cannot say "ZMQ to the ASIC, Redis to gbsyncd." Only a per-context field can, and that field must be able to mean enabled, disabled, or unset.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
- Three-state enum replaces the boolean pair. bool m_zmqEnable + bool m_loadedFromJson in ContextConfig become a single context_config_zmq_state_t with three named inhabitants: CONTEXT_CONFIG_ZMQ_EMPTY (key absent, defer to command line), CONTEXT_CONFIG_ZMQ_ENABLED (lock to ZMQ), CONTEXT_CONFIG_ZMQ_DISABLED (lock to Redis). EMPTY is the zero value so a default-constructed ContextConfig lands on the defer-to-cmdline state. Backed by uint8_t, kept as a C-style typedef enum to match the SAI/sairedis convention used by sai_redis_communication_mode_t.
 
- Parser becomes tolerant of optional fields. lib/ContextConfigContainer.cpp switches from item["zmq_enable"] to item.contains("zmq_enable") (matching the form orchagent's saihelper.cpp already uses) for all three ZMQ fields. Absent zmq_enable leaves the state at EMPTY instead of throwing; absent endpoints leave the constructor defaults instead of throwing. Required structure (guid, db names, switches) stays strict.
 
- syncd/Syncd.cpp (six sites) and lib/RedisRemoteSaiInterface.cpp (four sites) replace the old m_loadedFromJson && m_zmqEnable / m_loadedFromJson && !m_zmqEnable patterns with m_zmqEnable == ENABLED / m_zmqEnable == DISABLED. The deprecated -s reconcile in Syncd correspondingly maps EMPTY and DISABLED to the demote path while ENABLED keeps the file's lock.
 
- Fixed the runtime-promotion bug in RedisRemoteSaiInterface.cpp. Two changes: the SYNC_MODE attr handler now reads m_redisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC (resolved channel state) instead of m_zmqEnable == ENABLED (file opinion), and the m_zmqEnable = ENABLED write inside the COMMUNICATION_MODE = ZMQ_SYNC case is deleted. m_zmqEnable is now immutable after parse and represents only the file's opinion, the resolved channel state lives in m_redisCommunicationMode, which is already maintained correctly. With this change, a context promoted to ZMQ via the SAI attr can be downgraded back to Redis via the same attr.

#### How did you verify/test it?
Added unit tests covering the new states.