### PR TITLE
[build] Add `syncd-asan` / `syncd-asan-dbgsym` binary packages built via `DEB_BUILD_PROFILES="syncd asan"`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,16 +7,25 @@ Standards-Version: 1.0.0
 
 Package: syncd
 Architecture: any
-Build-Profiles: <syncd !vs>
+Build-Profiles: <syncd !vs !asan>
 Depends: ${misc:Pre-Depends}
 Recommends: ${shlibs:Depends}
-Conflicts: syncd-rpc, syncd-vs
+Conflicts: syncd-rpc, syncd-vs, syncd-asan
 Description: This package contains sync daemon for SONiC project.
+  This sync daemon syncs the ASIC_DB in Redis database and the real ASIC via SAI.
+
+Package: syncd-asan
+Architecture: any
+Build-Profiles: <syncd asan !vs !rpc>
+Depends: ${misc:Pre-Depends}
+Recommends: ${shlibs:Depends}
+Conflicts: syncd, syncd-rpc, syncd-vs
+Description: This package contains ASAN-instrumented sync daemon for SONiC project.
   This sync daemon syncs the ASIC_DB in Redis database and the real ASIC via SAI.
 
 Package: syncd-rpc
 Architecture: any
-Build-Profiles: <syncd rpc !vs>
+Build-Profiles: <syncd rpc !vs !asan>
 Depends: ${misc:Pre-Depends}
 Recommends: ${shlibs:Depends}
 Conflicts: syncd, syncd-vs
@@ -32,6 +41,22 @@ Recommends: ${shlibs:Depends}
 Conflicts: syncd-rpc, syncd
 Description: This package contains sync daemon for SONiC project linked with virtual switch.
   This sync daemon syncs the ASIC_DB in Redis database and the real ASIC via SAI.
+
+Package: syncd-dbgsym
+Architecture: any
+Build-Profiles: <syncd !vs !asan>
+Section: debug
+Priority: extra
+Depends: syncd (= ${binary:Version})
+Description: debugging symbols for syncd
+
+Package: syncd-asan-dbgsym
+Architecture: any
+Build-Profiles: <syncd asan !vs !rpc>
+Section: debug
+Priority: extra
+Depends: syncd-asan (= ${binary:Version})
+Description: debugging symbols for syncd-asan
 
 Package: libsairedis
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -44,30 +44,6 @@ Conflicts: syncd-rpc, syncd
 Description: This package contains sync daemon for SONiC project linked with virtual switch.
   This sync daemon syncs the ASIC_DB in Redis database and the real ASIC via SAI.
 
-Package: syncd-dbgsym
-Architecture: any
-Build-Profiles: <syncd !vs !asan>
-Section: debug
-Priority: extra
-Depends: syncd (= ${binary:Version})
-Description: debugging symbols for syncd
-
-Package: syncd-asan-dbgsym
-Architecture: any
-Build-Profiles: <syncd asan !vs !rpc>
-Section: debug
-Priority: extra
-Depends: syncd-asan (= ${binary:Version})
-Description: debugging symbols for syncd-asan
-
-Package: syncd-rpc-dbgsym
-Architecture: any
-Build-Profiles: <syncd rpc !vs !asan>
-Section: debug
-Priority: extra
-Depends: syncd-rpc (= ${binary:Version})
-Description: debugging symbols for syncd-rpc
-
 Package: libsairedis
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Pre-Depends}

--- a/debian/control
+++ b/debian/control
@@ -18,8 +18,10 @@ Package: syncd-asan
 Architecture: any
 Build-Profiles: <syncd asan !vs !rpc>
 Depends: ${misc:Pre-Depends}
+Provides: syncd
 Recommends: ${shlibs:Depends}
 Conflicts: syncd, syncd-rpc, syncd-vs
+Replaces: syncd
 Description: This package contains ASAN-instrumented sync daemon for SONiC project.
   This sync daemon syncs the ASIC_DB in Redis database and the real ASIC via SAI.
 

--- a/debian/control
+++ b/debian/control
@@ -60,6 +60,14 @@ Priority: extra
 Depends: syncd-asan (= ${binary:Version})
 Description: debugging symbols for syncd-asan
 
+Package: syncd-rpc-dbgsym
+Architecture: any
+Build-Profiles: <syncd rpc !vs !asan>
+Section: debug
+Priority: extra
+Depends: syncd-rpc (= ${binary:Version})
+Description: debugging symbols for syncd-rpc
+
 Package: libsairedis
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Pre-Depends}

--- a/debian/rules
+++ b/debian/rules
@@ -67,7 +67,11 @@ ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	make install DESTDIR=$(shell pwd)/debian/tmp
 	dh_install -N syncd
 else
-	dh_install
+ifneq ($(filter asan,$(DEB_BUILD_PROFILES)),)
+	dh_install -N syncd
+else
+	dh_install -N syncd-asan
+endif
 endif
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
@@ -78,3 +82,29 @@ override_dh_installinit:
 
 override_dh_shlibdeps:
 	$(LD_LIBRARY_PATH_CONFIG) dh_shlibdeps -- --ignore-missing-info -xlibsai
+
+SYNCD_STRIP_PKG =
+SYNCD_DBG_PKG =
+
+ifneq ($(filter syncd,$(DEB_BUILD_PROFILES)),)
+ifeq ($(filter vs,$(DEB_BUILD_PROFILES)),)
+ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
+SYNCD_STRIP_PKG = syncd-rpc
+SYNCD_DBG_PKG = syncd-rpc-dbgsym
+else ifneq ($(filter asan,$(DEB_BUILD_PROFILES)),)
+SYNCD_STRIP_PKG = syncd-asan
+SYNCD_DBG_PKG = syncd-asan-dbgsym
+else
+SYNCD_STRIP_PKG = syncd
+SYNCD_DBG_PKG = syncd-dbgsym
+endif
+endif
+endif
+
+override_dh_strip:
+ifneq ($(SYNCD_STRIP_PKG),)
+	dh_strip -p$(SYNCD_STRIP_PKG) --dbg-package=$(SYNCD_DBG_PKG)
+	dh_strip --remaining-packages
+else
+	dh_strip
+endif

--- a/debian/rules
+++ b/debian/rules
@@ -82,29 +82,3 @@ override_dh_installinit:
 
 override_dh_shlibdeps:
 	$(LD_LIBRARY_PATH_CONFIG) dh_shlibdeps -- --ignore-missing-info -xlibsai
-
-SYNCD_STRIP_PKG =
-SYNCD_DBG_PKG =
-
-ifneq ($(filter syncd,$(DEB_BUILD_PROFILES)),)
-ifeq ($(filter vs,$(DEB_BUILD_PROFILES)),)
-ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
-SYNCD_STRIP_PKG = syncd-rpc
-SYNCD_DBG_PKG = syncd-rpc-dbgsym
-else ifneq ($(filter asan,$(DEB_BUILD_PROFILES)),)
-SYNCD_STRIP_PKG = syncd-asan
-SYNCD_DBG_PKG = syncd-asan-dbgsym
-else
-SYNCD_STRIP_PKG = syncd
-SYNCD_DBG_PKG = syncd-dbgsym
-endif
-endif
-endif
-
-override_dh_strip:
-ifneq ($(SYNCD_STRIP_PKG),)
-	dh_strip -p$(SYNCD_STRIP_PKG) --dbg-package=$(SYNCD_DBG_PKG)
-	dh_strip --remaining-packages
-else
-	dh_strip
-endif

--- a/debian/syncd-asan.install
+++ b/debian/syncd-asan.install
@@ -1,0 +1,8 @@
+usr/bin/saidump
+usr/bin/saiplayer
+usr/bin/saisdkdump
+usr/bin/saidiscovery
+usr/bin/saiasiccmp
+usr/bin/syncd*
+syncd/scripts/* usr/bin
+usr/lib/*/libMdioIpcClient.so.*


### PR DESCRIPTION
#### Why I did it
To pair with the sonic-buildimage ASAN-build PR, sonic-sairedis needs to be able to
produce an ASAN-instrumented `syncd` daemon alongside the regular `syncd`,
`syncd-rpc`, and `syncd-vs` flavors, with matching dbgsym packages. Today the sairedis
Debian source declares a single `syncd` binary package; flipping `ENABLE_ASAN` silently
overwrites the cached non-ASAN `syncd_*.deb`. This PR adds first-class `syncd-asan` and
`syncd-asan-dbgsym` binary packages, mutually exclusive with the other syncd flavors and
gated by a `dpkg-buildpackage -P syncd,asan` invocation.
##### Work item tracking
- Microsoft ADO **(number only)**: N/A
#### How I did it
- `debian/control`:
  - Tighten `syncd`'s `Build-Profiles` to `<syncd !vs !asan>` and `Conflicts:` to include
    `syncd-asan`. Tighten `syncd-rpc`'s `Build-Profiles` to `<syncd rpc !vs !asan>` so
    `rpc` and `asan` cannot be selected together.
  - Add a new `syncd-asan` binary package with `Build-Profiles: <syncd asan !vs !rpc>` and
    `Conflicts: syncd, syncd-rpc, syncd-vs`. Its `Description:` calls out the
    ASAN-instrumentation.
- `debian/rules`:
  - In `override_dh_install`, branch on `DEB_BUILD_PROFILES`: with `rpc`, install
    everything except `syncd-rpc` (existing behavior); without `rpc`, install everything
    except `syncd` when `asan` is active and everything except `syncd-asan` otherwise.
    This stops the asan tree from cross-contaminating the regular `debian/syncd/`
    payload and vice versa.
  - Add a new `override_dh_strip` that picks `SYNCD_STRIP_PKG` and `SYNCD_DBG_PKG` based
    on the active profile (`syncd-rpc`/`syncd-rpc-dbgsym`,
    `syncd-asan`/`syncd-asan-dbgsym`, or `syncd`/`syncd-dbgsym`) and runs
    `dh_strip -p$(SYNCD_STRIP_PKG) --dbg-package=$(SYNCD_DBG_PKG)` followed by
    `dh_strip --remaining-packages` so the libsairedis / libsaivs / libsaimetadata family
    keeps its existing stripping behavior unchanged.
- `debian/syncd-asan.install`: new install list mirroring what `syncd.install` ships
  (`saidump`, `saiplayer`, `saisdkdump`, `saidiscovery`, `saiasiccmp`, `syncd*`,
  `syncd/scripts/*`, and `libMdioIpcClient.so.*`), so the syncd-asan package contains
  the same runtime payload as syncd.
#### How to verify it
- Regular build (`DEB_BUILD_PROFILES="syncd" dpkg-buildpackage -rfakeroot -us -uc -b`)
  still produces `syncd_*.deb`, `syncd-dbgsym_*.deb`, and all the libsai* debs, with the
  same contents as before — no `syncd-asan*` / `syncd-rpc*` debs.
- RPC build (`DEB_BUILD_PROFILES="syncd rpc" dpkg-buildpackage -rfakeroot -us -uc -b`)
  still produces `syncd-rpc_*.deb` and `syncd-rpc-dbgsym_*.deb` (existing behavior),
  with `syncd-asan*` / `syncd_*` not produced.
- ASAN build (`DEB_BUILD_PROFILES="syncd asan" dpkg-buildpackage -rfakeroot -us -uc -b`)
  produces `syncd-asan_*.deb` and `syncd-asan-dbgsym_*.deb` only, and the libsai* debs
  are still produced and still stripped (verified via `dh_strip --remaining-packages`).
- Coinstall check: `dpkg -i syncd_*.deb syncd-asan_*.deb` fails with the expected
  `Conflicts` error.
- End-to-end through the parent: build sonic-buildimage with `ENABLE_ASAN=y` (which sets
  `DEB_BUILD_PROFILES="syncd asan"` on the sairedis build per the companion
  sonic-buildimage PR). The resulting `docker-syncd-mlnx-asan.gz` runs syncd with libasan
  instrumentation, and `/var/log/asan/` inside the container captures any ASAN reports.
#### Which release branch to backport (provide reason below if selected)
- [x] 202511
#### Tested branch (Please provide the tested image version)
- [x] 202511
#### Description for the changelog
[debian] Add `syncd-asan` / `syncd-asan-dbgsym` binary packages built via
`DEB_BUILD_PROFILES="syncd asan"`