### PR TITLE
[syncd]: Rename ZMQ variable to match route_performance knob consolidation

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -42,7 +42,7 @@ mkdir -p /var/log/sai_failure_dump/
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SYNCD_VARS | jq -r '.synchronous_mode')
 SWITCH_TYPE=$(echo $SYNCD_VARS | jq -r '.switch_type')
-SOUTHBOUND_ZMQ=$(echo $SYNCD_VARS | jq -r '.orch_southbound_zmq_enabled')
+SOUTHBOUND_ZMQ=$(echo $SYNCD_VARS | jq -r '.swss_zmq')
 if [ "$SWITCH_TYPE" == "dpu" ]; then
     CMD_ARGS+=" -z zmq_sync -x $CONTEXT_CONFIG_FILE"
 elif [ "$SOUTHBOUND_ZMQ" == "true" ]; then


### PR DESCRIPTION
### Description of PR

Rename the JSON variable read by `syncd_init_common.sh` from `orch_southbound_zmq_enabled` to `swss_zmq` to align with the flat `SYSTEM_DEFAULTS|swss_zmq` schema consolidation.

The `swss_vars.j2` template (in sonic-buildimage) now outputs `swss_zmq` as part of consolidating 4 route-performance knobs into 2 flat `SYSTEM_DEFAULTS` entries.

Companion PRs:
- sonic-swss: https://github.com/sonic-net/sonic-swss/pull/4630
- sonic-buildimage: https://github.com/sonic-net/sonic-buildimage/pull/27674
- sonic-net/SONiC (doc): https://github.com/sonic-net/SONiC/pull/2359

### Type of change

- [x] Refactor / cleanup

### Approach
#### What is the motivation for this PR?

The route-performance knob consolidation moves ZMQ configuration from `DEVICE_METADATA|localhost` (4 separate knobs) to flat `SYSTEM_DEFAULTS` entries (`SYSTEM_DEFAULTS|swss_zmq` with `status: enabled/disabled`). The intermediate JSON variable output by `swss_vars.j2` is renamed from `orch_southbound_zmq_enabled` to `swss_zmq` for consistency with the CONFIG_DB key name.

#### How did you do it?

Single line change in `syncd/scripts/syncd_init_common.sh`:
```bash
# Before:
SOUTHBOUND_ZMQ=$(echo $SYNCD_VARS | jq -r '.orch_southbound_zmq_enabled')

# After:
SOUTHBOUND_ZMQ=$(echo $SYNCD_VARS | jq -r '.swss_zmq')
```

#### How did you verify/test it?

Built VS image and tested on KVM testbed:
- Default state: syncd starts with `-s` (synchronous mode)
- `swss_zmq=enabled`: syncd starts with `-z zmq_sync`
- Disable: syncd reverts to `-s`

**Merge order**: This PR and sonic-swss #4630 merge first. Then sonic-buildimage #27674 bumps submodules.

#### Any platform specific information?

None — this is the VS/generic syncd startup script used by all platforms.

### Documentation

Doc update PR: https://github.com/sonic-net/SONiC/pull/2359
