### PR TITLE
[vslib][vpp] Skip non-PORT/SUB_PORT RIF types in vpp_remove_router_interface

### DIFF
--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1828,6 +1828,14 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
     }
     rif_type = attr.value.s32;
 
+    if (rif_type != SAI_ROUTER_INTERFACE_TYPE_SUB_PORT &&
+        rif_type != SAI_ROUTER_INTERFACE_TYPE_PORT)
+    {
+        SWSS_LOG_NOTICE("Skipping router interface remove for attr type %d", rif_type);
+
+        return SAI_STATUS_SUCCESS;
+    }
+
     attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
     status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &attr);
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-buildimage/issues/27732

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
`vpp_remove_router_interface` unconditionally attempts to retrieve
`SAI_ROUTER_INTERFACE_ATTR_PORT_ID` for all non-VLAN router interface types.
However, `SAI_ROUTER_INTERFACE_TYPE_LOOPBACK` RIFs (used as overlay/underlay
interfaces for IP-in-IP tunnel decap) have no associated port — `PORT_ID` is
not a valid attribute for them. This caused a spurious `ERR` log and a
`SAI_STATUS_FAILURE` return during tunnel teardown:

```
2026 Jun  5 00:11:22.177778 vlab-vpp-02 ERR syncd#syncd#syncd: :- vpp_remove_router_interface: attr SAI_ROUTER_INTERFACE_ATTR_PORT_ID was not passed
2026 Jun  5 00:11:22.179350 vlab-vpp-02 NOTICE swss#orchagent: :- RemoveTunnelIfNotReferenced: Tunnel TEST_IPINIP_V6_TUNNEL removed from ASIC_DB.
```

The create path (`vpp_create_router_interface`) already correctly skips any
RIF type that is not `PORT` or `SUB_PORT`, since VPP has no corresponding
interface to create for loopback RIFs. The remove path was missing the same
guard.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


##### Work item tracking
- Microsoft ADO **(number only)**: 38292686

#### How did you do it?
Added an early-return guard in `vpp_remove_router_interface` after reading
`SAI_ROUTER_INTERFACE_ATTR_TYPE`: if the type is not `PORT` or `SUB_PORT`,
log a NOTICE and return `SAI_STATUS_SUCCESS` immediately — mirroring the
existing behavior in `vpp_create_router_interface`. No VPP state was ever
created for these RIF types, so there is nothing to remove.


#### How did you verify/test it?
Ran `tests/decap/test_decap.py` on a VPP-based VS testbed (`vms-kvm-vpp-t0`).
The test passed and the `ERR` syslog message no longer appears during tunnel
teardown.

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
