### PR TITLE
[vpp][fdb] Add fdb support

### DIFF
--- a/unittest/vslib/TestSai.cpp
+++ b/unittest/vslib/TestSai.cpp
@@ -94,7 +94,7 @@ TEST(Sai, bulkGet)
 TEST(Sai, fdbAgingWakeEvent)
 {
     // Verify the FDB aging thread wakes when a switch is created and shuts
-    // down cleanly. The wake event path (SaiFdbAging.cpp sel==wakeEvent) is
+    // down cleanly. The wake event path (SaiFdbAging.cpp: selectable==wakeEvent) is
     // exercised by the fact that apiInitialize + create(SWITCH) starts the
     // thread and installs the wake functor, and remove(SWITCH) triggers a
     // clean join without hanging.

--- a/unittest/vslib/TestSai.cpp
+++ b/unittest/vslib/TestSai.cpp
@@ -3,6 +3,9 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <thread>
+
 #include <memory>
 
 using namespace saivs;
@@ -87,4 +90,32 @@ TEST(Sai, bulkGet)
                 pattrs.data(),
                 SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR,
                 statuses.data()));
+}
+TEST(Sai, fdbAgingWakeEvent)
+{
+    // Verify the FDB aging thread wakes when a switch is created and shuts
+    // down cleanly. The wake event path (SaiFdbAging.cpp sel==wakeEvent) is
+    // exercised by the fact that apiInitialize + create(SWITCH) starts the
+    // thread and installs the wake functor, and remove(SWITCH) triggers a
+    // clean join without hanging.
+    Sai sai;
+
+    EXPECT_EQ(sai.apiInitialize(0, &test_services), SAI_STATUS_SUCCESS);
+
+    sai_attribute_t attr;
+    sai_object_id_t switch_id = SAI_NULL_OBJECT_ID;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    EXPECT_EQ(sai.create(SAI_OBJECT_TYPE_SWITCH, &switch_id, SAI_NULL_OBJECT_ID, 1, &attr), SAI_STATUS_SUCCESS);
+    EXPECT_NE(switch_id, SAI_NULL_OBJECT_ID);
+
+    // Allow the aging thread to run at least one cycle.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // remove(SWITCH) triggers stopFdbAgingThread() which joins the thread.
+    // If the wake/shutdown paths are broken this would hang; the test passing
+    // confirms the aging thread terminates correctly.
+    EXPECT_EQ(sai.remove(SAI_OBJECT_TYPE_SWITCH, switch_id), SAI_STATUS_SUCCESS);
 }

--- a/unittest/vslib/TestSai.cpp
+++ b/unittest/vslib/TestSai.cpp
@@ -93,11 +93,10 @@ TEST(Sai, bulkGet)
 }
 TEST(Sai, fdbAgingWakeEvent)
 {
-    // Verify the FDB aging thread wakes when a switch is created and shuts
-    // down cleanly. The wake event path (SaiFdbAging.cpp: selectable==wakeEvent) is
-    // exercised by the fact that apiInitialize + create(SWITCH) starts the
-    // thread and installs the wake functor, and remove(SWITCH) triggers a
-    // clean join without hanging.
+    // Smoke test: verify the FDB aging thread starts and shuts down cleanly
+    // without deadlocking. The aging thread's normal wake path (MAC event
+    // delivery via m_fdbAgingWakeEvent) is NOT exercised here — this only
+    // confirms the start/stop lifecycle completes without hanging.
     Sai sai;
 
     EXPECT_EQ(sai.apiInitialize(0, &test_services), SAI_STATUS_SUCCESS);

--- a/unittest/vslib/TestSai.cpp
+++ b/unittest/vslib/TestSai.cpp
@@ -96,7 +96,7 @@ TEST(Sai, fdbAgingWakeEvent)
     // Smoke test: verify the FDB aging thread starts and shuts down cleanly
     // without deadlocking. The aging thread's normal wake path (MAC event
     // delivery via m_fdbAgingWakeEvent) is NOT exercised here — this only
-    // confirms the start/stop lifecycle completes without hanging.
+    // confirms the start/stop life cycle completes without hanging.
     Sai sai;
 
     EXPECT_EQ(sai.apiInitialize(0, &test_services), SAI_STATUS_SUCCESS);

--- a/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
+++ b/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
@@ -501,7 +501,7 @@ TEST_F(VirtualSwitchSaiInterfaceTest, objectTypeGetAvailability_MySidEntry_Inval
 TEST_F(VirtualSwitchSaiInterfaceTest, initFdbEventHandling)
 {
     // Verify the wake functor is forwarded to all switch instances.
-    // For the base (non-VPP) SwitchStateBase the virtual is a no-op, so the
+    // For the base (non-platform) SwitchStateBase the virtual is a no-op, so the
     // functor is never called — but the call chain itself must not crash.
     bool called = false;
     m_vssai->initFdbEventHandling([&called]() { called = true; });

--- a/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
+++ b/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
@@ -497,3 +497,18 @@ TEST_F(VirtualSwitchSaiInterfaceTest, objectTypeGetAvailability_MySidEntry_Inval
 
     EXPECT_EQ(status, SAI_STATUS_FAILURE);
 }
+
+TEST_F(VirtualSwitchSaiInterfaceTest, initFdbEventHandling)
+{
+    // Verify the wake functor is forwarded to all switch instances.
+    // For the base (non-VPP) SwitchStateBase the virtual is a no-op, so the
+    // functor is never called — but the call chain itself must not crash.
+    bool called = false;
+    m_vssai->initFdbEventHandling([&called]() { called = true; });
+
+    // Base SwitchStateBase does NOT invoke the functor — calling it is a no-op.
+    EXPECT_FALSE(called);
+
+    // deinitFdbEventHandling must also be safe to call after init.
+    EXPECT_NO_FATAL_FAILURE(m_vssai->deinitFdbEventHandling());
+}

--- a/vslib/Sai.h
+++ b/vslib/Sai.h
@@ -282,6 +282,10 @@ namespace saivs
 
             std::shared_ptr<swss::SelectableEvent> m_fdbAgingThreadEvent;
 
+            // Signaled by VPP MAC event callback to wake the aging thread
+            // immediately instead of waiting for the 1s timeout.
+            std::shared_ptr<swss::SelectableEvent> m_fdbAgingWakeEvent;
+
             std::shared_ptr<std::thread> m_fdbAgingThread;
 
         private: // event queue

--- a/vslib/Sai.h
+++ b/vslib/Sai.h
@@ -282,7 +282,7 @@ namespace saivs
 
             std::shared_ptr<swss::SelectableEvent> m_fdbAgingThreadEvent;
 
-            // Signaled by VPP MAC event callback to wake the aging thread
+            // Signaled by the platform MAC event callback to wake the aging thread
             // immediately instead of waiting for the 1s timeout.
             std::shared_ptr<swss::SelectableEvent> m_fdbAgingWakeEvent;
 

--- a/vslib/SaiFdbAging.cpp
+++ b/vslib/SaiFdbAging.cpp
@@ -23,7 +23,7 @@ void Sai::startFdbAgingThread()
     // This is used by VPP switch to wake up the aging thread immediately
     // after the MAC events are received from VPP (avoids 1s timer latency)
     auto wakeEvent = m_fdbAgingWakeEvent;
-    m_vsSai->setFdbAgingWakeFunction([wakeEvent]() { wakeEvent->notify(); });
+    m_vsSai->initFdbEventHandling([wakeEvent]() { wakeEvent->notify(); });
 
     m_fdbAgingThreadRun = true;
 

--- a/vslib/SaiFdbAging.cpp
+++ b/vslib/SaiFdbAging.cpp
@@ -18,6 +18,12 @@ void Sai::startFdbAgingThread()
     SWSS_LOG_ENTER();
 
     m_fdbAgingThreadEvent = std::make_shared<swss::SelectableEvent>();
+    m_fdbAgingWakeEvent = std::make_shared<swss::SelectableEvent>();
+
+    // This is used by VPP switch to wake up the aging thread immediately
+    // after the MAC events are received from VPP (avoids 1s timer latency)
+    auto wakeEvent = m_fdbAgingWakeEvent;
+    m_vsSai->setFdbAgingWakeFunction([wakeEvent]() { wakeEvent->notify(); });
 
     m_fdbAgingThreadRun = true;
 
@@ -64,6 +70,7 @@ void Sai::fdbAgingThreadProc()
     swss::Select s;
 
     s.addSelectable(m_fdbAgingThreadEvent.get());
+    s.addSelectable(m_fdbAgingWakeEvent.get());
 
     while (m_fdbAgingThreadRun)
     {
@@ -77,7 +84,8 @@ void Sai::fdbAgingThreadProc()
             break;
         }
 
-        if (result == swss::Select::TIMEOUT)
+        if (result == swss::Select::TIMEOUT ||
+            sel == m_fdbAgingWakeEvent.get())
         {
             processFdbEntriesForAging();
         }

--- a/vslib/SaiFdbAging.cpp
+++ b/vslib/SaiFdbAging.cpp
@@ -20,8 +20,8 @@ void Sai::startFdbAgingThread()
     m_fdbAgingThreadEvent = std::make_shared<swss::SelectableEvent>();
     m_fdbAgingWakeEvent = std::make_shared<swss::SelectableEvent>();
 
-    // This is used by VPP switch to wake up the aging thread immediately
-    // after the MAC events are received from VPP (avoids 1s timer latency)
+    // This is used by the platform switch to wake up the aging thread immediately
+    // after the MAC events are received (avoids 1s timer latency)
     auto wakeEvent = m_fdbAgingWakeEvent;
     m_vsSai->initFdbEventHandling([wakeEvent]() { wakeEvent->notify(); });
 

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <unordered_set>
 #include <vector>
+#include <functional>
 
 #define SAI_VS_FDB_INFO "SAI_VS_FDB_INFO"
 
@@ -377,6 +378,10 @@ namespace saivs
 
             virtual void processFdbEntriesForAging();
 
+            // Called by Switch instance to pass a wake function that signals the FDB aging
+            // thread immediately when MAC events arrive. Default is a no-op;
+            virtual void setFdbAgingWakeFunction(std::function<void()> /*fn*/) {}
+
         private: // fdb related
 
             void updateLocalDB(
@@ -387,18 +392,20 @@ namespace saivs
                     _In_ const FdbInfo &fi,
                     _In_ sai_fdb_event_t fdb_event);
 
-            void findBridgeVlanForPortVlan(
-                    _In_ sai_object_id_t port_id,
-                    _In_ sai_vlan_id_t vlan_id,
-                    _Inout_ sai_object_id_t &bv_id,
-                    _Inout_ sai_object_id_t &bridge_port_id);
-
             bool getLagFromPort(
                     _In_ sai_object_id_t port_id,
                     _Inout_ sai_object_id_t& lag_id);
 
             bool isLagOrPortRifBased(
                     _In_ sai_object_id_t lag_or_port_id);
+
+        protected:
+
+            void findBridgeVlanForPortVlan(
+                    _In_ sai_object_id_t port_id,
+                    _In_ sai_vlan_id_t vlan_id,
+                    _Inout_ sai_object_id_t &bv_id,
+                    _Inout_ sai_object_id_t &bridge_port_id);
 
         public:
 

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -380,7 +380,7 @@ namespace saivs
 
             // Called by Switch instance to pass a wake function that signals the FDB aging
             // thread immediately when MAC events arrive. Default is a no-op;
-            virtual void initFdbEventHandling(std::function<void()> /*fn*/) {}
+            virtual void initFdbEventHandling(std::function<void()> /*wakeFn*/) {}
             virtual void deinitFdbEventHandling() {}
 
         private: // fdb related

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -380,7 +380,8 @@ namespace saivs
 
             // Called by Switch instance to pass a wake function that signals the FDB aging
             // thread immediately when MAC events arrive. Default is a no-op;
-            virtual void setFdbAgingWakeFunction(std::function<void()> /*fn*/) {}
+            virtual void initFdbEventHandling(std::function<void()> /*fn*/) {}
+            virtual void deinitFdbEventHandling() {}
 
         private: // fdb related
 

--- a/vslib/VirtualSwitchSaiInterface.cpp
+++ b/vslib/VirtualSwitchSaiInterface.cpp
@@ -631,6 +631,11 @@ std::shared_ptr<SwitchStateBase> VirtualSwitchSaiInterface::init_switch(
 
     ss->setMeta(meta);
 
+    if (m_fdbEventFn)
+    {
+        ss->initFdbEventHandling(m_fdbEventFn);
+    }
+
     if (warmBootState != nullptr)
     {
         auto status = ss->warm_boot_initialize_objects(); // TODO move to constructor

--- a/vslib/VirtualSwitchSaiInterface.h
+++ b/vslib/VirtualSwitchSaiInterface.h
@@ -353,5 +353,7 @@ namespace saivs
             std::shared_ptr<RealObjectIdManager> m_realObjectIdManager;
 
             SwitchStateBase::SwitchStateMap m_switchStateMap;
+
+            std::function<void()> m_fdbEventFn;
     };
 }

--- a/vslib/VirtualSwitchSaiInterface.h
+++ b/vslib/VirtualSwitchSaiInterface.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <functional>
 
 namespace saivs
 {
@@ -323,6 +324,10 @@ namespace saivs
                     _In_ const char* warmBootFile);
 
             void ageFdbs();
+
+            // Set the wake function used to signal the FDB
+            // aging thread immediately on MAC events.
+            void setFdbAgingWakeFunction(std::function<void()> fn);
 
             void debugSetStats(
                     _In_ sai_object_id_t oid,

--- a/vslib/VirtualSwitchSaiInterface.h
+++ b/vslib/VirtualSwitchSaiInterface.h
@@ -327,7 +327,8 @@ namespace saivs
 
             // Set the wake function used to signal the FDB
             // aging thread immediately on MAC events.
-            void setFdbAgingWakeFunction(std::function<void()> fn);
+            void initFdbEventHandling(std::function<void()> fn);
+            void deinitFdbEventHandling();
 
             void debugSetStats(
                     _In_ sai_object_id_t oid,

--- a/vslib/VirtualSwitchSaiInterfaceFdb.cpp
+++ b/vslib/VirtualSwitchSaiInterfaceFdb.cpp
@@ -1,8 +1,5 @@
 #include "VirtualSwitchSaiInterface.h"
 #include "SwitchStateBase.h"
-#ifdef USE_VPP
-#include "SwitchVpp.h"
-#endif
 
 #include "meta/sai_serialize.h"
 
@@ -325,4 +322,10 @@ void VirtualSwitchSaiInterface::ageFdbs()
     {
         it.second->processFdbEntriesForAging();
     }
+}
+
+void VirtualSwitchSaiInterface::setFdbAgingWakeFunction(std::function<void()> fn)
+{
+    for (auto &kv : m_switchStateMap)
+        kv.second->setFdbAgingWakeFunction(fn);
 }

--- a/vslib/VirtualSwitchSaiInterfaceFdb.cpp
+++ b/vslib/VirtualSwitchSaiInterfaceFdb.cpp
@@ -1,6 +1,8 @@
 #include "VirtualSwitchSaiInterface.h"
 #include "SwitchStateBase.h"
+#ifdef USE_VPP
 #include "vpp/SwitchVpp.h"
+#endif
 
 #include "meta/sai_serialize.h"
 

--- a/vslib/VirtualSwitchSaiInterfaceFdb.cpp
+++ b/vslib/VirtualSwitchSaiInterfaceFdb.cpp
@@ -327,14 +327,18 @@ void VirtualSwitchSaiInterface::ageFdbs()
 
 void VirtualSwitchSaiInterface::initFdbEventHandling(std::function<void()> fn)
 {
+    SWSS_LOG_ENTER();
+
     for (auto &kv : m_switchStateMap)
     {
         kv.second->initFdbEventHandling(fn);
-    }       
+    }
 }
 
 void VirtualSwitchSaiInterface::deinitFdbEventHandling()
 {
+    SWSS_LOG_ENTER();
+
     for (auto &kv : m_switchStateMap)
     {
         kv.second->deinitFdbEventHandling();

--- a/vslib/VirtualSwitchSaiInterfaceFdb.cpp
+++ b/vslib/VirtualSwitchSaiInterfaceFdb.cpp
@@ -329,6 +329,8 @@ void VirtualSwitchSaiInterface::initFdbEventHandling(std::function<void()> fn)
 {
     SWSS_LOG_ENTER();
 
+    m_fdbEventFn = fn;
+
     for (auto &kv : m_switchStateMap)
     {
         kv.second->initFdbEventHandling(fn);

--- a/vslib/VirtualSwitchSaiInterfaceFdb.cpp
+++ b/vslib/VirtualSwitchSaiInterfaceFdb.cpp
@@ -1,5 +1,6 @@
 #include "VirtualSwitchSaiInterface.h"
 #include "SwitchStateBase.h"
+#include "vpp/SwitchVpp.h"
 
 #include "meta/sai_serialize.h"
 
@@ -324,8 +325,18 @@ void VirtualSwitchSaiInterface::ageFdbs()
     }
 }
 
-void VirtualSwitchSaiInterface::setFdbAgingWakeFunction(std::function<void()> fn)
+void VirtualSwitchSaiInterface::initFdbEventHandling(std::function<void()> fn)
 {
     for (auto &kv : m_switchStateMap)
-        kv.second->setFdbAgingWakeFunction(fn);
+    {
+        kv.second->initFdbEventHandling(fn);
+    }       
+}
+
+void VirtualSwitchSaiInterface::deinitFdbEventHandling()
+{
+    for (auto &kv : m_switchStateMap)
+    {
+        kv.second->deinitFdbEventHandling();
+    }
 }

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -2,7 +2,7 @@
 
 #include <mutex>
 #include <queue>
-
+#include <set>
 #include "meta/sai_serialize.h"
 
 #include "swss/logger.h"
@@ -70,16 +70,6 @@ SwitchVpp::SwitchVpp(
     SWSS_LOG_ENTER();
 
     vpp_dp_initialize();
-
-    // Register for push-based FDB MAC events once at switch init.
-    vpp_l2fib_set_scan_delay(1);  /* scan interval = 1 unit = 10ms */
-
-    int ret = vpp_want_l2_macs_events2(true, &SwitchVpp::staticMacEventCb, this);
-    if (ret == 0)
-        SWSS_LOG_NOTICE("FDB: registered for VPP L2 MAC push events");
-    else
-        SWSS_LOG_ERROR("FDB: vpp_want_l2_macs_events2 failed (%d), "
-                       "FDB event generation will be inactive", ret);
 }
 
 SwitchVpp::~SwitchVpp()
@@ -94,7 +84,82 @@ SwitchVpp::~SwitchVpp()
         m_vpp_thread->join();
     }
 
+    deinitFdbEventHandling();
+
     SWSS_LOG_NOTICE("SwitchVpp destructor completed");
+}
+
+void SwitchVpp::deinitFdbEventHandling()
+{
+    // Deregister MAC event callback before destroying state.
+    // Without this, VPP may deliver a batch after destruction and
+    // staticMacEventCb will dereference a dangling `this`.
+    vpp_want_l2_macs_events2(false, nullptr, nullptr);
+    m_fdbAgingWakeFn = nullptr;
+}
+
+void SwitchVpp::initFdbEventHandling(std::function<void()> fn)
+{
+    // Store the functor first — staticMacEventCb may fire immediately after
+    // vpp_want_l2_macs_events2() returns, so m_fdbAgingWakeFn must be set
+    // before we register with VPP.
+    m_fdbAgingWakeFn = std::move(fn);
+
+    vpp_l2fib_set_scan_delay(1);  /* scan interval = 1 unit = 10ms */
+    int ret = vpp_want_l2_macs_events2(true, &SwitchVpp::staticMacEventCb, this);
+    if (ret == 0)
+        SWSS_LOG_NOTICE("FDB: registered for VPP L2 MAC push events");
+    else {
+        SWSS_LOG_ERROR("FDB: vpp_want_l2_macs_events2 failed (%d), "
+                       "FDB event generation will be inactive", ret);
+        return;
+    }
+
+    /*
+     * Seed m_swif_to_bdid and synthesize ADD events for any MACs that were
+     * already present in VPP's L2FIB before we registered — push mode only
+     * delivers future events, so we need a one-time dump to catch the rest.
+     */
+    vpp_bridge_domain_dump_swif_bdid(
+        [](uint32_t sw_if_index, uint32_t bd_id, void *ctx) {
+            static_cast<SwitchVpp *>(ctx)->swif_bdid_track_by_swif(sw_if_index, bd_id);
+        },
+        this);
+    m_swif_bdid_seeded = true;
+    SWSS_LOG_NOTICE("FDB: seeded %zu sw_if → bd_id mappings from bridge dump", m_swif_to_bdid.size());
+
+    /* For each bridge domain, dump existing L2FIB entries and enqueue synthetic
+     * ADD events so the aging thread can learn MACs that existed before
+     * registration. Use a local set to deduplicate bd_ids since m_swif_to_bdid
+     * may have multiple sw_if_index entries per bd. */
+    std::set<uint32_t> seen_bds;
+    for (auto &kv : m_swif_to_bdid)
+    {
+        seen_bds.insert(kv.second);
+    }
+
+
+    struct SeedCtx { SwitchVpp *self; };
+    SeedCtx sctx { this };
+    for (uint32_t bd_id : seen_bds) {
+        vpp_l2fib_table_dump(bd_id,
+            [](const vpp_l2fib_entry_t *e, void *ctx) {
+                SeedCtx *sc = static_cast<SeedCtx *>(ctx);
+                VppMacEvent mev;
+                memcpy(mev.mac, e->mac, 6);
+                mev.sw_if_index = e->sw_if_index;
+                mev.action = 0; /* ADD */
+                std::lock_guard<std::mutex> lock(sc->self->m_mac_event_queue_mutex);
+                sc->self->m_mac_event_queue.push(mev);
+            },
+            &sctx);
+    }
+
+    /* Wake the aging thread to process any seeded events. */
+    if (m_fdbAgingWakeFn)
+    {
+        m_fdbAgingWakeFn();
+    }
 }
 
 sai_status_t SwitchVpp::create_qos_queues_per_port(
@@ -1168,19 +1233,6 @@ sai_status_t SwitchVpp::getStatsExt(
 void SwitchVpp::processFdbEntriesForAging()
 {
     SWSS_LOG_ENTER();
-
-    /*
-     * On first call, seed m_swif_to_bdid from the current bridge topology.
-     */
-    if (!m_swif_bdid_seeded) {
-        vpp_bridge_domain_dump_swif_bdid(
-            [](uint32_t sw_if_index, uint32_t bd_id, void *ctx) {
-                static_cast<SwitchVpp *>(ctx)->swif_bdid_track_by_swif(sw_if_index, bd_id);
-            },
-            this);
-        m_swif_bdid_seeded = true;
-        SWSS_LOG_NOTICE("FDB: seeded %zu sw_if → bd_id mappings", m_swif_to_bdid.size());
-    }
 
     /*
      * Drain the MAC event queue populated by the VPP API receive thread.

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -2,7 +2,7 @@
 
 #include <mutex>
 #include <queue>
-#include <set>
+
 #include "meta/sai_serialize.h"
 
 #include "swss/logger.h"
@@ -111,57 +111,9 @@ void SwitchVpp::initFdbEventHandling(std::function<void()> fn)
     int ret = vpp_want_l2_macs_events2(true, &SwitchVpp::staticMacEventCb, this);
     if (ret == 0)
         SWSS_LOG_NOTICE("FDB: registered for VPP L2 MAC push events");
-    else {
+    else
         SWSS_LOG_ERROR("FDB: vpp_want_l2_macs_events2 failed (%d), "
                        "FDB event generation will be inactive", ret);
-        return;
-    }
-
-    /*
-     * Seed m_swif_to_bdid and synthesize ADD events for any MACs that were
-     * already present in VPP's L2FIB before we registered — push mode only
-     * delivers future events, so we need a one-time dump to catch the rest.
-     */
-    vpp_bridge_domain_dump_swif_bdid(
-        [](uint32_t sw_if_index, uint32_t bd_id, void *ctx) {
-            static_cast<SwitchVpp *>(ctx)->swif_bdid_track_by_swif(sw_if_index, bd_id);
-        },
-        this);
-    m_swif_bdid_seeded = true;
-    SWSS_LOG_NOTICE("FDB: seeded %zu sw_if → bd_id mappings from bridge dump", m_swif_to_bdid.size());
-
-    /* For each bridge domain, dump existing L2FIB entries and enqueue synthetic
-     * ADD events so the aging thread can learn MACs that existed before
-     * registration. Use a local set to deduplicate bd_ids since m_swif_to_bdid
-     * may have multiple sw_if_index entries per bd. */
-    std::set<uint32_t> seen_bds;
-    for (auto &kv : m_swif_to_bdid)
-    {
-        seen_bds.insert(kv.second);
-    }
-
-
-    struct SeedCtx { SwitchVpp *self; };
-    SeedCtx sctx { this };
-    for (uint32_t bd_id : seen_bds) {
-        vpp_l2fib_table_dump(bd_id,
-            [](const vpp_l2fib_entry_t *e, void *ctx) {
-                SeedCtx *sc = static_cast<SeedCtx *>(ctx);
-                VppMacEvent mev;
-                memcpy(mev.mac, e->mac, 6);
-                mev.sw_if_index = e->sw_if_index;
-                mev.action = 0; /* ADD */
-                std::lock_guard<std::mutex> lock(sc->self->m_mac_event_queue_mutex);
-                sc->self->m_mac_event_queue.push(mev);
-            },
-            &sctx);
-    }
-
-    /* Wake the aging thread to process any seeded events. */
-    if (m_fdbAgingWakeFn)
-    {
-        m_fdbAgingWakeFn();
-    }
 }
 
 sai_status_t SwitchVpp::create_qos_queues_per_port(

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -91,6 +91,8 @@ SwitchVpp::~SwitchVpp()
 
 void SwitchVpp::deinitFdbEventHandling()
 {
+    SWSS_LOG_ENTER();
+
     // Deregister MAC event callback before destroying state.
     // Without this, VPP may deliver a batch after destruction and
     // staticMacEventCb will dereference a dangling `this`.
@@ -1305,6 +1307,8 @@ void SwitchVpp::processFdbEntriesForAging()
  */
 void SwitchVpp::staticMacEventCb(const vpp_mac_event_t *evs, uint32_t n, void *ctx)
 {
+    SWSS_LOG_ENTER();
+
     auto *self = static_cast<SwitchVpp *>(ctx);
     {
         std::lock_guard<std::mutex> lock(self->m_mac_event_queue_mutex);

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1226,7 +1226,7 @@ void SwitchVpp::processFdbEntriesForAging()
         key.bd_id = bd_it->second;
 
         switch (ev.action) {
-        case 0: /* ADD — newly learned */
+        case VPP_MAC_ACTION_ADD:
             if (m_vpp_fdb_entries.find(key) == m_vpp_fdb_entries.end()) {
                 if (generateFdbLearnedOrMoveEvent(key, ev.sw_if_index, SAI_FDB_EVENT_LEARNED)) {
                     m_vpp_fdb_entries[key] = ev.sw_if_index;
@@ -1238,7 +1238,7 @@ void SwitchVpp::processFdbEntriesForAging()
             }
             break;
 
-        case 1: /* DELETE — aged out */
+        case VPP_MAC_ACTION_DELETE:
             if (m_vpp_fdb_entries.find(key) != m_vpp_fdb_entries.end()) {
                 if (generateFdbAgedEvent(key)) {
                     m_vpp_fdb_entries.erase(key);
@@ -1250,7 +1250,7 @@ void SwitchVpp::processFdbEntriesForAging()
             }
             break;
 
-        case 2: /* MOVE — port changed */
+        case VPP_MAC_ACTION_MOVE:
             if (generateFdbLearnedOrMoveEvent(key, ev.sw_if_index, SAI_FDB_EVENT_MOVE)) {
                 m_vpp_fdb_entries[key] = ev.sw_if_index;
             }

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -76,6 +76,10 @@ SwitchVpp::~SwitchVpp()
 {
     SWSS_LOG_ENTER();
 
+    // Deregister VPP MAC events before stopping the thread so no callback
+    // fires against a partially-destroyed object during join().
+    deinitFdbEventHandling();
+
     // Signal the vpp events thread to stop
     m_run_vpp_events_thread = false;
 
@@ -83,8 +87,6 @@ SwitchVpp::~SwitchVpp()
     if (m_vpp_thread && m_vpp_thread->joinable()) {
         m_vpp_thread->join();
     }
-
-    deinitFdbEventHandling();
 
     SWSS_LOG_NOTICE("SwitchVpp destructor completed");
 }

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1228,21 +1228,32 @@ void SwitchVpp::processFdbEntriesForAging()
         switch (ev.action) {
         case 0: /* ADD — newly learned */
             if (m_vpp_fdb_entries.find(key) == m_vpp_fdb_entries.end()) {
-                generateFdbLearnedOrMoveEvent(key, ev.sw_if_index, SAI_FDB_EVENT_LEARNED);
+                if (generateFdbLearnedOrMoveEvent(key, ev.sw_if_index, SAI_FDB_EVENT_LEARNED)) {
+                    m_vpp_fdb_entries[key] = ev.sw_if_index;
+                }
+            } else {
+                SWSS_LOG_INFO("FDB: ADD for already-known MAC %02x:%02x:%02x:%02x:%02x:%02x bd %u sw_if_index %u, skipping",
+                              key.mac[0], key.mac[1], key.mac[2], key.mac[3], key.mac[4], key.mac[5],
+                              key.bd_id, ev.sw_if_index);
             }
-            m_vpp_fdb_entries[key] = ev.sw_if_index;
             break;
 
         case 1: /* DELETE — aged out */
-            if (m_vpp_fdb_entries.count(key)) {
-                generateFdbAgedEvent(key);
-                m_vpp_fdb_entries.erase(key);
+            if (m_vpp_fdb_entries.find(key) != m_vpp_fdb_entries.end()) {
+                if (generateFdbAgedEvent(key)) {
+                    m_vpp_fdb_entries.erase(key);
+                }
+            } else {
+                SWSS_LOG_INFO("FDB: DELETE for unknown MAC %02x:%02x:%02x:%02x:%02x:%02x bd %u, skipping",
+                              key.mac[0], key.mac[1], key.mac[2], key.mac[3], key.mac[4], key.mac[5],
+                              key.bd_id);
             }
             break;
 
         case 2: /* MOVE — port changed */
-            generateFdbLearnedOrMoveEvent(key, ev.sw_if_index, SAI_FDB_EVENT_MOVE);
-            m_vpp_fdb_entries[key] = ev.sw_if_index;
+            if (generateFdbLearnedOrMoveEvent(key, ev.sw_if_index, SAI_FDB_EVENT_MOVE)) {
+                m_vpp_fdb_entries[key] = ev.sw_if_index;
+            }
             break;
 
         default:

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1,5 +1,8 @@
 #include "SwitchVpp.h"
 
+#include <mutex>
+#include <queue>
+
 #include "meta/sai_serialize.h"
 
 #include "swss/logger.h"
@@ -67,6 +70,16 @@ SwitchVpp::SwitchVpp(
     SWSS_LOG_ENTER();
 
     vpp_dp_initialize();
+
+    // Register for push-based FDB MAC events once at switch init.
+    vpp_l2fib_set_scan_delay(1);  /* scan interval = 1 unit = 10ms */
+
+    int ret = vpp_want_l2_macs_events2(true, &SwitchVpp::staticMacEventCb, this);
+    if (ret == 0)
+        SWSS_LOG_NOTICE("FDB: registered for VPP L2 MAC push events");
+    else
+        SWSS_LOG_ERROR("FDB: vpp_want_l2_macs_events2 failed (%d), "
+                       "FDB event generation will be inactive", ret);
 }
 
 SwitchVpp::~SwitchVpp()
@@ -1156,7 +1169,104 @@ void SwitchVpp::processFdbEntriesForAging()
 {
     SWSS_LOG_ENTER();
 
-    return;
+    /*
+     * On first call, seed m_swif_to_bdid from the current bridge topology.
+     */
+    if (!m_swif_bdid_seeded) {
+        vpp_bridge_domain_dump_swif_bdid(
+            [](uint32_t sw_if_index, uint32_t bd_id, void *ctx) {
+                static_cast<SwitchVpp *>(ctx)->swif_bdid_track_by_swif(sw_if_index, bd_id);
+            },
+            this);
+        m_swif_bdid_seeded = true;
+        SWSS_LOG_NOTICE("FDB: seeded %zu sw_if → bd_id mappings", m_swif_to_bdid.size());
+    }
+
+    /*
+     * Drain the MAC event queue populated by the VPP API receive thread.
+     * We hold MUTEX() here (called from Sai::processFdbEntriesForAging which
+     * acquires m_apimutex before calling into vslib), so it is safe to call
+     * the generate* helpers.
+     */
+    std::queue<VppMacEvent> events;
+    {
+        std::lock_guard<std::mutex> lock(m_mac_event_queue_mutex);
+        std::swap(events, m_mac_event_queue);
+    }
+
+    if (events.empty())
+    {
+        SWSS_LOG_DEBUG("FDB: no MAC events from VPP");
+        return;
+    }
+
+    SWSS_LOG_DEBUG("FDB: draining %zu queued MAC events", events.size());
+
+    while (!events.empty()) {
+        const VppMacEvent &ev = events.front();
+
+        auto bd_it = m_swif_to_bdid.find(ev.sw_if_index);
+        if (bd_it == m_swif_to_bdid.end()) {
+            SWSS_LOG_DEBUG("FDB: unknown sw_if_index %u in MAC event, skipping",
+                           ev.sw_if_index);
+            events.pop();
+            continue;
+        }
+
+        VppFdbKey key;
+        memcpy(key.mac, ev.mac, 6);
+        key.bd_id = bd_it->second;
+
+        switch (ev.action) {
+        case 0: /* ADD — newly learned */
+            if (m_vpp_fdb_entries.find(key) == m_vpp_fdb_entries.end()) {
+                generateFdbLearnedOrMoveEvent(key, ev.sw_if_index, SAI_FDB_EVENT_LEARNED);
+            }
+            m_vpp_fdb_entries[key] = ev.sw_if_index;
+            break;
+
+        case 1: /* DELETE — aged out */
+            if (m_vpp_fdb_entries.count(key)) {
+                generateFdbAgedEvent(key);
+                m_vpp_fdb_entries.erase(key);
+            }
+            break;
+
+        case 2: /* MOVE — port changed */
+            generateFdbLearnedOrMoveEvent(key, ev.sw_if_index, SAI_FDB_EVENT_MOVE);
+            m_vpp_fdb_entries[key] = ev.sw_if_index;
+            break;
+
+        default:
+            SWSS_LOG_WARN("FDB: unknown MAC event action %u", ev.action);
+            break;
+        }
+
+        events.pop();
+    }
+}
+
+/*
+ * Static trampoline: called on the VPP API receive thread when VPP pushes a
+ * batch of MAC learn/age/move events.  Must NOT acquire m_apimutex — just
+ * enqueue for safe dispatch by processFdbEntriesForAging() under the mutex.
+ */
+void SwitchVpp::staticMacEventCb(const vpp_mac_event_t *evs, uint32_t n, void *ctx)
+{
+    auto *self = static_cast<SwitchVpp *>(ctx);
+    {
+        std::lock_guard<std::mutex> lock(self->m_mac_event_queue_mutex);
+        for (uint32_t i = 0; i < n; i++) {
+            VppMacEvent mev;
+            memcpy(mev.mac, evs[i].mac, 6);
+            mev.sw_if_index = evs[i].sw_if_index;
+            mev.action = evs[i].action;
+            self->m_mac_event_queue.push(mev);
+        }
+    }
+    // Wake the FDB aging thread once for the entire batch
+    if (self->m_fdbAgingWakeFn)
+        self->m_fdbAgingWakeFn();
 }
 
 sai_status_t SwitchVpp::create(

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1269,6 +1269,10 @@ void SwitchVpp::processFdbEntriesForAging()
  * Static trampoline: called on the VPP API receive thread when VPP pushes a
  * batch of MAC learn/age/move events.  Must NOT acquire m_apimutex — just
  * enqueue for safe dispatch by processFdbEntriesForAging() under the mutex.
+ *
+ * TODO: MAC events currently arrive on the shared VPP API socket and are
+ * dispatched synchronously inside the WR() polling loop. Move to a separate
+ * event socket in the future.
  */
 void SwitchVpp::staticMacEventCb(const vpp_mac_event_t *evs, uint32_t n, void *ctx)
 {
@@ -2759,4 +2763,29 @@ sai_status_t SwitchVpp::refresh_port_oper_speed(
     CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
 
     return SAI_STATUS_SUCCESS;
+}
+
+/*
+ * Resolve a VPP sw_if_index to a SAI port OID via the 3-step lookup chain:
+ * sw_if_index -> VPP hw interface name -> Linux tap/SONiC port name -> SAI port OID.
+ * Returns SAI_NULL_OBJECT_ID on any lookup failure.
+ */
+sai_object_id_t SwitchVpp::getPortIdFromSwIfIndex(uint32_t sw_if_index)
+{
+    SWSS_LOG_ENTER();
+    const char *hwifname = vpp_get_swif_name(sw_if_index);
+    if (!hwifname)
+    {
+        SWSS_LOG_WARN("FDB: cannot get hwif name for sw_if_index %u", sw_if_index);
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    const char *tapname = hwif_to_tap_name(hwifname);
+    if (!tapname)
+    {
+        SWSS_LOG_WARN("FDB: cannot get tap name for hwif %s", hwifname);
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    return getPortIdFromIfName(std::string(tapname));
 }

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1114,6 +1114,10 @@ namespace saivs
             // and de-duplication of events.
             std::map<VppFdbKey, uint32_t> m_vpp_fdb_entries;
 
+            // Cache: VPP sw_if_index -> SAI port OID, built from FDB learn events.
+            // Avoids per-entry VPP API calls in vpp_fdb_entries_invalidate_by_port().
+            std::unordered_map<uint32_t, sai_object_id_t> m_swif_to_port_id;
+
             // Maps VPP sw_if_index -> bridge domain ID.
             // Maintained when ports are added/removed from bridge domains.
             // Required because l2_macs_event carries sw_if_index but not bd_id.
@@ -1153,6 +1157,11 @@ namespace saivs
             bool generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type);
             bool generateFdbAgedEvent(const VppFdbKey &key);
             sai_object_id_t getPortIdFromSwIfIndex(uint32_t sw_if_index);
+
+            // Cache-first resolution of sw_if_index -> SAI port OID.
+            // On a cache miss, falls back to the VPP API lookup and memoizes the result.
+            // Defined inline in SwitchVppFdb.cpp (its only translation unit).
+            sai_object_id_t resolvePortIdFromSwIfIndex(uint32_t sw_if_index);
 
             void vpp_fdb_entries_invalidate_all();
             void vpp_fdb_entries_invalidate_by_bd(uint32_t bd_id);

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1148,11 +1148,6 @@ namespace saivs
             // Receives the entire batch from a single l2_macs_event message.
             static void staticMacEventCb(const vpp_mac_event_t *evs, uint32_t n, void *ctx);
 
-            // Whether m_swif_to_bdid has been seeded from the bridge topology.
-            // Seeding is deferred to the first processFdbEntriesForAging() call
-            // because bridge members are configured after switch init.
-            bool m_swif_bdid_seeded = false;
-
             // Optional callback to wake the FDB aging thread immediately when
             // MAC events are enqueued (set by Sai after starting aging thread).
             std::function<void()> m_fdbAgingWakeFn;
@@ -1168,8 +1163,6 @@ namespace saivs
             // Track/untrack sw_if_index→bd_id when ports join/leave bridge domains.
             void swif_bdid_track(const char *hwif_name, uint32_t bd_id);
             void swif_bdid_untrack(const char *hwif_name);
-            // Direct insert by sw_if_index (used when sw_if_index is already known).
-            void swif_bdid_track_by_swif(uint32_t sw_if_index, uint32_t bd_id) { m_swif_to_bdid[sw_if_index] = bd_id; }
 
             std::map<std::string, std::shared_ptr<HostInterfaceInfo>> m_hostif_info_map;
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1116,6 +1116,8 @@ namespace saivs
 
             // Cache: VPP sw_if_index -> SAI port OID, built from FDB learn events.
             // Avoids per-entry VPP API calls in vpp_fdb_entries_invalidate_by_port().
+            // Invalidated per sw_if_index on port-leave via swif_bdid_untrack(),
+            // since VPP recycles sw_if_index values after an interface is deleted.
             std::unordered_map<uint32_t, sai_object_id_t> m_swif_to_port_id;
 
             // Maps VPP sw_if_index -> bridge domain ID.
@@ -1168,6 +1170,8 @@ namespace saivs
             void vpp_fdb_entries_invalidate_by_port(sai_object_id_t port_id);
 
             // Track/untrack sw_if_index→bd_id when ports join/leave bridge domains.
+            // Untrack also invalidates the m_swif_to_port_id cache for that
+            // sw_if_index, since both per-swif caches share the same lifecycle.
             void swif_bdid_track(const char *hwif_name, uint32_t bd_id);
             void swif_bdid_untrack(const char *hwif_name);
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1109,8 +1109,6 @@ namespace saivs
 
             BitResourcePool dynamic_bd_id_pool = BitResourcePool(dynamic_bd_id_pool_size, dynamic_bd_id_base);
 
-            std::set<FdbInfo> m_fdb_info_set;
-
             // Snapshot of VPP L2FIB: {mac, bd_id} -> sw_if_index.
             // Kept in sync with MAC events from VPP to support flush operations
             // and de-duplication of events.

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1062,7 +1062,8 @@ namespace saivs
                     _In_ const sai_attribute_t *attr_list) override;
 
             // Set the callback to wake the FDB aging thread immediately on MAC events.
-            void setFdbAgingWakeFunction(std::function<void()> fn) override { m_fdbAgingWakeFn = fn; }
+            void initFdbEventHandling(std::function<void()> fn) override;
+            void deinitFdbEventHandling() override;
 
         protected: // VPP
             typedef struct platform_bond_info_ {

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -18,6 +18,8 @@
 #include <unordered_map>
 #include <mutex>
 #include <chrono>
+#include <functional>
+#include <queue>
 
 #define BFD_MUTEX std::lock_guard<std::mutex> lock(bfdMapMutex);
 
@@ -206,6 +208,23 @@ namespace saivs
                     _Out_ uint64_t *counters) override;
 
             virtual void processFdbEntriesForAging() override;
+
+        public:
+
+            // Key for the m_vpp_fdb_entries snapshot map.
+            // Uniquely identifies an L2FIB entry within VPP: a MAC address
+            // learned on a specific bridge domain (bd_id == SAI VLAN ID).
+            // Used to detect LEARNED/AGED/MOVE events by diffing VPP push
+            // notifications against the previously-known state.
+            struct VppFdbKey {
+                uint8_t mac[6];   // source MAC address
+                uint32_t bd_id;   // VPP bridge domain ID (equals SAI VLAN ID)
+                bool operator<(const VppFdbKey &o) const {
+                    int r = memcmp(mac, o.mac, 6);
+                    if (r != 0) return r < 0;
+                    return bd_id < o.bd_id;
+                }
+            };
 
         public:
 
@@ -1042,6 +1061,9 @@ namespace saivs
                     _In_ uint32_t attr_count,
                     _In_ const sai_attribute_t *attr_list) override;
 
+            // Set the callback to wake the FDB aging thread immediately on MAC events.
+            void setFdbAgingWakeFunction(std::function<void()> fn) override { m_fdbAgingWakeFn = fn; }
+
         protected: // VPP
             typedef struct platform_bond_info_ {
                 uint32_t sw_if_index;
@@ -1087,6 +1109,66 @@ namespace saivs
             BitResourcePool dynamic_bd_id_pool = BitResourcePool(dynamic_bd_id_pool_size, dynamic_bd_id_base);
 
             std::set<FdbInfo> m_fdb_info_set;
+
+            // Snapshot of VPP L2FIB: {mac, bd_id} -> sw_if_index.
+            // Kept in sync with MAC events from VPP to support flush operations
+            // and de-duplication of events.
+            std::map<VppFdbKey, uint32_t> m_vpp_fdb_entries;
+
+            // Maps VPP sw_if_index -> bridge domain ID.
+            // Maintained when ports are added/removed from bridge domains.
+            // Required because l2_macs_event carries sw_if_index but not bd_id.
+            std::map<uint32_t, uint32_t> m_swif_to_bdid;
+
+            // MAC event queue — thread boundary between VPP and saivpp.
+            //
+            // Producer: VPP API receive thread via staticMacEventCb()
+            //   -> vl_api_l2_macs_event_t_handler (holds VPP_LOCK, not m_apimutex)
+            //   -> onVppMacEvent() pushes to queue and signals m_fdbAgingWakeEvent
+            //
+            // Consumer: FDB aging thread via processFdbEntriesForAging()
+            //   -> woken by m_fdbAgingWakeEvent (~10ms after VPP event)
+            //   -> drains queue under m_apimutex
+            //   -> calls generateFdbLearnedOrMoveEvent / generateFdbAgedEvent
+            //
+            // Protected by m_mac_event_queue_mutex (separate from m_apimutex).
+            struct VppMacEvent {
+                uint8_t  mac[6];
+                uint32_t sw_if_index;
+                uint8_t  action; // 0=ADD(learn), 1=DELETE(age), 2=MOVE
+            };
+            std::mutex              m_mac_event_queue_mutex;
+            std::queue<VppMacEvent> m_mac_event_queue;
+
+            // Called from VPP API receive thread via vpp_want_l2_macs_events2 callback.
+            // Enqueues events for safe processing under m_apimutex.
+
+            // Static trampoline registered as vpp_mac_event_cb_fn.
+            // Receives the entire batch from a single l2_macs_event message.
+            static void staticMacEventCb(const vpp_mac_event_t *evs, uint32_t n, void *ctx);
+
+            // Whether m_swif_to_bdid has been seeded from the bridge topology.
+            // Seeding is deferred to the first processFdbEntriesForAging() call
+            // because bridge members are configured after switch init.
+            bool m_swif_bdid_seeded = false;
+
+            // Optional callback to wake the FDB aging thread immediately when
+            // MAC events are enqueued (set by Sai after starting aging thread).
+            std::function<void()> m_fdbAgingWakeFn;
+
+            void generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type);
+            void generateFdbAgedEvent(const VppFdbKey &key);
+            sai_object_id_t getPortIdFromSwIfIndex(uint32_t sw_if_index);
+
+            void vpp_fdb_entries_invalidate_all();
+            void vpp_fdb_entries_invalidate_by_bd(uint32_t bd_id);
+            void vpp_fdb_entries_invalidate_by_port(sai_object_id_t port_id);
+
+            // Track/untrack sw_if_index→bd_id when ports join/leave bridge domains.
+            void swif_bdid_track(const char *hwif_name, uint32_t bd_id);
+            void swif_bdid_untrack(const char *hwif_name);
+            // Direct insert by sw_if_index (used when sw_if_index is already known).
+            void swif_bdid_track_by_swif(uint32_t sw_if_index, uint32_t bd_id) { m_swif_to_bdid[sw_if_index] = bd_id; }
 
             std::map<std::string, std::shared_ptr<HostInterfaceInfo>> m_hostif_info_map;
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1152,8 +1152,8 @@ namespace saivs
             // MAC events are enqueued (set by Sai after starting aging thread).
             std::function<void()> m_fdbAgingWakeFn;
 
-            void generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type);
-            void generateFdbAgedEvent(const VppFdbKey &key);
+            bool generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type);
+            bool generateFdbAgedEvent(const VppFdbKey &key);
             sai_object_id_t getPortIdFromSwIfIndex(uint32_t sw_if_index);
 
             void vpp_fdb_entries_invalidate_all();

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1520,6 +1520,12 @@ void SwitchVpp::swif_bdid_untrack(const char *hwif_name)
     if (swif != (uint32_t)~0u)
     {
         m_swif_to_bdid.erase(swif);
+
+        // Invalidate the sw_if_index -> SAI port OID memoization as well.
+        // VPP recycles sw_if_index values after an interface is deleted, so a
+        // stale entry would mis-attribute FDB learn/move/age notifications (and
+        // vpp_fdb_entries_invalidate_by_port matches) to the previous port OID.
+        m_swif_to_port_id.erase(swif);
     }
 }
 

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1379,7 +1379,7 @@ sai_object_id_t SwitchVpp::getPortIdFromSwIfIndex(uint32_t sw_if_index)
     return getPortIdFromIfName(std::string(tapname));
 }
 
-void SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type)
+bool SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type)
 {
     SWSS_LOG_ENTER();
 
@@ -1389,7 +1389,7 @@ void SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_
     if (port_id == SAI_NULL_OBJECT_ID)
     {
         SWSS_LOG_ERROR("FDB: cannot resolve port OID for sw_if_index %u", sw_if_index);
-        return;
+        return false;
     }
 
     sai_object_id_t bv_id = SAI_NULL_OBJECT_ID;
@@ -1401,7 +1401,7 @@ void SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_
     {
         SWSS_LOG_ERROR("FDB: bv_id or bridge_port not found for sw_if_index %u bd %u",
                        sw_if_index, key.bd_id);
-        return;
+        return false;
     }
 
     std::set<FdbInfo>::iterator existing_it = m_fdb_info_set.end();
@@ -1418,8 +1418,7 @@ void SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_
         {
             SWSS_LOG_WARN("FDB: entry not found in m_fdb_info_set for bd %u, treating as learn",
                           key.bd_id);
-            generateFdbLearnedOrMoveEvent(key, sw_if_index, SAI_FDB_EVENT_LEARNED);
-            return;
+            return generateFdbLearnedOrMoveEvent(key, sw_if_index, SAI_FDB_EVENT_LEARNED);
         }
         fi = *existing_it;
     }
@@ -1460,7 +1459,7 @@ void SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_
         SWSS_LOG_ERROR("FDB: %s failed for %s: %s",
                        is_move ? "set_internal" : "create_internal",
                        sid.c_str(), sai_serialize_status(status).c_str());
-        return;
+        return false;
     }
 
     if (is_move)
@@ -1473,9 +1472,10 @@ void SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_
                     is_move ? "MOVE" : "LEARNED",
                     key.mac[0], key.mac[1], key.mac[2], key.mac[3], key.mac[4], key.mac[5],
                     key.bd_id, sw_if_index);
+    return true;
 }
 
-void SwitchVpp::generateFdbAgedEvent(const VppFdbKey &key)
+bool SwitchVpp::generateFdbAgedEvent(const VppFdbKey &key)
 {
     SWSS_LOG_ENTER();
 
@@ -1487,7 +1487,7 @@ void SwitchVpp::generateFdbAgedEvent(const VppFdbKey &key)
     if (it == m_fdb_info_set.end())
     {
         SWSS_LOG_ERROR("FDB: entry not found in m_fdb_info_set for bd %u", key.bd_id);
-        return;
+        return false;
     }
 
     FdbInfo fi = *it;
@@ -1513,6 +1513,7 @@ void SwitchVpp::generateFdbAgedEvent(const VppFdbKey &key)
 
     SWSS_LOG_NOTICE("FDB: notified AGED for MAC %02x:%02x:%02x:%02x:%02x:%02x bd %u",
                     key.mac[0], key.mac[1], key.mac[2], key.mac[3], key.mac[4], key.mac[5], key.bd_id);
+    return true;
 }
 
 void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1361,6 +1361,7 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
  */
 sai_object_id_t SwitchVpp::getPortIdFromSwIfIndex(uint32_t sw_if_index)
 {
+    SWSS_LOG_ENTER();
     const char *hwifname = vpp_get_swif_name(sw_if_index);
     if (!hwifname)
     {
@@ -1516,6 +1517,7 @@ void SwitchVpp::generateFdbAgedEvent(const VppFdbKey &key)
 
 void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)
 {
+    SWSS_LOG_ENTER();
     uint32_t swif = vpp_get_swif_idx_by_name(hwif_name);
     if (swif != (uint32_t)~0u)
     {
@@ -1525,6 +1527,7 @@ void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)
 
 void SwitchVpp::swif_bdid_untrack(const char *hwif_name)
 {
+    SWSS_LOG_ENTER();
     uint32_t swif = vpp_get_swif_idx_by_name(hwif_name);
     if (swif != (uint32_t)~0u)
     {
@@ -1534,12 +1537,14 @@ void SwitchVpp::swif_bdid_untrack(const char *hwif_name)
 
 void SwitchVpp::vpp_fdb_entries_invalidate_all()
 {
+    SWSS_LOG_ENTER();
     SWSS_LOG_INFO("FDB: invalidating all %zu m_vpp_fdb_entries", m_vpp_fdb_entries.size());
     m_vpp_fdb_entries.clear();
 }
 
 void SwitchVpp::vpp_fdb_entries_invalidate_by_bd(uint32_t bd_id)
 {
+    SWSS_LOG_ENTER();
     size_t before = m_vpp_fdb_entries.size();
     for (auto it = m_vpp_fdb_entries.begin(); it != m_vpp_fdb_entries.end(); )
     {
@@ -1554,6 +1559,7 @@ void SwitchVpp::vpp_fdb_entries_invalidate_by_bd(uint32_t bd_id)
 
 void SwitchVpp::vpp_fdb_entries_invalidate_by_port(sai_object_id_t port_id)
 {
+    SWSS_LOG_ENTER();
     /* O(N) scan: resolves sw_if_index -> port OID via VPP API for each entry.
      * This is acceptable since flush-by-interface is infrequent.
      * TODO: Improve this by storing the sw_if_index -> port OID mapping somewhere. */

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1311,10 +1311,7 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
                     const char *hwif_name = ifname.c_str();
                     auto ret = l2fib_flush_int(hwif_name);
                     SWSS_LOG_NOTICE(" Flush by interface on hwif_name %s  Successful ret_val: %d", hwif_name, ret);
-                    if (is_tunnel_bridge_port(br_port_id))
-                        vpp_fdb_entries_invalidate_all();
-                    else
-                        vpp_fdb_entries_invalidate_by_port(port_id);
+                    vpp_fdb_entries_invalidate_by_port(port_id);
                 }
                 else
                 {
@@ -1354,29 +1351,17 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
     return SAI_STATUS_SUCCESS;
 }
 
-/*
- * Resolve a VPP sw_if_index to a SAI port OID via the 3-step lookup chain:
- * sw_if_index -> VPP hw interface name -> Linux tap/SONiC port name -> SAI port OID.
- * Returns SAI_NULL_OBJECT_ID on any lookup failure.
- */
-sai_object_id_t SwitchVpp::getPortIdFromSwIfIndex(uint32_t sw_if_index)
+inline sai_object_id_t SwitchVpp::resolvePortIdFromSwIfIndex(uint32_t sw_if_index)
 {
-    SWSS_LOG_ENTER();
-    const char *hwifname = vpp_get_swif_name(sw_if_index);
-    if (!hwifname)
-    {
-        SWSS_LOG_WARN("FDB: cannot get hwif name for sw_if_index %u", sw_if_index);
-        return SAI_NULL_OBJECT_ID;
-    }
+    auto it = m_swif_to_port_id.find(sw_if_index);
+    if (it != m_swif_to_port_id.end())
+        return it->second;
 
-    const char *tapname = hwif_to_tap_name(hwifname);
-    if (!tapname)
-    {
-        SWSS_LOG_WARN("FDB: cannot get tap name for hwif %s", hwifname);
-        return SAI_NULL_OBJECT_ID;
-    }
+    sai_object_id_t port_id = getPortIdFromSwIfIndex(sw_if_index);
+    if (port_id != SAI_NULL_OBJECT_ID)
+        m_swif_to_port_id[sw_if_index] = port_id;
 
-    return getPortIdFromIfName(std::string(tapname));
+    return port_id;
 }
 
 bool SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type)
@@ -1385,7 +1370,7 @@ bool SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_
 
     bool is_move = (event_type == SAI_FDB_EVENT_MOVE);
 
-    sai_object_id_t port_id = getPortIdFromSwIfIndex(sw_if_index);
+    sai_object_id_t port_id = resolvePortIdFromSwIfIndex(sw_if_index);
     if (port_id == SAI_NULL_OBJECT_ID)
     {
         SWSS_LOG_ERROR("FDB: cannot resolve port OID for sw_if_index %u", sw_if_index);
@@ -1561,13 +1546,10 @@ void SwitchVpp::vpp_fdb_entries_invalidate_by_bd(uint32_t bd_id)
 void SwitchVpp::vpp_fdb_entries_invalidate_by_port(sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
-    /* O(N) scan: resolves sw_if_index -> port OID via VPP API for each entry.
-     * This is acceptable since flush-by-interface is infrequent.
-     * TODO: Improve this by storing the sw_if_index -> port OID mapping somewhere. */
     size_t before = m_vpp_fdb_entries.size();
     for (auto it = m_vpp_fdb_entries.begin(); it != m_vpp_fdb_entries.end(); )
     {
-        if (getPortIdFromSwIfIndex(it->second) == port_id)
+        if (resolvePortIdFromSwIfIndex(it->second) == port_id)
             it = m_vpp_fdb_entries.erase(it);
         else
             ++it;

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -201,6 +201,8 @@ sai_status_t SwitchVpp::vpp_create_vlan_member(
         //Create bridge and set the l2 port
         set_sw_interface_l2_bridge(hw_ifname,bridge_id, true, VPP_API_PORT_TYPE_NORMAL);
 
+        swif_bdid_track(hw_ifname, bridge_id);
+
         //Set interface state up
         interface_set_state(hw_ifname, true);
     }
@@ -210,6 +212,8 @@ sai_status_t SwitchVpp::vpp_create_vlan_member(
 
         //Create bridge and set the l2 port
         set_sw_interface_l2_bridge(hw_ifname,bridge_id, true, VPP_API_PORT_TYPE_NORMAL);
+
+        swif_bdid_track(hw_ifname, bridge_id);
 
         //Set the vlan member to bridge and tags rewrite
         vpp_l2_vtr_op_t vtr_op = L2_VTR_PUSH_1;
@@ -373,6 +377,7 @@ sai_status_t SwitchVpp::vpp_remove_vlan_member(
 
         //Remove interface from bridge, interface type should be changed to others types like l3.
         set_sw_interface_l2_bridge(hw_ifname, bridge_id, false, VPP_API_PORT_TYPE_NORMAL);
+        swif_bdid_untrack(hw_ifname);
     }
     else if (tagging_mode == SAI_VLAN_TAGGING_MODE_TAGGED)
     {
@@ -382,6 +387,7 @@ sai_status_t SwitchVpp::vpp_remove_vlan_member(
         hw_ifname = host_subifname;
         // Remove the l2 port from bridge
         set_sw_interface_l2_bridge(hw_ifname, bridge_id, false, VPP_API_PORT_TYPE_NORMAL);
+        swif_bdid_untrack(hw_ifname);
 
         // delete subinterface
         delete_sub_interface(hw_ifname, vlan_id);
@@ -1282,6 +1288,7 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
                             sai_serialize_object_id(br_port_id).c_str());
                     auto ret = l2fib_flush_all();
                     SWSS_LOG_NOTICE("Flush ALL (tunnel bridge port fallback) ret_val: %d", ret);
+                    vpp_fdb_entries_invalidate_all();
                     break;
                 }
 
@@ -1304,6 +1311,10 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
                     const char *hwif_name = ifname.c_str();
                     auto ret = l2fib_flush_int(hwif_name);
                     SWSS_LOG_NOTICE(" Flush by interface on hwif_name %s  Successful ret_val: %d", hwif_name, ret);
+                    if (is_tunnel_bridge_port(br_port_id))
+                        vpp_fdb_entries_invalidate_all();
+                    else
+                        vpp_fdb_entries_invalidate_by_port(port_id);
                 }
                 else
                 {
@@ -1319,6 +1330,7 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
             {
                 auto ret = l2fib_flush_bd(bd_id);
                 SWSS_LOG_NOTICE(" Flush on bd_id %d Successfull ret_val: %d",bd_id, ret);
+                vpp_fdb_entries_invalidate_by_bd(bd_id);
             }
             break;
 
@@ -1328,6 +1340,7 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
             {
                 auto ret = l2fib_flush_all();
                 SWSS_LOG_NOTICE(" Flush ALL fdb entry ret_val: %d", ret);
+                vpp_fdb_entries_invalidate_all();
             }
             break;
 
@@ -1339,4 +1352,220 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
     }
 
     return SAI_STATUS_SUCCESS;
+}
+
+/*
+ * Resolve a VPP sw_if_index to a SAI port OID via the 3-step lookup chain:
+ * sw_if_index -> VPP hw interface name -> Linux tap/SONiC port name -> SAI port OID.
+ * Returns SAI_NULL_OBJECT_ID on any lookup failure.
+ */
+sai_object_id_t SwitchVpp::getPortIdFromSwIfIndex(uint32_t sw_if_index)
+{
+    const char *hwifname = vpp_get_swif_name(sw_if_index);
+    if (!hwifname)
+    {
+        SWSS_LOG_WARN("FDB: cannot get hwif name for sw_if_index %u", sw_if_index);
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    const char *tapname = hwif_to_tap_name(hwifname);
+    if (!tapname)
+    {
+        SWSS_LOG_WARN("FDB: cannot get tap name for hwif %s", hwifname);
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    return getPortIdFromIfName(std::string(tapname));
+}
+
+void SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type)
+{
+    SWSS_LOG_ENTER();
+
+    bool is_move = (event_type == SAI_FDB_EVENT_MOVE);
+
+    sai_object_id_t port_id = getPortIdFromSwIfIndex(sw_if_index);
+    if (port_id == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("FDB: cannot resolve port OID for sw_if_index %u", sw_if_index);
+        return;
+    }
+
+    sai_object_id_t bv_id = SAI_NULL_OBJECT_ID;
+    sai_object_id_t bridge_port_id = SAI_NULL_OBJECT_ID;
+
+    findBridgeVlanForPortVlan(port_id, (sai_vlan_id_t)key.bd_id, bv_id, bridge_port_id);
+
+    if (bv_id == SAI_NULL_OBJECT_ID || bridge_port_id == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("FDB: bv_id or bridge_port not found for sw_if_index %u bd %u",
+                       sw_if_index, key.bd_id);
+        return;
+    }
+
+    std::set<FdbInfo>::iterator existing_it = m_fdb_info_set.end();
+    FdbInfo fi;
+
+    if (is_move)
+    {
+        FdbInfo fi_search;
+        fi_search.setVlanId((sai_vlan_id_t)key.bd_id);
+        memcpy(fi_search.m_fdbEntry.mac_address, key.mac, sizeof(sai_mac_t));
+
+        existing_it = m_fdb_info_set.find(fi_search);
+        if (existing_it == m_fdb_info_set.end())
+        {
+            SWSS_LOG_WARN("FDB: entry not found in m_fdb_info_set for bd %u, treating as learn",
+                          key.bd_id);
+            generateFdbLearnedOrMoveEvent(key, sw_if_index, SAI_FDB_EVENT_LEARNED);
+            return;
+        }
+        fi = *existing_it;
+    }
+    else
+    {
+        fi.m_fdbEntry.switch_id = m_switch_id;
+        fi.m_fdbEntry.bv_id = bv_id;
+        memcpy(fi.m_fdbEntry.mac_address, key.mac, sizeof(sai_mac_t));
+    }
+
+    fi.setBridgePortId(bridge_port_id);
+    fi.setPortId(port_id);
+    fi.setVlanId((sai_vlan_id_t)key.bd_id);
+    fi.setTimestamp((uint32_t)time(NULL));
+
+    sai_attribute_t attrs[2];
+    attrs[0].id = SAI_FDB_ENTRY_ATTR_TYPE;
+    attrs[0].value.s32 = SAI_FDB_ENTRY_TYPE_DYNAMIC;
+    attrs[1].id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
+    attrs[1].value.oid = bridge_port_id;
+
+    sai_fdb_event_notification_data_t data;
+    data.event_type = event_type;
+    data.fdb_entry = fi.getFdbEntry();
+    data.attr_count = 2;
+    data.attr = attrs;
+
+    auto sid = sai_serialize_fdb_entry(data.fdb_entry);
+    sai_status_t status;
+
+    if (is_move)
+        status = set_internal(SAI_OBJECT_TYPE_FDB_ENTRY, sid, &attrs[1]);
+    else
+        status = create_internal(SAI_OBJECT_TYPE_FDB_ENTRY, sid, m_switch_id, 2, attrs);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("FDB: %s failed for %s: %s",
+                       is_move ? "set_internal" : "create_internal",
+                       sid.c_str(), sai_serialize_status(status).c_str());
+        return;
+    }
+
+    if (is_move)
+        m_fdb_info_set.erase(existing_it);
+    m_fdb_info_set.insert(fi);
+
+    send_fdb_event_notification(data);
+
+    SWSS_LOG_NOTICE("FDB: notified %s for MAC %02x:%02x:%02x:%02x:%02x:%02x bd %u sw_if_index %u",
+                    is_move ? "MOVE" : "LEARNED",
+                    key.mac[0], key.mac[1], key.mac[2], key.mac[3], key.mac[4], key.mac[5],
+                    key.bd_id, sw_if_index);
+}
+
+void SwitchVpp::generateFdbAgedEvent(const VppFdbKey &key)
+{
+    SWSS_LOG_ENTER();
+
+    FdbInfo fi_search;
+    fi_search.setVlanId((sai_vlan_id_t)key.bd_id);
+    memcpy(fi_search.m_fdbEntry.mac_address, key.mac, sizeof(sai_mac_t));
+
+    auto it = m_fdb_info_set.find(fi_search);
+    if (it == m_fdb_info_set.end())
+    {
+        SWSS_LOG_ERROR("FDB: entry not found in m_fdb_info_set for bd %u", key.bd_id);
+        return;
+    }
+
+    FdbInfo fi = *it;
+
+    sai_attribute_t attrs[2];
+    attrs[0].id = SAI_FDB_ENTRY_ATTR_TYPE;
+    attrs[0].value.s32 = SAI_FDB_ENTRY_TYPE_DYNAMIC;
+    attrs[1].id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
+    attrs[1].value.oid = fi.getBridgePortId();
+
+    sai_fdb_event_notification_data_t data;
+    data.event_type = SAI_FDB_EVENT_AGED;
+    data.fdb_entry = fi.getFdbEntry();
+    data.attr_count = 2;
+    data.attr = attrs;
+
+    auto sid = sai_serialize_fdb_entry(data.fdb_entry);
+    remove_internal(SAI_OBJECT_TYPE_FDB_ENTRY, sid);
+
+    m_fdb_info_set.erase(it);
+
+    send_fdb_event_notification(data);
+
+    SWSS_LOG_NOTICE("FDB: notified AGED for MAC %02x:%02x:%02x:%02x:%02x:%02x bd %u",
+                    key.mac[0], key.mac[1], key.mac[2], key.mac[3], key.mac[4], key.mac[5], key.bd_id);
+}
+
+void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)
+{
+    uint32_t swif = vpp_get_swif_idx_by_name(hwif_name);
+    if (swif != (uint32_t)~0u)
+    {
+        m_swif_to_bdid[swif] = bd_id;
+    }
+}
+
+void SwitchVpp::swif_bdid_untrack(const char *hwif_name)
+{
+    uint32_t swif = vpp_get_swif_idx_by_name(hwif_name);
+    if (swif != (uint32_t)~0u)
+    {
+        m_swif_to_bdid.erase(swif);
+    }
+}
+
+void SwitchVpp::vpp_fdb_entries_invalidate_all()
+{
+    SWSS_LOG_INFO("FDB: invalidating all %zu m_vpp_fdb_entries", m_vpp_fdb_entries.size());
+    m_vpp_fdb_entries.clear();
+}
+
+void SwitchVpp::vpp_fdb_entries_invalidate_by_bd(uint32_t bd_id)
+{
+    size_t before = m_vpp_fdb_entries.size();
+    for (auto it = m_vpp_fdb_entries.begin(); it != m_vpp_fdb_entries.end(); )
+    {
+        if (it->first.bd_id == bd_id)
+            it = m_vpp_fdb_entries.erase(it);
+        else
+            ++it;
+    }
+    SWSS_LOG_INFO("FDB: invalidated by bd_id=%u, removed %zu entries, %zu remain",
+                  bd_id, before - m_vpp_fdb_entries.size(), m_vpp_fdb_entries.size());
+}
+
+void SwitchVpp::vpp_fdb_entries_invalidate_by_port(sai_object_id_t port_id)
+{
+    /* O(N) scan: resolves sw_if_index -> port OID via VPP API for each entry.
+     * This is acceptable since flush-by-interface is infrequent.
+     * TODO: Improve this by storing the sw_if_index -> port OID mapping somewhere. */
+    size_t before = m_vpp_fdb_entries.size();
+    for (auto it = m_vpp_fdb_entries.begin(); it != m_vpp_fdb_entries.end(); )
+    {
+        if (getPortIdFromSwIfIndex(it->second) == port_id)
+            it = m_vpp_fdb_entries.erase(it);
+        else
+            ++it;
+    }
+    SWSS_LOG_INFO("FDB: invalidated by port_id=%s, removed %zu entries, %zu remain",
+                  sai_serialize_object_id(port_id).c_str(),
+                  before - m_vpp_fdb_entries.size(), m_vpp_fdb_entries.size());
 }

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1353,6 +1353,8 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
 
 inline sai_object_id_t SwitchVpp::resolvePortIdFromSwIfIndex(uint32_t sw_if_index)
 {
+    SWSS_LOG_ENTER();
+
     auto it = m_swif_to_port_id.find(sw_if_index);
     if (it != m_swif_to_port_id.end())
         return it->second;

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1059,34 +1059,6 @@ vl_api_l2_macs_event_t_handler (vl_api_l2_macs_event_t *mp)
 
 /* ----- end WANT_L2_MACS_EVENTS2 handlers (implementations below) ----- */
 
-/* Context passed through mp->context for vpp_l2fib_table_dump(). */
-typedef struct {
-    vpp_l2fib_cb_fn  cb;
-    void            *user_ctx;
-} vpp_l2fib_dump_ctx_t;
-
-static void
-vl_api_l2_fib_table_details_t_handler (vl_api_l2_fib_table_details_t *mp)
-{
-    uintptr_t p = get_index_ptr(ntohl(mp->context));
-    if (!p) return;
-    vpp_l2fib_dump_ctx_t *ctx = (vpp_l2fib_dump_ctx_t *)(void *)p;
-
-    /* Skip static, filter, and BVI entries — only dynamic MACs are relevant. */
-    if (mp->static_mac || mp->filter_mac || mp->bvi_mac)
-        return;
-
-    vpp_l2fib_entry_t e;
-    memcpy(e.mac, mp->mac, 6);
-    e.sw_if_index = ntohl(mp->sw_if_index);
-    e.bd_id       = ntohl(mp->bd_id);
-    ctx->cb(&e, ctx->user_ctx);
-}
-
-/* Magic value to distinguish vpp_swif_bdid_dump_ctx_t from legacy u32 *member_count context.
- * The typedef is at the bottom of this file (must be after l2_msg_id_base declaration). */
-#define VPP_SWIF_BDID_CTX_MAGIC 0xBD2D0000u
-
 static void
 vl_api_bfd_udp_add_reply_t_handler (vl_api_bfd_udp_add_reply_t *msg)
 {
@@ -1165,23 +1137,6 @@ vl_api_bridge_domain_details_t_handler (vl_api_bridge_domain_details_t *mp)
     void *ptr = (void *) get_index_ptr(mp->context);
     if (!ptr)
     {
-        return;
-    }
-
-    /* Check for swif→bdid dump context by magic value */
-    uint32_t *magic = (uint32_t *) ptr;
-    if (*magic == VPP_SWIF_BDID_CTX_MAGIC) {
-        /* vpp_swif_bdid_dump_ctx_t layout: {magic, cb, user_ctx} */
-        void **fields = (void **) ptr;
-        vpp_swif_bdid_cb_fn cb = (vpp_swif_bdid_cb_fn) fields[1];
-        void *user_ctx = fields[2];
-        uint32_t bd_id = ntohl(mp->bd_id);
-        uint32_t n = ntohl(mp->n_sw_ifs);
-        vl_api_bridge_domain_sw_if_t *sw_ifs = mp->sw_if_details;
-        for (uint32_t i = 0; i < n; i++) {
-            uint32_t sw_if_index = ntohl(sw_ifs[i].sw_if_index);
-            cb(sw_if_index, bd_id, user_ctx);
-        }
         return;
     }
 
@@ -1450,7 +1405,6 @@ static void vpp_base_vpe_init(void)
     _(L2_MSG_ID(WANT_L2_MACS_EVENTS2_REPLY), want_l2_macs_events2_reply) \
     _(L2_MSG_ID(L2_MACS_EVENT), l2_macs_event) \
     _(L2_MSG_ID(L2FIB_SET_SCAN_DELAY_REPLY), l2fib_set_scan_delay_reply) \
-    _(L2_MSG_ID(L2_FIB_TABLE_DETAILS), l2_fib_table_details) \
     _(BFD_MSG_ID(BFD_UDP_ADD_REPLY), bfd_udp_add_reply) \
     _(BFD_MSG_ID(BFD_UDP_DEL_REPLY), bfd_udp_del_reply) \
     _(BFD_MSG_ID(BFD_UDP_SESSION_EVENT), bfd_udp_session_event) \
@@ -4691,12 +4645,6 @@ int vpp_sw_interface_find_by_ip(vpp_ip_addr_t *search_ip, uint32_t vrf_id,
  * These must appear after l2_msg_id_base and __plugin_msg_base declarations.
  * ========================================================================= */
 
-typedef struct {
-    uint32_t magic;
-    vpp_swif_bdid_cb_fn cb;
-    void *user_ctx;
-} vpp_swif_bdid_dump_ctx_t;
-
 int
 vpp_want_l2_macs_events2 (bool enable, vpp_mac_event_cb_fn cb, void *ctx)
 {
@@ -4748,55 +4696,4 @@ vpp_get_swif_idx_by_name (const char *hwif_name)
     vat_main_t *vam = &vat_main;
     u32 idx = get_swif_idx(vam, hwif_name);
     return (idx == (u32)~0) ? (uint32_t)~0u : (uint32_t)idx;
-}
-
-int
-vpp_bridge_domain_dump_swif_bdid (vpp_swif_bdid_cb_fn cb, void *user_ctx)
-{
-    vat_main_t *vam = &vat_main;
-    vl_api_bridge_domain_dump_t *mp;
-    vl_api_control_ping_t *mp_ping;
-    vpp_swif_bdid_dump_ctx_t ctx = { VPP_SWIF_BDID_CTX_MAGIC, cb, user_ctx };
-    int ret;
-
-    VPP_LOCK();
-    __plugin_msg_base = l2_msg_id_base;
-
-    M(BRIDGE_DOMAIN_DUMP, mp);
-    mp->bd_id = htonl((uint32_t)~0u);
-    mp->sw_if_index = htonl((uint32_t)~0u);
-    mp->context = store_ptr(&ctx);
-    S(mp);
-
-    M(CONTROL_PING, mp_ping);
-    S(mp_ping);
-    WR(ret);
-
-    VPP_UNLOCK();
-    return ret;
-}
-
-int
-vpp_l2fib_table_dump (uint32_t bd_id, vpp_l2fib_cb_fn cb, void *user_ctx)
-{
-    vat_main_t *vam = &vat_main;
-    vl_api_l2_fib_table_dump_t *mp;
-    vl_api_control_ping_t *mp_ping;
-    vpp_l2fib_dump_ctx_t ctx = { cb, user_ctx };
-    int ret;
-
-    VPP_LOCK();
-    __plugin_msg_base = l2_msg_id_base;
-
-    M(L2_FIB_TABLE_DUMP, mp);
-    mp->bd_id   = htonl(bd_id);
-    mp->context = store_ptr(&ctx);
-    S(mp);
-
-    M(CONTROL_PING, mp_ping);
-    S(mp_ping);
-    WR(ret);
-
-    VPP_UNLOCK();
-    return ret;
 }

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1059,6 +1059,30 @@ vl_api_l2_macs_event_t_handler (vl_api_l2_macs_event_t *mp)
 
 /* ----- end WANT_L2_MACS_EVENTS2 handlers (implementations below) ----- */
 
+/* Context passed through mp->context for vpp_l2fib_table_dump(). */
+typedef struct {
+    vpp_l2fib_cb_fn  cb;
+    void            *user_ctx;
+} vpp_l2fib_dump_ctx_t;
+
+static void
+vl_api_l2_fib_table_details_t_handler (vl_api_l2_fib_table_details_t *mp)
+{
+    uintptr_t p = get_index_ptr(ntohl(mp->context));
+    if (!p) return;
+    vpp_l2fib_dump_ctx_t *ctx = (vpp_l2fib_dump_ctx_t *)(void *)p;
+
+    /* Skip static, filter, and BVI entries — only dynamic MACs are relevant. */
+    if (mp->static_mac || mp->filter_mac || mp->bvi_mac)
+        return;
+
+    vpp_l2fib_entry_t e;
+    memcpy(e.mac, mp->mac, 6);
+    e.sw_if_index = ntohl(mp->sw_if_index);
+    e.bd_id       = ntohl(mp->bd_id);
+    ctx->cb(&e, ctx->user_ctx);
+}
+
 /* Magic value to distinguish vpp_swif_bdid_dump_ctx_t from legacy u32 *member_count context.
  * The typedef is at the bottom of this file (must be after l2_msg_id_base declaration). */
 #define VPP_SWIF_BDID_CTX_MAGIC 0xBD2D0000u
@@ -1426,6 +1450,7 @@ static void vpp_base_vpe_init(void)
     _(L2_MSG_ID(WANT_L2_MACS_EVENTS2_REPLY), want_l2_macs_events2_reply) \
     _(L2_MSG_ID(L2_MACS_EVENT), l2_macs_event) \
     _(L2_MSG_ID(L2FIB_SET_SCAN_DELAY_REPLY), l2fib_set_scan_delay_reply) \
+    _(L2_MSG_ID(L2_FIB_TABLE_DETAILS), l2_fib_table_details) \
     _(BFD_MSG_ID(BFD_UDP_ADD_REPLY), bfd_udp_add_reply) \
     _(BFD_MSG_ID(BFD_UDP_DEL_REPLY), bfd_udp_del_reply) \
     _(BFD_MSG_ID(BFD_UDP_SESSION_EVENT), bfd_udp_session_event) \
@@ -4740,6 +4765,31 @@ vpp_bridge_domain_dump_swif_bdid (vpp_swif_bdid_cb_fn cb, void *user_ctx)
     M(BRIDGE_DOMAIN_DUMP, mp);
     mp->bd_id = htonl((uint32_t)~0u);
     mp->sw_if_index = htonl((uint32_t)~0u);
+    mp->context = store_ptr(&ctx);
+    S(mp);
+
+    M(CONTROL_PING, mp_ping);
+    S(mp_ping);
+    WR(ret);
+
+    VPP_UNLOCK();
+    return ret;
+}
+
+int
+vpp_l2fib_table_dump (uint32_t bd_id, vpp_l2fib_cb_fn cb, void *user_ctx)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_l2_fib_table_dump_t *mp;
+    vl_api_control_ping_t *mp_ping;
+    vpp_l2fib_dump_ctx_t ctx = { cb, user_ctx };
+    int ret;
+
+    VPP_LOCK();
+    __plugin_msg_base = l2_msg_id_base;
+
+    M(L2_FIB_TABLE_DUMP, mp);
+    mp->bd_id   = htonl(bd_id);
     mp->context = store_ptr(&ctx);
     S(mp);
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1041,20 +1041,22 @@ vl_api_l2_macs_event_t_handler (vl_api_l2_macs_event_t *mp)
 
     u32 n = ntohl(mp->n_macs);
     if (n == 0) return;
-    if (n > VPP_MAC_EVENT_BATCH_MAX)
-    {
-        SAIVPP_ERROR("Got %d MACs in event, truncating to %d",
-                     n, VPP_MAC_EVENT_BATCH_MAX);
-        n = VPP_MAC_EVENT_BATCH_MAX;
-    }
 
-    for (u32 i = 0; i < n; i++) {
-        vl_api_mac_entry_t *e = &mp->mac[i];
-        memcpy(g_mac_event_batch[i].mac, e->mac_addr, 6);
-        g_mac_event_batch[i].sw_if_index = ntohl(e->sw_if_index);
-        g_mac_event_batch[i].action = (uint8_t)e->action;
+    // Process the full batch in chunks to avoid dropping FDB state deltas.
+    for (u32 off = 0; off < n; off += VPP_MAC_EVENT_BATCH_MAX)
+    {
+        u32 chunk = n - off;
+        if (chunk > VPP_MAC_EVENT_BATCH_MAX)
+            chunk = VPP_MAC_EVENT_BATCH_MAX;
+
+        for (u32 i = 0; i < chunk; i++) {
+            vl_api_mac_entry_t *e = &mp->mac[off + i];
+            memcpy(g_mac_event_batch[i].mac, e->mac_addr, 6);
+            g_mac_event_batch[i].sw_if_index = ntohl(e->sw_if_index);
+            g_mac_event_batch[i].action = (uint8_t)e->action;
+        }
+        g_mac_event_cb(g_mac_event_batch, chunk, g_mac_event_ctx);
     }
-    g_mac_event_cb(g_mac_event_batch, n, g_mac_event_ctx);
 }
 
 /* ----- end WANT_L2_MACS_EVENTS2 handlers (implementations below) ----- */

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1005,6 +1005,64 @@ vl_api_l2fib_flush_bd_reply_t_handler (vl_api_l2fib_flush_bd_reply_t *msg)
     set_reply_status(retval);
 }
 
+/* ----- WANT_L2_MACS_EVENTS2: push-based MAC learn/age/move notifications ----- */
+
+static vpp_mac_event_cb_fn g_mac_event_cb = NULL;
+static void *g_mac_event_ctx = NULL;
+
+#define VPP_MAC_EVENT_BATCH_MAX 128
+static vpp_mac_event_t g_mac_event_batch[VPP_MAC_EVENT_BATCH_MAX];
+
+static void
+vl_api_want_l2_macs_events2_reply_t_handler (vl_api_want_l2_macs_events2_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void
+vl_api_l2fib_set_scan_delay_reply_t_handler (vl_api_l2fib_set_scan_delay_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+/*
+ * Handler for unsolicited L2_MACS_EVENT notifications pushed by VPP.
+ * Called on VPP's API receive thread — MUST NOT acquire the saivpp main
+ * mutex.  Callers register a callback that enqueues the event for safe
+ * processing on a thread that holds the mutex.
+ */
+static void
+vl_api_l2_macs_event_t_handler (vl_api_l2_macs_event_t *mp)
+{
+    if (!g_mac_event_cb)
+        return;
+
+    u32 n = ntohl(mp->n_macs);
+    if (n == 0) return;
+    if (n > VPP_MAC_EVENT_BATCH_MAX)
+    {
+        SAIVPP_ERROR("Got %d MACs in event, truncating to %d",
+                     n, VPP_MAC_EVENT_BATCH_MAX);
+        n = VPP_MAC_EVENT_BATCH_MAX;
+    }
+
+    for (u32 i = 0; i < n; i++) {
+        vl_api_mac_entry_t *e = &mp->mac[i];
+        memcpy(g_mac_event_batch[i].mac, e->mac_addr, 6);
+        g_mac_event_batch[i].sw_if_index = ntohl(e->sw_if_index);
+        g_mac_event_batch[i].action = (uint8_t)e->action;
+    }
+    g_mac_event_cb(g_mac_event_batch, n, g_mac_event_ctx);
+}
+
+/* ----- end WANT_L2_MACS_EVENTS2 handlers (implementations below) ----- */
+
+/* Magic value to distinguish vpp_swif_bdid_dump_ctx_t from legacy u32 *member_count context.
+ * The typedef is at the bottom of this file (must be after l2_msg_id_base declaration). */
+#define VPP_SWIF_BDID_CTX_MAGIC 0xBD2D0000u
+
 static void
 vl_api_bfd_udp_add_reply_t_handler (vl_api_bfd_udp_add_reply_t *msg)
 {
@@ -1075,18 +1133,38 @@ vl_api_bfd_udp_session_event_t_handler (vl_api_bfd_udp_session_event_t *msg)
 static void
 vl_api_bridge_domain_details_t_handler (vl_api_bridge_domain_details_t *mp)
 {
+    if (!mp->context)
+    {
+        return;
+    }
 
-  if (mp->context) {
-      u32 *member_count = (u32 *) get_index_ptr(mp->context);
-      if (!member_count) {
-          return;
-      }
-      *member_count = ntohl(mp->n_sw_ifs);
-      SAIVPP_INFO("bridge member count: %d", ntohl(mp->n_sw_ifs));
-      release_index(mp->context);
-      return;
-  }
-  return;
+    void *ptr = (void *) get_index_ptr(mp->context);
+    if (!ptr)
+    {
+        return;
+    }
+
+    /* Check for swif→bdid dump context by magic value */
+    uint32_t *magic = (uint32_t *) ptr;
+    if (*magic == VPP_SWIF_BDID_CTX_MAGIC) {
+        /* vpp_swif_bdid_dump_ctx_t layout: {magic, cb, user_ctx} */
+        void **fields = (void **) ptr;
+        vpp_swif_bdid_cb_fn cb = (vpp_swif_bdid_cb_fn) fields[1];
+        void *user_ctx = fields[2];
+        uint32_t bd_id = ntohl(mp->bd_id);
+        uint32_t n = ntohl(mp->n_sw_ifs);
+        vl_api_bridge_domain_sw_if_t *sw_ifs = mp->sw_if_details;
+        for (uint32_t i = 0; i < n; i++) {
+            uint32_t sw_if_index = ntohl(sw_ifs[i].sw_if_index);
+            cb(sw_if_index, bd_id, user_ctx);
+        }
+        return;
+    }
+
+    /* Legacy: treat context as u32 *member_count */
+    u32 *member_count = (u32 *) ptr;
+    *member_count = ntohl(mp->n_sw_ifs);
+    SAIVPP_INFO("bridge member count: %d", ntohl(mp->n_sw_ifs));
 }
 
 static void
@@ -1345,6 +1423,9 @@ static void vpp_base_vpe_init(void)
     _(L2_MSG_ID(L2FIB_FLUSH_ALL_REPLY), l2fib_flush_all_reply) \
     _(L2_MSG_ID(L2FIB_FLUSH_INT_REPLY), l2fib_flush_int_reply) \
     _(L2_MSG_ID(L2FIB_FLUSH_BD_REPLY), l2fib_flush_bd_reply) \
+    _(L2_MSG_ID(WANT_L2_MACS_EVENTS2_REPLY), want_l2_macs_events2_reply) \
+    _(L2_MSG_ID(L2_MACS_EVENT), l2_macs_event) \
+    _(L2_MSG_ID(L2FIB_SET_SCAN_DELAY_REPLY), l2fib_set_scan_delay_reply) \
     _(BFD_MSG_ID(BFD_UDP_ADD_REPLY), bfd_udp_add_reply) \
     _(BFD_MSG_ID(BFD_UDP_DEL_REPLY), bfd_udp_del_reply) \
     _(BFD_MSG_ID(BFD_UDP_SESSION_EVENT), bfd_udp_session_event) \
@@ -4578,4 +4659,94 @@ int vpp_sw_interface_find_by_ip(vpp_ip_addr_t *search_ip, uint32_t vrf_id,
 
     vec_free(sw_if_idxs);
     return -ENOENT;
+}
+
+/* =========================================================================
+ * WANT_L2_MACS_EVENTS2 implementation functions
+ * These must appear after l2_msg_id_base and __plugin_msg_base declarations.
+ * ========================================================================= */
+
+typedef struct {
+    uint32_t magic;
+    vpp_swif_bdid_cb_fn cb;
+    void *user_ctx;
+} vpp_swif_bdid_dump_ctx_t;
+
+int
+vpp_want_l2_macs_events2 (bool enable, vpp_mac_event_cb_fn cb, void *ctx)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_want_l2_macs_events2_t *mp;
+    int ret;
+
+    g_mac_event_cb = enable ? cb : NULL;
+    g_mac_event_ctx = enable ? ctx : NULL;
+
+    VPP_LOCK();
+    __plugin_msg_base = l2_msg_id_base;
+
+    M(WANT_L2_MACS_EVENTS2, mp);
+    mp->enable_disable = enable ? 1 : 0;
+    // Set the maximum number of MAC entries in each event to 10
+    // Each entry can contain up to 10 MACs, so 100 MACs per event
+    mp->max_macs_in_event = 10;
+    mp->pid = htonl((uint32_t)getpid());
+    S(mp);
+    WR(ret);
+
+    VPP_UNLOCK();
+    return ret;
+}
+
+int
+vpp_l2fib_set_scan_delay (uint16_t delay_10ms)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_l2fib_set_scan_delay_t *mp;
+    int ret;
+
+    VPP_LOCK();
+    __plugin_msg_base = l2_msg_id_base;
+
+    M(L2FIB_SET_SCAN_DELAY, mp);
+    mp->scan_delay = htons(delay_10ms);
+    S(mp);
+    WR(ret);
+
+    VPP_UNLOCK();
+    return ret;
+}
+
+uint32_t
+vpp_get_swif_idx_by_name (const char *hwif_name)
+{
+    vat_main_t *vam = &vat_main;
+    u32 idx = get_swif_idx(vam, hwif_name);
+    return (idx == (u32)~0) ? (uint32_t)~0u : (uint32_t)idx;
+}
+
+int
+vpp_bridge_domain_dump_swif_bdid (vpp_swif_bdid_cb_fn cb, void *user_ctx)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_bridge_domain_dump_t *mp;
+    vl_api_control_ping_t *mp_ping;
+    vpp_swif_bdid_dump_ctx_t ctx = { VPP_SWIF_BDID_CTX_MAGIC, cb, user_ctx };
+    int ret;
+
+    VPP_LOCK();
+    __plugin_msg_base = l2_msg_id_base;
+
+    M(BRIDGE_DOMAIN_DUMP, mp);
+    mp->bd_id = htonl((uint32_t)~0u);
+    mp->sw_if_index = htonl((uint32_t)~0u);
+    mp->context = store_ptr(&ctx);
+    S(mp);
+
+    M(CONTROL_PING, mp_ping);
+    S(mp_ping);
+    WR(ret);
+
+    VPP_UNLOCK();
+    return ret;
 }

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -4654,6 +4654,19 @@ vpp_want_l2_macs_events2 (bool enable, vpp_mac_event_cb_fn cb, void *ctx)
     vl_api_want_l2_macs_events2_t *mp;
     int ret;
 
+    /*
+     * NOTE: Single-switch assumption: VPP has one L2 MAC event stream per process.
+     * g_mac_event_cb/ctx are process-globals — the last registration wins and
+     * one switch's teardown nulls the callback for all.  Assert here so a
+     * future multi-switch deployment fails loudly instead of silently losing
+     * MAC events from all but the last registered switch.
+     * Supporting multiple switches would require demultiplexing events by
+     * sw_if_index at this layer.
+     */
+    if (enable) {
+        assert(g_mac_event_cb == NULL && "only one switch may register MAC events at a time");
+    }
+
     g_mac_event_cb = enable ? cb : NULL;
     g_mac_event_ctx = enable ? ctx : NULL;
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -343,11 +343,18 @@ typedef enum {
     extern int l2fib_flush_int(const char *hwif_name);
     extern int l2fib_flush_bd(uint32_t bd_id);
 
+    /* MAC event action codes from VPP l2_macs_event */
+    typedef enum {
+        VPP_MAC_ACTION_ADD    = 0,  /* newly learned */
+        VPP_MAC_ACTION_DELETE = 1,  /* aged out */
+        VPP_MAC_ACTION_MOVE   = 2,  /* moved to a different port */
+    } vpp_mac_action_t;
+
     /* MAC event callback types for push-based FDB notification via WANT_L2_MACS_EVENTS2 */
     typedef struct {
         uint8_t  mac[6];
         uint32_t sw_if_index;
-        uint8_t  action; /* 0=ADD(learn), 1=DELETE(age), 2=MOVE */
+        uint8_t  action; /* vpp_mac_action_t */
     } vpp_mac_event_t;
 
     /* Batch callback: invoked once per l2_macs_event message with all entries.

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -342,6 +342,36 @@ typedef enum {
     extern int l2fib_flush_all();
     extern int l2fib_flush_int(const char *hwif_name);
     extern int l2fib_flush_bd(uint32_t bd_id);
+
+    /* MAC event callback types for push-based FDB notification via WANT_L2_MACS_EVENTS2 */
+    typedef struct {
+        uint8_t  mac[6];
+        uint32_t sw_if_index;
+        uint8_t  action; /* 0=ADD(learn), 1=DELETE(age), 2=MOVE */
+    } vpp_mac_event_t;
+
+    /* Batch callback: invoked once per l2_macs_event message with all entries.
+     * Called on the VPP API receive thread — must NOT acquire m_apimutex. */
+    typedef void (*vpp_mac_event_cb_fn)(const vpp_mac_event_t *evs, uint32_t n, void *ctx);
+
+    /* Register/deregister for push-based MAC learn/age/move events from VPP.
+     * cb is invoked on the VPP API receive thread — implementations MUST NOT
+     * acquire the saivpp main mutex (m_apimutex) directly; enqueue the event
+     * and process it from a thread that safely holds the mutex. */
+    extern int vpp_want_l2_macs_events2(bool enable, vpp_mac_event_cb_fn cb, void *ctx);
+
+    /* Set the L2 FIB scan delay (in units of 10ms, default=10 → 100ms).
+     * Reduces the interval between VPP scanning for aged/moved MACs. */
+    extern int vpp_l2fib_set_scan_delay(uint16_t delay_10ms);
+
+    /* Reverse-lookup: return the VPP sw_if_index for a given hw interface name,
+     * or ~0u if not found. */
+    extern uint32_t vpp_get_swif_idx_by_name(const char *hwif_name);
+
+    /* Dump all VPP bridge domains and return a map of sw_if_index → bd_id
+     * via per-entry callback. Used for startup sync of m_swif_to_bdid. */
+    typedef void (*vpp_swif_bdid_cb_fn)(uint32_t sw_if_index, uint32_t bd_id, void *ctx);
+    extern int vpp_bridge_domain_dump_swif_bdid(vpp_swif_bdid_cb_fn cb, void *ctx);
     extern int bfd_udp_add(bool multihop, const char *hwif_name, vpp_ip_addr_t *local_addr,
                            vpp_ip_addr_t *peer_addr, uint8_t detect_mult,
                            uint32_t desired_min_tx, uint32_t required_min_rx);

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -372,6 +372,17 @@ typedef enum {
      * via per-entry callback. Used for startup sync of m_swif_to_bdid. */
     typedef void (*vpp_swif_bdid_cb_fn)(uint32_t sw_if_index, uint32_t bd_id, void *ctx);
     extern int vpp_bridge_domain_dump_swif_bdid(vpp_swif_bdid_cb_fn cb, void *ctx);
+
+    /* Dump all dynamic L2FIB entries for a bridge domain (bd_id == ~0 → all BDs).
+     * Callback receives {mac[6], sw_if_index, bd_id} for each dynamic entry.
+     * Used for initial seeding of m_vpp_fdb_entries on startup. */
+    typedef struct {
+        uint8_t  mac[6];
+        uint32_t sw_if_index;
+        uint32_t bd_id;
+    } vpp_l2fib_entry_t;
+    typedef void (*vpp_l2fib_cb_fn)(const vpp_l2fib_entry_t *entry, void *ctx);
+    extern int vpp_l2fib_table_dump(uint32_t bd_id, vpp_l2fib_cb_fn cb, void *ctx);
     extern int bfd_udp_add(bool multihop, const char *hwif_name, vpp_ip_addr_t *local_addr,
                            vpp_ip_addr_t *peer_addr, uint8_t detect_mult,
                            uint32_t desired_min_tx, uint32_t required_min_rx);

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -368,21 +368,6 @@ typedef enum {
      * or ~0u if not found. */
     extern uint32_t vpp_get_swif_idx_by_name(const char *hwif_name);
 
-    /* Dump all VPP bridge domains and return a map of sw_if_index → bd_id
-     * via per-entry callback. Used for startup sync of m_swif_to_bdid. */
-    typedef void (*vpp_swif_bdid_cb_fn)(uint32_t sw_if_index, uint32_t bd_id, void *ctx);
-    extern int vpp_bridge_domain_dump_swif_bdid(vpp_swif_bdid_cb_fn cb, void *ctx);
-
-    /* Dump all dynamic L2FIB entries for a bridge domain (bd_id == ~0 → all BDs).
-     * Callback receives {mac[6], sw_if_index, bd_id} for each dynamic entry.
-     * Used for initial seeding of m_vpp_fdb_entries on startup. */
-    typedef struct {
-        uint8_t  mac[6];
-        uint32_t sw_if_index;
-        uint32_t bd_id;
-    } vpp_l2fib_entry_t;
-    typedef void (*vpp_l2fib_cb_fn)(const vpp_l2fib_entry_t *entry, void *ctx);
-    extern int vpp_l2fib_table_dump(uint32_t bd_id, vpp_l2fib_cb_fn cb, void *ctx);
     extern int bfd_udp_add(bool multihop, const char *hwif_name, vpp_ip_addr_t *local_addr,
                            vpp_ip_addr_t *peer_addr, uint8_t detect_mult,
                            uint32_t desired_min_tx, uint32_t required_min_rx);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

The VPP SAI virtual switch (saivpp) currently has no FDB support — MAC learning, aging, and move events are not propagated to SONiC's FDB_TABLE. This means L2 forwarding state is invisible to the SONiC control plane on VPP-based platforms.

This PR adds FDB support to saivpp using VPP's push-based `WANT_L2_MACS_EVENTS2` API, which delivers MAC learn/age/move notifications within ~10 ms of the hardware event directly to the SAI layer without requiring periodic polling.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 38333755

#### How did you do it?

Please refer to HLD: https://github.com/sonic-net/SONiC/pull/2368

#### How did you verify/test it?

Ran the existing sonic-mgmt `tests/fdb/test_fdb.py` suite on a VPP KVM t0 testbed (vms-kvm-vpp-t0) in a 10-iteration soak:
* 40/40 test cases passed, 0 errors, 0 failures.
Tests exercise: FDB learning via Ethernet frames, ARP requests, and ARP replies; self-MAC non-learning; and FDB aging/cleanup.

#### Any platform specific information?
VPP platform only (`saivpp` / `docker-syncd-vpp`). No changes to other SAI implementations.

Requires VPP with the l2 plugin supporting `WANT_L2_MACS_EVENTS2` (available since VPP 22.06).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
