### PR TITLE
[Link Event Damping] Add RedisInterface plumbing for damping config

### DIFF
--- a/lib/ClientSai.cpp
+++ b/lib/ClientSai.cpp
@@ -247,6 +247,13 @@ sai_status_t ClientSai::set(
         return SAI_STATUS_FAILURE;
     }
 
+    if (RedisRemoteSaiInterface::isRedisPortAttribute(objectType, attr))
+    {
+        SWSS_LOG_ERROR("redis port extension attributes are not supported in CLIENT mode");
+
+        return SAI_STATUS_FAILURE;
+    }
+
     auto status = set(
             objectType,
             sai_serialize_object_id(objectId),

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -666,6 +666,11 @@ sai_status_t RedisRemoteSaiInterface::set(
         return setRedisExtensionAttribute(objectType, objectId, attr);
     }
 
+    if (RedisRemoteSaiInterface::isRedisPortAttribute(objectType, attr))
+    {
+        return setRedisPortExtensionAttribute(objectType, objectId, attr);
+    }
+
     auto status = set(
             objectType,
             sai_serialize_object_id(objectId),
@@ -2199,6 +2204,112 @@ bool RedisRemoteSaiInterface::isRedisAttribute(
     }
 
     return true;
+}
+
+bool RedisRemoteSaiInterface::isRedisPortAttribute(
+        _In_ sai_object_type_t objectType,
+        _In_ const sai_attribute_t* attr)
+{
+    SWSS_LOG_ENTER();
+
+    return objectType == SAI_OBJECT_TYPE_PORT
+        && attr != nullptr
+        && attr->id >= SAI_PORT_ATTR_CUSTOM_RANGE_START;
+}
+
+sai_status_t RedisRemoteSaiInterface::setRedisPortExtensionAttribute(
+        _In_ sai_object_type_t objectType,
+        _In_ sai_object_id_t objectId,
+        _In_ const sai_attribute_t *attr)
+{
+    SWSS_LOG_ENTER();
+
+    if (attr == nullptr)
+    {
+        SWSS_LOG_ERROR("attr pointer is null");
+
+        return SAI_STATUS_FAILURE;
+    }
+
+    switch ((sai_redis_port_attr_t)attr->id)
+    {
+        case SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM:
+        case SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGO_AIED_CONFIG:
+            return setLinkEventDampingConfig(objectId, attr);
+
+        default:
+            break;
+    }
+
+    SWSS_LOG_ERROR("unknown redis port extension attribute: %d", attr->id);
+
+    return SAI_STATUS_INVALID_PARAMETER;
+}
+
+sai_status_t RedisRemoteSaiInterface::setLinkEventDampingConfig(
+        _In_ sai_object_id_t objectId,
+        _In_ const sai_attribute_t *attr)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<swss::FieldValueTuple> entries;
+
+    std::string strAttrId = sai_serialize_redis_port_attr_id(
+            static_cast<sai_redis_port_attr_t>(attr->id));
+
+    switch ((sai_redis_port_attr_t)attr->id)
+    {
+        case SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM:
+        {
+            std::string strAttrValue = sai_serialize_redis_link_event_damping_algorithm(
+                    static_cast<sai_redis_link_event_damping_algorithm_t>(attr->value.s32));
+
+            entries.emplace_back(strAttrId, strAttrValue);
+            break;
+        }
+
+        case SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGO_AIED_CONFIG:
+        {
+            auto *config = static_cast<const sai_redis_link_event_damping_algo_aied_config_t*>(attr->value.ptr);
+
+            if (config == nullptr)
+            {
+                SWSS_LOG_ERROR("link event damping AIED config pointer is null");
+
+                return SAI_STATUS_INVALID_PARAMETER;
+            }
+
+            std::string strAttrValue = sai_serialize_redis_link_event_damping_aied_config(*config);
+
+            entries.emplace_back(strAttrId, strAttrValue);
+            break;
+        }
+
+        default:
+
+            SWSS_LOG_ERROR("unknown damping config attribute: %d", attr->id);
+
+            return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    std::string key = sai_serialize_object_type(SAI_OBJECT_TYPE_PORT) + ":" + sai_serialize_object_id(objectId);
+
+    SWSS_LOG_DEBUG("damping config set key: %s", key.c_str());
+
+    m_communicationChannel->set(key, entries, REDIS_ASIC_STATE_COMMAND_DAMPING_CONFIG_SET);
+
+    return waitForLinkEventDampingConfigResponse();
+}
+
+sai_status_t RedisRemoteSaiInterface::waitForLinkEventDampingConfigResponse()
+{
+    SWSS_LOG_ENTER();
+
+    swss::KeyOpFieldsValuesTuple kco;
+
+    auto status = m_communicationChannel->wait(REDIS_ASIC_STATE_COMMAND_DAMPING_CONFIG_RESPONSE, kco);
+
+    return status;
 }
 
 void RedisRemoteSaiInterface::handleNotification(

--- a/lib/RedisRemoteSaiInterface.h
+++ b/lib/RedisRemoteSaiInterface.h
@@ -227,6 +227,10 @@ namespace sairedis
                     _In_ sai_object_id_t obejctType,
                     _In_ const sai_attribute_t* attr);
 
+            static bool isRedisPortAttribute(
+                    _In_ sai_object_type_t objectType,
+                    _In_ const sai_attribute_t* attr);
+
             sai_status_t setRedisAttribute(
                     _In_ sai_object_id_t switchId,
                     _In_ const sai_attribute_t* attr);
@@ -400,6 +404,17 @@ namespace sairedis
                     _In_ sai_object_type_t objectType,
                     _In_ sai_object_id_t objectId,
                     _In_ const sai_attribute_t *attr);
+
+            sai_status_t setRedisPortExtensionAttribute(
+                    _In_ sai_object_type_t objectType,
+                    _In_ sai_object_id_t objectId,
+                    _In_ const sai_attribute_t *attr);
+
+            sai_status_t setLinkEventDampingConfig(
+                    _In_ sai_object_id_t objectId,
+                    _In_ const sai_attribute_t *attr);
+
+            sai_status_t waitForLinkEventDampingConfigResponse();
 
             bool isSaiS8ListValidString(
                     _In_ const sai_s8_list_t &s8list);

--- a/lib/Sai.cpp
+++ b/lib/Sai.cpp
@@ -249,6 +249,13 @@ sai_status_t Sai::set(
         return success ? SAI_STATUS_SUCCESS : SAI_STATUS_FAILURE;
     }
 
+    if (RedisRemoteSaiInterface::isRedisPortAttribute(objectType, attr))
+    {
+        REDIS_CHECK_CONTEXT(objectId);
+
+        return context->m_redisSai->set(objectType, objectId, attr);
+    }
+
     REDIS_CHECK_CONTEXT(objectId);
 
     return context->m_meta->set(objectType, objectId, attr);

--- a/lib/sairediscommon.h
+++ b/lib/sairediscommon.h
@@ -64,6 +64,9 @@
 #define REDIS_ASIC_STATE_COMMAND_STATS_ST_CAPABILITY_QUERY "stats_st_capability_query"
 #define REDIS_ASIC_STATE_COMMAND_STATS_ST_CAPABILITY_RESPONSE "stats_st_capability_response"
 
+#define REDIS_ASIC_STATE_COMMAND_DAMPING_CONFIG_SET          "link_event_damping_config_set"
+#define REDIS_ASIC_STATE_COMMAND_DAMPING_CONFIG_RESPONSE     "link_event_damping_config_response"
+
 /**
  * @brief Redis virtual object id counter key name.
  *

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -850,7 +850,7 @@ sai_status_t Syncd::processLinkEventDampingConfigSet(
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_NOTICE("processLinkEventDampingConfigSet: stub, returning NOT_IMPLEMENTED");
+    SWSS_LOG_NOTICE("link event damping config set not yet wired to SAI");
 
     sendLinkEventDampingConfigResponse(SAI_STATUS_NOT_IMPLEMENTED);
 

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -473,6 +473,9 @@ sai_status_t Syncd::processSingleEvent(
     if (op == REDIS_ASIC_STATE_COMMAND_OBJECT_TYPE_GET_AVAILABILITY_QUERY)
         return processObjectTypeGetAvailabilityQuery(kco);
 
+    if (op == REDIS_ASIC_STATE_COMMAND_DAMPING_CONFIG_SET)
+        return processLinkEventDampingConfigSet(kco);
+
     if (op == REDIS_FLEX_COUNTER_COMMAND_START_POLL)
         return processFlexCounterEvent(key, SET_COMMAND, kfvFieldsValues(kco));
 
@@ -840,6 +843,30 @@ sai_status_t Syncd::processStatsStCapabilityQuery(
     m_selectableChannel->set(sai_serialize_status(status), entry, REDIS_ASIC_STATE_COMMAND_STATS_ST_CAPABILITY_RESPONSE);
 
     return status;
+}
+
+sai_status_t Syncd::processLinkEventDampingConfigSet(
+        _In_ const swss::KeyOpFieldsValuesTuple &kco)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("processLinkEventDampingConfigSet: stub, returning NOT_IMPLEMENTED");
+
+    sendLinkEventDampingConfigResponse(SAI_STATUS_NOT_IMPLEMENTED);
+
+    return SAI_STATUS_NOT_IMPLEMENTED;
+}
+
+void Syncd::sendLinkEventDampingConfigResponse(
+        _In_ sai_status_t status)
+{
+    SWSS_LOG_ENTER();
+
+    std::string strStatus = sai_serialize_status(status);
+
+    SWSS_LOG_INFO("sending link event damping config response: %s", strStatus.c_str());
+
+    m_selectableChannel->set(strStatus, {}, REDIS_ASIC_STATE_COMMAND_DAMPING_CONFIG_RESPONSE);
 }
 
 sai_status_t Syncd::processFdbFlush(

--- a/syncd/Syncd.h
+++ b/syncd/Syncd.h
@@ -145,6 +145,9 @@ namespace syncd
             sai_status_t processStatsStCapabilityQuery(
                 _In_ const swss::KeyOpFieldsValuesTuple &kco);
 
+            sai_status_t processLinkEventDampingConfigSet(
+                    _In_ const swss::KeyOpFieldsValuesTuple &kco);
+
             sai_status_t processFdbFlush(
                     _In_ const swss::KeyOpFieldsValuesTuple &kco);
 
@@ -393,6 +396,9 @@ namespace syncd
                     _In_ const std::vector<sai_status_t>& statuses);
 
             void sendNotifyResponse(
+                    _In_ sai_status_t status);
+
+            void sendLinkEventDampingConfigResponse(
                     _In_ sai_status_t status);
 
         private: // snoop get response oids

--- a/syncd/tests/Makefile.am
+++ b/syncd/tests/Makefile.am
@@ -5,7 +5,7 @@ LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
 bin_PROGRAMS = tests
 
 tests_SOURCES = \
-    main.cpp TestSyncdBrcm.cpp TestSyncdMlnx.cpp TestSyncdNvdaBf.cpp TestSyncdLib.cpp TestDisabledRedisClient.cpp
+    main.cpp TestSyncdBrcm.cpp TestSyncdMlnx.cpp TestSyncdNvdaBf.cpp TestSyncdLib.cpp TestDisabledRedisClient.cpp TestSyncdLinkEventDamping.cpp
 tests_CXXFLAGS = \
     $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDADD = \

--- a/syncd/tests/TestSyncdLinkEventDamping.cpp
+++ b/syncd/tests/TestSyncdLinkEventDamping.cpp
@@ -1,0 +1,187 @@
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <swss/logger.h>
+
+#include "Sai.h"
+#include "Syncd.h"
+#include "MetadataLogger.h"
+
+#include "TestSyncdLib.h"
+
+using namespace syncd;
+
+static const char* profile_get_value(
+    _In_ sai_switch_profile_id_t profile_id,
+    _In_ const char* variable)
+{
+    SWSS_LOG_ENTER();
+
+    return NULL;
+}
+
+static int profile_get_next_value(
+    _In_ sai_switch_profile_id_t profile_id,
+    _Out_ const char** variable,
+    _Out_ const char** value)
+{
+    SWSS_LOG_ENTER();
+
+    if (value == NULL)
+    {
+        SWSS_LOG_INFO("resetting profile map iterator");
+        return 0;
+    }
+
+    if (variable == NULL)
+    {
+        SWSS_LOG_WARN("variable is null");
+        return -1;
+    }
+
+    SWSS_LOG_INFO("iterator reached end");
+    return -1;
+}
+
+static sai_service_method_table_t test_services = {
+    profile_get_value,
+    profile_get_next_value
+};
+
+void syncdLinkEventDampingWorkerThread()
+{
+    SWSS_LOG_ENTER();
+
+    swss::Logger::getInstance().setMinPrio(swss::Logger::SWSS_NOTICE);
+    MetadataLogger::initialize();
+
+    auto vendorSai = std::make_shared<VendorSai>();
+    auto commandLineOptions = std::make_shared<CommandLineOptions>();
+    auto isWarmStart = false;
+
+    commandLineOptions->m_enableSyncMode = true;
+    commandLineOptions->m_enableTempView = true;
+    commandLineOptions->m_disableExitSleep = true;
+    commandLineOptions->m_enableUnittests = false;
+    commandLineOptions->m_enableSaiBulkSupport = true;
+    commandLineOptions->m_startType = SAI_START_TYPE_COLD_BOOT;
+    commandLineOptions->m_redisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+    commandLineOptions->m_profileMapFile = "./brcm/testprofile.ini";
+
+    auto syncd = std::make_shared<Syncd>(vendorSai, commandLineOptions, isWarmStart);
+    syncd->run();
+
+    SWSS_LOG_NOTICE("Started syncd link event damping worker");
+}
+
+class SyncdLinkEventDampingTest : public ::testing::Test
+{
+public:
+    SyncdLinkEventDampingTest() = default;
+    virtual ~SyncdLinkEventDampingTest() = default;
+
+public:
+    virtual void SetUp() override
+    {
+        SWSS_LOG_ENTER();
+
+        flushAsicDb();
+
+        m_worker = std::make_shared<std::thread>(syncdLinkEventDampingWorkerThread);
+
+        m_sairedis = std::make_shared<sairedis::Sai>();
+
+        auto status = m_sairedis->apiInitialize(0, &test_services);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+        sai_attribute_t attr;
+
+        attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
+        attr.value.s32 = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+
+        status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+        attr.id = SAI_REDIS_SWITCH_ATTR_RECORD;
+        attr.value.booldata = true;
+
+        status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+    }
+
+    virtual void TearDown() override
+    {
+        SWSS_LOG_ENTER();
+
+        auto status = m_sairedis->apiUninitialize();
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+        sendSyncdShutdownNotification();
+        m_worker->join();
+    }
+
+protected:
+    std::shared_ptr<std::thread> m_worker;
+    std::shared_ptr<sairedis::Sai> m_sairedis;
+};
+
+TEST_F(SyncdLinkEventDampingTest, SetLinkEventDampingAlgorithm)
+{
+    sai_attribute_t attr;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD;
+    attr.value.s32 = SAI_REDIS_NOTIFY_SYNCD_INIT_VIEW;
+
+    auto status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+    ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+    sai_object_id_t switchId;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    status = m_sairedis->create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, &attr);
+    ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+    attr.id = SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM;
+    attr.value.s32 = SAI_REDIS_LINK_EVENT_DAMPING_ALGORITHM_AIED;
+
+    status = m_sairedis->set(SAI_OBJECT_TYPE_PORT, SAI_NULL_OBJECT_ID, &attr);
+    EXPECT_EQ(status, SAI_STATUS_NOT_IMPLEMENTED);
+}
+
+TEST_F(SyncdLinkEventDampingTest, SetLinkEventDampingAiedConfig)
+{
+    sai_attribute_t attr;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD;
+    attr.value.s32 = SAI_REDIS_NOTIFY_SYNCD_INIT_VIEW;
+
+    auto status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, &attr);
+    ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+    sai_object_id_t switchId;
+
+    attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attr.value.booldata = true;
+
+    status = m_sairedis->create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, &attr);
+    ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+    sai_redis_link_event_damping_algo_aied_config_t config = {};
+    config.max_suppress_time = 30000;
+    config.suppress_threshold = 3000;
+    config.reuse_threshold = 750;
+    config.decay_half_life = 5000;
+    config.flap_penalty = 1000;
+
+    attr.id = SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGO_AIED_CONFIG;
+    attr.value.ptr = &config;
+
+    status = m_sairedis->set(SAI_OBJECT_TYPE_PORT, SAI_NULL_OBJECT_ID, &attr);
+    EXPECT_EQ(status, SAI_STATUS_NOT_IMPLEMENTED);
+}

--- a/unittest/lib/TestClientServerSai.cpp
+++ b/unittest/lib/TestClientServerSai.cpp
@@ -264,6 +264,45 @@ TEST(ClientServerSai, bulk_ ## OT)                                              
 SAIREDIS_DECLARE_EVERY_BULK_ENTRY(TEST_BULK_ENTRY)
 
 
+TEST(ClientServerSai, VerifySaiRedisPortAttrNotSupportedInClientMode)
+{
+    auto css = std::make_shared<ClientServerSai>();
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, css->apiInitialize(0, &test_client_services));
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM;
+    attr.value.s32 = SAI_REDIS_LINK_EVENT_DAMPING_ALGORITHM_AIED;
+
+    EXPECT_EQ(SAI_STATUS_FAILURE, css->set(SAI_OBJECT_TYPE_PORT, SAI_NULL_OBJECT_ID, &attr));
+}
+
+TEST(ClientServerSai, SetLinkEventDampingConfigNullPtr)
+{
+    auto css = std::make_shared<ClientServerSai>();
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, css->apiInitialize(0, &test_services));
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGO_AIED_CONFIG;
+    attr.value.ptr = nullptr;
+
+    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, css->set(SAI_OBJECT_TYPE_PORT, SAI_NULL_OBJECT_ID, &attr));
+}
+
+TEST(ClientServerSai, SetInvalidSaiRedisPortAttribute)
+{
+    auto css = std::make_shared<ClientServerSai>();
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS, css->apiInitialize(0, &test_services));
+
+    sai_attribute_t attr;
+    attr.id = SAI_PORT_ATTR_CUSTOM_RANGE_START + 99;
+    attr.value.s32 = 0;
+
+    EXPECT_EQ(SAI_STATUS_INVALID_PARAMETER, css->set(SAI_OBJECT_TYPE_PORT, SAI_NULL_OBJECT_ID, &attr));
+}
+
 TEST(ClientServerSai, bulkGet)
 {
     ClientServerSai sai;


### PR DESCRIPTION
## Summary

Supersedes #1331, originally authored by @Ashish1805. The original PR has been inactive for ~2 years and has merge conflicts against current master.

This PR adds the Redis communication layer for link event damping configuration:

**lib/ (orchagent -> Redis):**
- `sairediscommon.h`: New command strings `link_event_damping_config_set` / `link_event_damping_config_response`
- `RedisRemoteSaiInterface`: New `isRedisPortAttribute()` (port analog to `isRedisAttribute()`), `setRedisPortExtensionAttribute()` dispatch, and `setLinkEventDampingConfig()` which is **always synchronous** (per @kcudnik review)
- `ClientSai::set()`: Blocks port extension attrs in CLIENT mode
- `Sai::set()`: Routes port extension attrs directly, bypassing metadata validation

**syncd/ (Redis -> syncd handler):**
- `Syncd`: Dispatches `link_event_damping_config_set` to `processLinkEventDampingConfigSet()` stub
- `sendLinkEventDampingConfigResponse()` **always** sends a response (no `m_enableSyncMode` guard), since the lib always waits

## Fixes from @kcudnik's review of #1331

1. **Always synchronous**: `setLinkEventDampingConfig` unconditionally calls `m_communicationChannel->wait()`. The original code skipped the wait in async mode, which @kcudnik said was wrong: *"make this api always synchronous, async mode is just for create/remove/set operations all other apis should be synchronous."*

2. **Simplified `isRedisPortAttribute`**: Single boolean expression using reversed condition, per @kcudnik: *"you can turn this to 1 single line by reversing condition."*

3. **Syncd always sends response**: `sendLinkEventDampingConfigResponse` omits the `m_enableSyncMode` guard, since the lib side always waits unconditionally.

## Relation to other PRs

This is part of the [Link Event Damping](https://github.com/sonic-net/SONiC/pull/1071) feature:
- #1798 (SelectablesTracker) -- **merged**
- **This PR** -- Redis plumbing (stub syncd handler)
- #1334 supersede -- will fill in `processLinkEventDampingConfigSet` with actual damping algorithm (next)

## Test plan
- [x] 3 new unit tests in `unittest/lib/TestClientServerSai.cpp` (client mode rejection, null pointer rejection, invalid attribute rejection)
- [x] 2 new integration tests in `syncd/tests/TestSyncdLinkEventDamping.cpp` (full lib->Redis->syncd round trip for algorithm and AIED config, asserting `NOT_IMPLEMENTED` response from stub)
- [x] Existing tests unaffected -- normal port set operations (speed, MTU, admin state) have attr IDs far below `SAI_PORT_ATTR_CUSTOM_RANGE_START` (0x10000000)

Credits: Original implementation by @Ashish1805 (PR #1331).