### PR TITLE
PR  1/2 - SaiVppSflow skeleton in phase one

### DIFF
--- a/vslib/Makefile.am
+++ b/vslib/Makefile.am
@@ -88,6 +88,7 @@ libSaiVS_a_SOURCES +=\
 					  vpp/SwitchVppRoute.cpp \
 					  vpp/SwitchVppNbr.cpp \
 					  vpp/SwitchVppSRv6.cpp \
+					  vpp/SwitchVppSflow.cpp \
 					  vpp/TunnelManager.cpp \
 					  vpp/SaiVppLog.cpp \
 					  vpp/vppxlate/SaiVppXlate.c \

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1431,6 +1431,13 @@ sai_status_t SwitchVpp::create(
         return sflow_hostif_trap_samplepacket_create(object_id, switch_id, attr_count, attr_list);
     }
 
+    if(object_type == SAI_OBJECT_TYPE_HOSTIF_TABLE_ENTRY)
+    {
+        sai_object_id_t object_id;
+        sai_deserialize_object_id(serializedObjectId, object_id);
+        return sflow_hostif_table_entry_create(object_id, switch_id, attr_count, attr_list);
+    }
+
     if (object_type == SAI_OBJECT_TYPE_MACSEC_PORT)
     {
         sai_object_id_t object_id;
@@ -1780,6 +1787,11 @@ sai_status_t SwitchVpp::remove(
     if(object_type == SAI_OBJECT_TYPE_HOSTIF_TRAP)
     {
         return sflow_hostif_trap_samplepacket_remove(serializedObjectId);
+    }
+
+    if(object_type == SAI_OBJECT_TYPE_HOSTIF_TABLE_ENTRY)
+    {
+        return sflow_hostif_table_entry_remove(serializedObjectId);
     }
 
     if (object_type == SAI_OBJECT_TYPE_ACL_ENTRY)

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1906,6 +1906,45 @@ sai_status_t SwitchVpp::setPort(
 
     UpdatePort(portId, 1, attr);
 
+    if (attr->id == SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE)
+    {
+        sai_object_id_t sp_oid = attr->value.oid;
+
+        if(sp_oid == SAI_NULL_OBJECT_ID)
+        {
+            m_sflow_port_to_samplepacket.erase(portId);
+            sflow_enable_disable(portId, false);
+        }
+        else 
+        {
+            sai_attribute_t rate_attr;
+            rate_attr.id = SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE;
+            uint32_t rate = 0;
+
+            auto serialized_id = sai_serialize_object_id(sp_oid);
+
+            if(get(SAI_OBJECT_TYPE_SAMPLEPACKET, serialized_id, 1, &rate_attr) == SAI_STATUS_SUCCESS)
+            {
+                rate = rate_attr.value.u32;
+            }
+
+            if(m_sflow_sample_rate != 0 && m_sflow_sample_rate != rate)
+            {
+                SWSS_LOG_WARN("sFlow sample rate mismatch: global=%u port %s requesting=%u (last-writer-wins)",
+                    m_sflow_sample_rate,
+                    sai_serialize_object_id(portId).c_str(),
+                    rate);
+            }
+
+            m_sflow_port_to_samplepacket[portId] = sp_oid;
+            m_sflow_sample_rate = rate;
+
+            sflow_enable_disable(portId, true);
+            sflow_sampling_rate_set(rate);
+        }
+
+    }
+
     auto sid = sai_serialize_object_id(portId);
 
     return set_internal(SAI_OBJECT_TYPE_PORT, sid, attr);

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1424,6 +1424,13 @@ sai_status_t SwitchVpp::create(
         return samplePacketCreate(object_id, switch_id, attr_count, attr_list);
     }
 
+    if(object_type == SAI_OBJECT_TYPE_HOSTIF_TRAP)
+    {
+        sai_object_id_t object_id;
+        sai_deserialize_object_id(serializedObjectId, object_id);
+        return sflow_hostif_trap_samplepacket_create(object_id, switch_id, attr_count, attr_list);
+    }
+
     if (object_type == SAI_OBJECT_TYPE_MACSEC_PORT)
     {
         sai_object_id_t object_id;
@@ -1768,6 +1775,11 @@ sai_status_t SwitchVpp::remove(
     if (object_type == SAI_OBJECT_TYPE_SAMPLEPACKET)
     {
         return samplePacketRemove(serializedObjectId);
+    }
+
+    if(object_type == SAI_OBJECT_TYPE_HOSTIF_TRAP)
+    {
+        return sflow_hostif_trap_samplepacket_remove(serializedObjectId);
     }
 
     if (object_type == SAI_OBJECT_TYPE_ACL_ENTRY)

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1417,6 +1417,13 @@ sai_status_t SwitchVpp::create(
         return createAclGrpMbr(object_id, switch_id, attr_count, attr_list);
     }
 
+    if(object_type == SAI_OBJECT_TYPE_SAMPLEPACKET)
+    {
+        sai_object_id_t object_id;
+        sai_deserialize_object_id(serializedObjectId, object_id);
+        return samplePacketCreate(object_id, switch_id, attr_count, attr_list);
+    }
+
     if (object_type == SAI_OBJECT_TYPE_MACSEC_PORT)
     {
         sai_object_id_t object_id;
@@ -1758,6 +1765,11 @@ sai_status_t SwitchVpp::remove(
         return status;
     }
 
+    if (object_type == SAI_OBJECT_TYPE_SAMPLEPACKET)
+    {
+        return samplePacketRemove(serializedObjectId);
+    }
+
     if (object_type == SAI_OBJECT_TYPE_ACL_ENTRY)
     {
         return removeAclEntry(serializedObjectId);
@@ -2036,6 +2048,13 @@ sai_status_t SwitchVpp::set(
         sai_object_id_t objectId;
         sai_deserialize_object_id(serializedObjectId, objectId);
         return setMACsecSA(objectId, attr);
+    }
+
+    if(objectType == SAI_OBJECT_TYPE_SAMPLEPACKET)
+    {
+        sai_object_id_t objectId;
+        sai_deserialize_object_id(serializedObjectId, objectId);
+        return samplePacketSet(objectId,attr);
     }
 
     if (objectType == SAI_OBJECT_TYPE_LAG)

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1428,14 +1428,14 @@ sai_status_t SwitchVpp::create(
     {
         sai_object_id_t object_id;
         sai_deserialize_object_id(serializedObjectId, object_id);
-        return sflow_hostif_trap_samplepacket_create(object_id, switch_id, attr_count, attr_list);
+        return sflowHostifTrapSamplePacketCreate(object_id, switch_id, attr_count, attr_list);
     }
 
     if(object_type == SAI_OBJECT_TYPE_HOSTIF_TABLE_ENTRY)
     {
         sai_object_id_t object_id;
         sai_deserialize_object_id(serializedObjectId, object_id);
-        return sflow_hostif_table_entry_create(object_id, switch_id, attr_count, attr_list);
+        return sflowHostifTableEntryCreate(object_id, switch_id, attr_count, attr_list);
     }
 
     if (object_type == SAI_OBJECT_TYPE_MACSEC_PORT)
@@ -1786,12 +1786,12 @@ sai_status_t SwitchVpp::remove(
 
     if(object_type == SAI_OBJECT_TYPE_HOSTIF_TRAP)
     {
-        return sflow_hostif_trap_samplepacket_remove(serializedObjectId);
+        return sflowHostifTrapSamplePacketRemove(serializedObjectId);
     }
 
     if(object_type == SAI_OBJECT_TYPE_HOSTIF_TABLE_ENTRY)
     {
-        return sflow_hostif_table_entry_remove(serializedObjectId);
+        return sflowHostifTableEntryRemove(serializedObjectId);
     }
 
     if (object_type == SAI_OBJECT_TYPE_ACL_ENTRY)
@@ -1929,44 +1929,10 @@ sai_status_t SwitchVpp::setPort(
     SWSS_LOG_ENTER();
 
     UpdatePort(portId, 1, attr);
-
+       
     if (attr->id == SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE)
     {
-        sai_object_id_t sp_oid = attr->value.oid;
-
-        if(sp_oid == SAI_NULL_OBJECT_ID)
-        {
-            m_sflow_port_to_samplepacket.erase(portId);
-            sflow_enable_disable(portId, false);
-        }
-        else 
-        {
-            sai_attribute_t rate_attr;
-            rate_attr.id = SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE;
-            uint32_t rate = 0;
-
-            auto serialized_id = sai_serialize_object_id(sp_oid);
-
-            if(get(SAI_OBJECT_TYPE_SAMPLEPACKET, serialized_id, 1, &rate_attr) == SAI_STATUS_SUCCESS)
-            {
-                rate = rate_attr.value.u32;
-            }
-
-            if(m_sflow_sample_rate != 0 && m_sflow_sample_rate != rate)
-            {
-                SWSS_LOG_WARN("sFlow sample rate mismatch: global=%u port %s requesting=%u (last-writer-wins)",
-                    m_sflow_sample_rate,
-                    sai_serialize_object_id(portId).c_str(),
-                    rate);
-            }
-
-            m_sflow_port_to_samplepacket[portId] = sp_oid;
-            m_sflow_sample_rate = rate;
-
-            sflow_enable_disable(portId, true);
-            sflow_sampling_rate_set(rate);
-        }
-
+        sflowPortSamplePacketSet(portId, attr);
     }
 
     auto sid = sai_serialize_object_id(portId);

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1928,7 +1928,7 @@ sai_status_t SwitchVpp::setPort(
 {
     SWSS_LOG_ENTER();
 
-    UpdatePort(portId, 1, attr); 
+    UpdatePort(portId, 1, attr);
 
     auto sid = sai_serialize_object_id(portId);
 

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1928,12 +1928,7 @@ sai_status_t SwitchVpp::setPort(
 {
     SWSS_LOG_ENTER();
 
-    UpdatePort(portId, 1, attr);
-       
-    if (attr->id == SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE)
-    {
-        sflowPortSamplePacketSet(portId, attr);
-    }
+    UpdatePort(portId, 1, attr); 
 
     auto sid = sai_serialize_object_id(portId);
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1043,7 +1043,7 @@ namespace saivs
                     _In_ sai_object_id_t ace_cntr_oid,
                     _In_ uint32_t attr_count,
                     _Out_ sai_attribute_t *attr_list);
-        
+
             sai_status_t samplePacketCreate(
                     _In_ sai_object_id_t object_id,
                     _In_ sai_object_id_t switch_id,
@@ -1073,7 +1073,7 @@ namespace saivs
             sai_status_t sflowPortSamplePacketSet(
                     _In_ sai_object_id_t portId,
                     _In_ const sai_attribute_t *attr);
-        
+
             sai_status_t sflowHostifTrapSamplePacketRemove(
                      _In_ const std::string &serializedObjectId);
 
@@ -1085,8 +1085,8 @@ namespace saivs
 
              sai_status_t sflowHostifTableEntryRemove(
                      _In_ const std::string &serializedObjectId);
-            
-                
+
+
         public: // VPP
 
             sai_status_t aclGetVppIndices(

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1057,29 +1057,33 @@ namespace saivs
                     _In_ sai_object_id_t entry_id,
                     _In_ const sai_attribute_t *attr);
 
-            sai_status_t sflow_enable_disable(
+            sai_status_t sflowEnableDisable(
                     _In_ sai_object_id_t port_id,
                     _In_ bool enable);
 
-            sai_status_t sflow_sampling_rate_set(
+            sai_status_t sflowSamplingRateSet(
                     _In_ uint32_t rate);
 
-            sai_status_t sflow_hostif_trap_samplepacket_create(
+            sai_status_t sflowHostifTrapSamplePacketCreate(
                      _In_ sai_object_id_t object_id,
                      _In_ sai_object_id_t switch_id,
                      _In_ uint32_t attr_count,
                      _In_ const sai_attribute_t *attr_list);
+
+            sai_status_t sflowPortSamplePacketSet(
+                    _In_ sai_object_id_t portId,
+                    _In_ const sai_attribute_t *attr);
         
-            sai_status_t sflow_hostif_trap_samplepacket_remove(
+            sai_status_t sflowHostifTrapSamplePacketRemove(
                      _In_ const std::string &serializedObjectId);
 
-            sai_status_t sflow_hostif_table_entry_create(
+            sai_status_t sflowHostifTableEntryCreate(
                      _In_ sai_object_id_t object_id,
                      _In_ sai_object_id_t switch_id,
                      _In_ uint32_t attr_count,
                      _In_ const sai_attribute_t *attr_list);
 
-             sai_status_t sflow_hostif_table_entry_remove(
+             sai_status_t sflowHostifTableEntryRemove(
                      _In_ const std::string &serializedObjectId);
             
                 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1063,6 +1063,16 @@ namespace saivs
 
             sai_status_t sflow_sampling_rate_set(
                     _In_ uint32_t rate);
+
+            sai_status_t sflow_hostif_trap_samplepacket_create(
+                     _In_ sai_object_id_t object_id,
+                     _In_ sai_object_id_t switch_id,
+                     _In_ uint32_t attr_count,
+                     _In_ const sai_attribute_t *attr_list);
+        
+            sai_status_t sflow_hostif_trap_samplepacket_remove(
+                     _In_ const std::string &serializedObjectId);
+            
                 
         public: // VPP
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1054,6 +1054,13 @@ namespace saivs
             sai_status_t samplePacketSet(
                     _In_ sai_object_id_t entry_id,
                     _In_ const sai_attribute_t *attr);
+
+            sai_status_t sflow_enable_disable(
+                    _In_ sai_object_id_t port_id,
+                    _In_ bool enable);
+
+            sai_status_t sflow_sampling_rate_set(
+                    _In_ uint32_t rate);
                 
         public: // VPP
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -793,9 +793,11 @@ namespace saivs
             std::chrono::steady_clock::time_point m_routeStatsCacheTime;
             bool m_routeStatsCacheValid = false;
             std::mutex m_routeStatsCacheMutex;
+            std::map<sai_object_id_t, sai_object_id_t> m_sflow_port_to_samplepacket;
 
             uint32_t m_acl_default_swindex = 0;
             bool m_acl_default_created = false;
+            uint32_t m_sflow_sample_rate = 0;
 
         protected: // VPP
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1072,6 +1072,15 @@ namespace saivs
         
             sai_status_t sflow_hostif_trap_samplepacket_remove(
                      _In_ const std::string &serializedObjectId);
+
+            sai_status_t sflow_hostif_table_entry_create(
+                     _In_ sai_object_id_t object_id,
+                     _In_ sai_object_id_t switch_id,
+                     _In_ uint32_t attr_count,
+                     _In_ const sai_attribute_t *attr_list);
+
+             sai_status_t sflow_hostif_table_entry_remove(
+                     _In_ const std::string &serializedObjectId);
             
                 
         public: // VPP

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1041,7 +1041,20 @@ namespace saivs
                     _In_ sai_object_id_t ace_cntr_oid,
                     _In_ uint32_t attr_count,
                     _Out_ sai_attribute_t *attr_list);
+        
+            sai_status_t samplePacketCreate(
+                    _In_ sai_object_id_t object_id,
+                    _In_ sai_object_id_t switch_id,
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list);
 
+            sai_status_t samplePacketRemove(
+                    _In_ const std::string &serializedObjectId);
+
+            sai_status_t samplePacketSet(
+                    _In_ sai_object_id_t entry_id,
+                    _In_ const sai_attribute_t *attr);
+                
         public: // VPP
 
             sai_status_t aclGetVppIndices(

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -593,6 +593,13 @@ sai_status_t SwitchVpp::UpdatePort(
         }
     }
 
+    attr_type = sai_metadata_get_attr_by_id(SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE, attr_count, attr_list);
+
+    if (attr_type != NULL)
+    {
+        sflowPortSamplePacketSet(object_id, attr_type);
+    }
+
     attr_type = sai_metadata_get_attr_by_id(SAI_PORT_ATTR_EGRESS_ACL, attr_count, attr_list);
 
     if (attr_type != NULL)

--- a/vslib/vpp/SwitchVppSflow.cpp
+++ b/vslib/vpp/SwitchVppSflow.cpp
@@ -53,7 +53,7 @@ sai_status_t SwitchVpp::samplePacketSet(
     return status;
 }
 
-sai_status_t SwitchVpp::sflow_enable_disable(
+sai_status_t SwitchVpp::sflowEnableDisable(
     _In_ sai_object_id_t port_id,
     _In_ bool enable)
 {
@@ -80,7 +80,7 @@ sai_status_t SwitchVpp::sflow_enable_disable(
 
 }
 
-sai_status_t SwitchVpp::sflow_sampling_rate_set(
+sai_status_t SwitchVpp::sflowSamplingRateSet(
     _In_ uint32_t rate)
 {
     SWSS_LOG_ENTER();
@@ -96,7 +96,7 @@ sai_status_t SwitchVpp::sflow_sampling_rate_set(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t SwitchVpp::sflow_hostif_trap_samplepacket_create(
+sai_status_t SwitchVpp::sflowHostifTrapSamplePacketCreate(
     _In_ sai_object_id_t object_id,
     _In_ sai_object_id_t switch_id,
     _In_ uint32_t attr_count,
@@ -106,21 +106,12 @@ sai_status_t SwitchVpp::sflow_hostif_trap_samplepacket_create(
 
     auto sid = sai_serialize_object_id(object_id);
 
-    const sai_attribute_value_t *trap_type_attr = nullptr;
-    uint32_t attr_index = 0;
+    SaiCachedObject trap_obj(this, SAI_OBJECT_TYPE_HOSTIF_TRAP, sid, attr_count, attr_list);
+    sai_attribute_t attr;
+    attr.id = SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE;
+    CHECK_STATUS_QUIET(trap_obj.get_mandatory_attr(attr));
 
-    sai_status_t status = find_attrib_in_list(
-            attr_count, attr_list,
-            SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE,
-            &trap_type_attr, &attr_index);
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("HOSTIF_TRAP %s missing mandatory TRAP_TYPE attribute", sid.c_str());
-        return SAI_STATUS_MANDATORY_ATTRIBUTE_MISSING;
-    }
-
-    if (trap_type_attr->s32 == SAI_HOSTIF_TRAP_TYPE_SAMPLEPACKET)
+    if (attr.value.s32 == SAI_HOSTIF_TRAP_TYPE_SAMPLEPACKET)
     {
         SWSS_LOG_NOTICE("HOSTIF_TRAP %s SAMPLEPACKET created (bookkeeping)", sid.c_str());
     }
@@ -131,7 +122,7 @@ sai_status_t SwitchVpp::sflow_hostif_trap_samplepacket_create(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t SwitchVpp::sflow_hostif_trap_samplepacket_remove(
+sai_status_t SwitchVpp::sflowHostifTrapSamplePacketRemove(
     _In_ const std::string &serializedObjectId)
 {
     SWSS_LOG_ENTER();
@@ -144,7 +135,7 @@ sai_status_t SwitchVpp::sflow_hostif_trap_samplepacket_remove(
 
 }
 
-sai_status_t SwitchVpp::sflow_hostif_table_entry_create(
+sai_status_t SwitchVpp::sflowHostifTableEntryCreate(
     _In_ sai_object_id_t object_id,
     _In_ sai_object_id_t switch_id,
     _In_ uint32_t attr_count,
@@ -161,7 +152,7 @@ sai_status_t SwitchVpp::sflow_hostif_table_entry_create(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t SwitchVpp::sflow_hostif_table_entry_remove(
+sai_status_t SwitchVpp::sflowHostifTableEntryRemove(
     _In_ const std::string &serializedObjectId)
 {
     SWSS_LOG_ENTER();
@@ -171,4 +162,42 @@ sai_status_t SwitchVpp::sflow_hostif_table_entry_remove(
     SWSS_LOG_NOTICE("HOSTIF_TABLE_ENTRY %s removed", serializedObjectId.c_str());
 
     return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::sflowPortSamplePacketSet(
+    _In_ sai_object_id_t portId,
+    _In_ const sai_attribute_t *attr)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t sp_oid = attr->value.oid;
+
+    if(sp_oid == SAI_NULL_OBJECT_ID)
+    {
+        return sflowEnableDisable(portId, false);
+    }
+
+    sai_attribute_t rate_attr;
+    rate_attr.id = SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE;
+    uint32_t rate = 0;
+
+    auto serialized_id = sai_serialize_object_id(sp_oid);
+
+    if (get(SAI_OBJECT_TYPE_SAMPLEPACKET, serialized_id, 1, &rate_attr) == SAI_STATUS_SUCCESS)
+    {
+        rate = rate_attr.value.u32;
+    }
+
+    if (m_sflow_sample_rate != 0 && m_sflow_sample_rate != rate)
+    {
+        SWSS_LOG_WARN("sFlow sample rate mismatch: global=%u port %s requesting=%u (last-writer-wins)",
+            m_sflow_sample_rate,
+            sai_serialize_object_id(portId).c_str(),
+            rate);
+    }
+
+    m_sflow_sample_rate = rate;
+
+    CHECK_STATUS(sflowEnableDisable(portId, true));
+    return sflowSamplingRateSet(rate);
 }

--- a/vslib/vpp/SwitchVppSflow.cpp
+++ b/vslib/vpp/SwitchVppSflow.cpp
@@ -1,7 +1,10 @@
 #include "SwitchVppSflow.h"
 #include "SwitchVpp.h"
+
+
 #include "meta/sai_serialize.h"
 #include "swss/logger.h"
+#include "vppxlate/SaiVppXlate.h"
 
 using namespace saivs;
 
@@ -63,7 +66,12 @@ sai_status_t SwitchVpp::sflow_enable_disable(
         return SAI_STATUS_FAILURE;
     }
 
-    // TODO: Call VPP enable_disable API 
+    int ret = vpp_sflow_enable_disable(if_name.c_str(), enable);
+    if(ret != 0){
+        SWSS_LOG_ERROR("sflow enable_disable failed for port %s, status %d",
+                   sai_serialize_object_id(port_id).c_str(), ret);
+        return SAI_STATUS_FAILURE;
+    }
 
     SWSS_LOG_NOTICE("Changed port %s to %d",sai_serialize_object_id(port_id).c_str(), enable);
 
@@ -76,7 +84,11 @@ sai_status_t SwitchVpp::sflow_sampling_rate_set(
 {
     SWSS_LOG_ENTER();
 
-    // TODO: Call VPP sampling rate API
+    int ret = vpp_sflow_sampling_rate_set(rate);
+    if (ret != 0 ){
+        SWSS_LOG_ERROR("sflow sampling_rate_set failed, status %d", ret);
+        return SAI_STATUS_FAILURE;
+    }
 
     SWSS_LOG_NOTICE("New rate set of 1 in %d packets", rate);
 

--- a/vslib/vpp/SwitchVppSflow.cpp
+++ b/vslib/vpp/SwitchVppSflow.cpp
@@ -1,5 +1,6 @@
 #include "SwitchVppSflow.h"
 #include "SwitchVpp.h"
+#include "SwitchVppUtils.h"
 
 
 #include "meta/sai_serialize.h"
@@ -93,4 +94,52 @@ sai_status_t SwitchVpp::sflow_sampling_rate_set(
     SWSS_LOG_NOTICE("New rate set of 1 in %d packets", rate);
 
     return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::sflow_hostif_trap_samplepacket_create(
+    _In_ sai_object_id_t object_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto sid = sai_serialize_object_id(object_id);
+
+    const sai_attribute_value_t *trap_type_attr = nullptr;
+    uint32_t attr_index = 0;
+
+    sai_status_t status = find_attrib_in_list(
+            attr_count, attr_list,
+            SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE,
+            &trap_type_attr, &attr_index);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("HOSTIF_TRAP %s missing mandatory TRAP_TYPE attribute", sid.c_str());
+        return SAI_STATUS_MANDATORY_ATTRIBUTE_MISSING;
+    }
+
+    if (trap_type_attr->s32 == SAI_HOSTIF_TRAP_TYPE_SAMPLEPACKET)
+    {
+        SWSS_LOG_NOTICE("HOSTIF_TRAP %s SAMPLEPACKET created (bookkeeping)", sid.c_str());
+    }
+
+    // Bookkeeping, store the trap object in the generic object hash
+    CHECK_STATUS(create_internal(SAI_OBJECT_TYPE_HOSTIF_TRAP, sid, switch_id, attr_count, attr_list));
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::sflow_hostif_trap_samplepacket_remove(
+    _In_ const std::string &serializedObjectId)
+{
+    SWSS_LOG_ENTER();
+
+    CHECK_STATUS(remove_internal(SAI_OBJECT_TYPE_HOSTIF_TRAP, serializedObjectId));
+
+    SWSS_LOG_NOTICE("HOSTIF_TRAP %s removed", serializedObjectId.c_str());
+
+    return SAI_STATUS_SUCCESS;
+
 }

--- a/vslib/vpp/SwitchVppSflow.cpp
+++ b/vslib/vpp/SwitchVppSflow.cpp
@@ -1,0 +1,50 @@
+#include "SwitchVppSflow.h"
+#include "SwitchVpp.h"
+#include "meta/sai_serialize.h"
+#include "swss/logger.h"
+
+using namespace saivs;
+
+sai_status_t SwitchVpp::samplePacketCreate(
+    _In_ sai_object_id_t object_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto sid = sai_serialize_object_id(object_id);
+
+    CHECK_STATUS(create_internal(SAI_OBJECT_TYPE_SAMPLEPACKET, sid, switch_id, attr_count, attr_list));
+
+    SWSS_LOG_NOTICE("Sample packet %s created", sid.c_str());
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::samplePacketRemove(
+    _In_ const std::string &serializedObjectId)
+{
+    SWSS_LOG_ENTER();
+
+    CHECK_STATUS(remove_internal(SAI_OBJECT_TYPE_SAMPLEPACKET, serializedObjectId));
+
+    SWSS_LOG_NOTICE("Sample packet %s removed", serializedObjectId.c_str());
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::samplePacketSet(
+    _In_ sai_object_id_t entry_id,
+    _In_ const sai_attribute_t *attr)
+{
+    SWSS_LOG_ENTER();
+
+    auto sid = sai_serialize_object_id(entry_id);
+
+    sai_status_t status = set_internal(SAI_OBJECT_TYPE_SAMPLEPACKET, sid, attr);
+
+    SWSS_LOG_NOTICE("Set sample packet %s status %d", sid.c_str(), status);
+
+    return status;
+}

--- a/vslib/vpp/SwitchVppSflow.cpp
+++ b/vslib/vpp/SwitchVppSflow.cpp
@@ -143,3 +143,32 @@ sai_status_t SwitchVpp::sflow_hostif_trap_samplepacket_remove(
     return SAI_STATUS_SUCCESS;
 
 }
+
+sai_status_t SwitchVpp::sflow_hostif_table_entry_create(
+    _In_ sai_object_id_t object_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    auto sid = sai_serialize_object_id(object_id);
+
+    CHECK_STATUS(create_internal(SAI_OBJECT_TYPE_HOSTIF_TABLE_ENTRY, sid, switch_id, attr_count,attr_list));
+
+    SWSS_LOG_NOTICE("HOSTIF_TABLE_ENTRY %s created (bookkeeping)", sid.c_str());
+    
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::sflow_hostif_table_entry_remove(
+    _In_ const std::string &serializedObjectId)
+{
+    SWSS_LOG_ENTER();
+
+    CHECK_STATUS(remove_internal(SAI_OBJECT_TYPE_HOSTIF_TABLE_ENTRY, serializedObjectId));
+
+    SWSS_LOG_NOTICE("HOSTIF_TABLE_ENTRY %s removed", serializedObjectId.c_str());
+
+    return SAI_STATUS_SUCCESS;
+}

--- a/vslib/vpp/SwitchVppSflow.cpp
+++ b/vslib/vpp/SwitchVppSflow.cpp
@@ -48,3 +48,37 @@ sai_status_t SwitchVpp::samplePacketSet(
 
     return status;
 }
+
+sai_status_t SwitchVpp::sflow_enable_disable(
+    _In_ sai_object_id_t port_id,
+    _In_ bool enable)
+{
+    SWSS_LOG_ENTER();
+
+    std::string if_name;
+
+    if(!port_to_hwifname(port_id, if_name))
+    {
+        SWSS_LOG_ERROR("failed to get hwif name for port %s", sai_serialize_object_id(port_id).c_str());
+        return SAI_STATUS_FAILURE;
+    }
+
+    // TODO: Call VPP enable_disable API 
+
+    SWSS_LOG_NOTICE("Changed port %s to %d",sai_serialize_object_id(port_id).c_str(), enable);
+
+    return SAI_STATUS_SUCCESS;
+
+}
+
+sai_status_t SwitchVpp::sflow_sampling_rate_set(
+    _In_ uint32_t rate)
+{
+    SWSS_LOG_ENTER();
+
+    // TODO: Call VPP sampling rate API
+
+    SWSS_LOG_NOTICE("New rate set of 1 in %d packets", rate);
+
+    return SAI_STATUS_SUCCESS;
+}

--- a/vslib/vpp/SwitchVppSflow.cpp
+++ b/vslib/vpp/SwitchVppSflow.cpp
@@ -148,7 +148,7 @@ sai_status_t SwitchVpp::sflowHostifTableEntryCreate(
     CHECK_STATUS(create_internal(SAI_OBJECT_TYPE_HOSTIF_TABLE_ENTRY, sid, switch_id, attr_count,attr_list));
 
     SWSS_LOG_NOTICE("HOSTIF_TABLE_ENTRY %s created (bookkeeping)", sid.c_str());
-    
+
     return SAI_STATUS_SUCCESS;
 }
 

--- a/vslib/vpp/SwitchVppSflow.h
+++ b/vslib/vpp/SwitchVppSflow.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <saitypes.h>
+#include <saisamplepacket.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct sflow_samplepacket_obj_{
+    // Keep for now, persistent objects needed so may move to map
+    // std::map<sai_object_id_t, sflow_samplepacket_obj_t> m_samplepacket_objs;
+    sai_object_id_t         sample_id;
+    
+    sai_uint32_t            sample_rate;
+    sai_samplepacket_type_t type;
+    sai_samplepacket_mode_t mode;
+} sflow_samplepacket_obj_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/vslib/vpp/SwitchVppSflow.h
+++ b/vslib/vpp/SwitchVppSflow.h
@@ -8,10 +8,6 @@ extern "C" {
 #endif
 
 typedef struct sflow_samplepacket_obj_{
-    // Keep for now, persistent objects needed so may move to map
-    // std::map<sai_object_id_t, sflow_samplepacket_obj_t> m_samplepacket_objs;
-    sai_object_id_t         sample_id;
-    
     sai_uint32_t            sample_rate;
     sai_samplepacket_type_t type;
     sai_samplepacket_mode_t mode;

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -2845,7 +2845,7 @@ int vpp_sflow_enable_disable(const char *hwif_name, bool enable)
         VPP_UNLOCK();
         return -EINVAL;
     }
-    
+
     mp->enable_disable = enable;
 
     S(mp);

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -50,6 +50,9 @@
 #include <vpp_plugins/acl/acl.api_enum.h>
 #include <vpp_plugins/acl/acl.api_types.h>
 
+#include <vpp_plugins/sflow/sflow.api_enum.h>
+#include <vpp_plugins/sflow/sflow.api_types.h>
+
 #include <vpp_plugins/tunterm_acl/tunterm_acl.api_enum.h>
 #include <vpp_plugins/tunterm_acl/tunterm_acl.api_types.h>
 
@@ -242,6 +245,24 @@
 
 #define vl_api_version(n, v) static u32 acl_api_version = v;
 #include <vpp_plugins/acl/acl.api.h>
+#undef vl_api_version
+
+/* sflow API inclusion */
+
+#define vl_typedefs
+#include <vpp_plugins/sflow/sflow.api.h>
+#undef vl_typedefs
+
+#define vl_endianfun
+#include <vpp_plugins/sflow/sflow.api.h>
+#undef vl_endianfun
+
+#define vl_calcsizefun
+#include <vpp_plugins/sflow/sflow.api.h>
+#undef vl_calcsizefun
+
+#define vl_api_version(n, v) static u32 sflow_api_version = v;
+#include <vpp_plugins/sflow/sflow.api.h>
 #undef vl_api_version
 
 /* BOND API inclusion */
@@ -1420,10 +1441,13 @@ static void vpp_base_vpe_init(void)
     _(BFD_MSG_ID(WANT_BFD_EVENTS_REPLY), want_bfd_events_reply) \
     _(BFD_MSG_ID(BFD_UDP_ENABLE_MULTIHOP_REPLY), bfd_udp_enable_multihop_reply) \
     _(BFD_MSG_ID(BFD_UDP_SET_TOS_REPLY), bfd_udp_set_tos_reply) \
+    _(SFLOW_MSG_ID(SFLOW_ENABLE_DISABLE_REPLY), sflow_enable_disable_reply) \
+    _(SFLOW_MSG_ID(SFLOW_SAMPLING_RATE_SET_REPLY), sflow_sampling_rate_set_reply) \
 
 
 static u16 ip_msg_id_base, ip_nbr_msg_id_base, lcp_msg_id_base;
 static u16 acl_msg_id_base;
+static u16 sflow_msg_id_base;
 
 static void vpp_ext_vpe_init(void)
 {
@@ -1482,7 +1506,20 @@ vl_api_acl_stats_intf_counters_enable_reply_t_handler (vl_api_acl_stats_intf_cou
 }
 
 static void
-vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_t *msg)
+vl_api_acl_interface_add_del_reply_t_handler(vl_api_sflow_enable_disable_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void
+vl_api_sflow_enable_disable_reply_t_handler(vl_api_sflow_sampling_rate_set_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void vl_api_sflow_sampling_rate_set_reply_t_handler(vl_api_acl_interface_add_del_reply_t *msg)
 {
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
@@ -1493,6 +1530,9 @@ vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_
 
 #define ACL_MSG_ID(id) \
     (VL_API_##id + acl_msg_id_base)
+
+#define SFLOW_MSG_ID(id) \
+    (VL_API_##id + sflow_msg_id_base)
 
 #define TUNTERM_MSG_ID(id) \
     (VL_API_##id + tunterm_msg_id_base)
@@ -1595,6 +1635,10 @@ static void get_base_msg_id()
     msg_base_lookup_name = format (0, "tunterm_acl_%08x%c", tunterm_api_version, 0);
     tunterm_msg_id_base = vl_client_get_first_plugin_msg_id ((char *) msg_base_lookup_name);
     assert(tunterm_msg_id_base != (u16) ~0);
+
+    msg_base_lookup_name = format (0, "sflow_%08x%c", sflow_api_version, 0);
+    sflow_msg_id_base = vl_client_get_first_plugin_msg_id ((char *) msg_base_lookup_name);
+    assert(sflow_msg_id_base != (u16) ~0);
 }
 
 #define API_SOCKET_FILE "/run/vpp/api.sock"

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1561,7 +1561,6 @@ vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_
     _(SR_MSG_ID(SR_POLICY_ADD_V2_REPLY), sr_policy_add_v2_reply) \
     _(SR_MSG_ID(SR_POLICY_DEL_REPLY), sr_policy_del_reply) \
     _(SR_MSG_ID(SR_STEERING_ADD_DEL_REPLY), sr_steering_add_del_reply) \
-    _(SR_MSG_ID(SR_SET_ENCAP_SOURCE_REPLY), sr_set_encap_source_reply)
     _(SR_MSG_ID(SR_SET_ENCAP_SOURCE_REPLY), sr_set_encap_source_reply) \
     _(SFLOW_MSG_ID(SFLOW_ENABLE_DISABLE_REPLY), sflow_enable_disable_reply) \
     _(SFLOW_MSG_ID(SFLOW_SAMPLING_RATE_SET_REPLY), sflow_sampling_rate_set_reply) \

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1513,13 +1513,14 @@ vl_api_acl_interface_add_del_reply_t_handler(vl_api_sflow_enable_disable_reply_t
 }
 
 static void
-vl_api_sflow_enable_disable_reply_t_handler(vl_api_sflow_sampling_rate_set_reply_t *msg)
+vl_api_sflow_enable_disable_reply_t_handler(vl_api_sflow_enable_disable_reply_t *msg)
 {
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 }
 
-static void vl_api_sflow_sampling_rate_set_reply_t_handler(vl_api_acl_interface_add_del_reply_t *msg)
+static void
+vl_api_sflow_sampling_rate_set_reply_t_handler(vl_api_sflow_sampling_rate_set_reply_t *msg)
 {
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
@@ -2816,6 +2817,73 @@ int vpp_acl_interface_unbind (const char *hwif_name, uint32_t acl_index,
                               bool is_input)
 {
     return __vpp_acl_interface_bind_unbind(hwif_name, acl_index, is_input, false);
+}
+
+int vpp_sflow_enable_disable(const char *hwif_name, bool enable)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_sflow_enable_disable_t *mp;
+    int ret;
+
+    VPP_LOCK();
+
+    __plugin_msg_base = sflow_msg_id_base;
+    M(SFLOW_ENABLE_DISABLE, mp);
+
+    if(hwif_name){
+        u32 idx;
+        idx = get_swif_idx(vam, hwif_name);
+        if(idx != (u32) - 1){
+            mp->hw_if_index = htonl(idx);
+        } else {
+            SAIVPP_ERROR("Unable to get the sw_index for %s\n", hwif_name);
+            VPP_UNLOCK();
+            return -EINVAL;
+        }
+    } else {
+        VPP_UNLOCK();
+        return -EINVAL;
+    }
+    
+    mp->enable_disable = enable;
+
+    S(mp);
+    WR(ret);
+
+    if (ret) {
+        SAIVPP_ERROR("%s failed(%d) %s enable %d", __func__, ret, hwif_name, enable);
+    } else {
+        SAIVPP_INFO("%s %s enable %d", __func__, hwif_name, enable);
+    }
+
+    VPP_UNLOCK();
+    return ret;
+
+}
+
+int vpp_sflow_sampling_rate_set(uint32_t sampling_n)
+{
+    vl_api_sflow_sampling_rate_set_t *mp;
+    int ret;
+
+    VPP_LOCK();
+
+    __plugin_msg_base = sflow_msg_id_base;
+    M(SFLOW_SAMPLING_RATE_SET, mp);
+
+    mp->sampling_N = htonl(sampling_n);
+
+    S(mp);
+    WR(ret);
+
+    if (ret) {
+        SAIVPP_ERROR("%s failed(%d) sampling_N %u", __func__, ret, sampling_n);
+    } else {
+        SAIVPP_INFO("%s sampling_N %u", __func__, sampling_n);
+    }
+
+    VPP_UNLOCK();
+    return ret;
 }
 
 int vpp_ip_flow_hash_set (uint32_t vrf_id, uint32_t hash_mask, int addr_family)

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1111,6 +1111,20 @@ vl_api_bfd_udp_enable_multihop_reply_t_handler (vl_api_bfd_udp_enable_multihop_r
 }
 
 static void
+vl_api_sflow_enable_disable_reply_t_handler(vl_api_sflow_enable_disable_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void
+vl_api_sflow_sampling_rate_set_reply_t_handler(vl_api_sflow_sampling_rate_set_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void
 vl_api_bfd_udp_set_tos_reply_t_handler (vl_api_bfd_udp_set_tos_reply_t *msg)
 {
     int retval = (int)ntohl((uint32_t)msg->retval);
@@ -1395,6 +1409,9 @@ static void vpp_base_vpe_init(void)
 #define BFD_MSG_ID(id) \
     (VL_API_##id + bfd_msg_id_base)
 
+#define SFLOW_MSG_ID(id) \
+    (VL_API_##id + sflow_msg_id_base)
+
 #define foreach_vpe_ext_api_reply_msg                                   \
     _(INTERFACE_MSG_ID(SW_INTERFACE_DETAILS), sw_interface_details)     \
     _(INTERFACE_MSG_ID(CREATE_LOOPBACK_INSTANCE_REPLY), create_loopback_instance_reply) \
@@ -1441,8 +1458,6 @@ static void vpp_base_vpe_init(void)
     _(BFD_MSG_ID(WANT_BFD_EVENTS_REPLY), want_bfd_events_reply) \
     _(BFD_MSG_ID(BFD_UDP_ENABLE_MULTIHOP_REPLY), bfd_udp_enable_multihop_reply) \
     _(BFD_MSG_ID(BFD_UDP_SET_TOS_REPLY), bfd_udp_set_tos_reply) \
-    _(SFLOW_MSG_ID(SFLOW_ENABLE_DISABLE_REPLY), sflow_enable_disable_reply) \
-    _(SFLOW_MSG_ID(SFLOW_SAMPLING_RATE_SET_REPLY), sflow_sampling_rate_set_reply) \
 
 
 static u16 ip_msg_id_base, ip_nbr_msg_id_base, lcp_msg_id_base;
@@ -1506,34 +1521,18 @@ vl_api_acl_stats_intf_counters_enable_reply_t_handler (vl_api_acl_stats_intf_cou
 }
 
 static void
-vl_api_acl_interface_add_del_reply_t_handler(vl_api_sflow_enable_disable_reply_t *msg)
+vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_t *msg)
 {
     int retval = (int)ntohl((uint32_t)msg->retval);
     set_reply_status(retval);
 }
 
-static void
-vl_api_sflow_enable_disable_reply_t_handler(vl_api_sflow_enable_disable_reply_t *msg)
-{
-    int retval = (int)ntohl((uint32_t)msg->retval);
-    set_reply_status(retval);
-}
-
-static void
-vl_api_sflow_sampling_rate_set_reply_t_handler(vl_api_sflow_sampling_rate_set_reply_t *msg)
-{
-    int retval = (int)ntohl((uint32_t)msg->retval);
-    set_reply_status(retval);
-}
 
 #define LCP_MSG_ID(id) \
     (VL_API_##id + lcp_msg_id_base)
 
 #define ACL_MSG_ID(id) \
     (VL_API_##id + acl_msg_id_base)
-
-#define SFLOW_MSG_ID(id) \
-    (VL_API_##id + sflow_msg_id_base)
 
 #define TUNTERM_MSG_ID(id) \
     (VL_API_##id + tunterm_msg_id_base)
@@ -1562,9 +1561,7 @@ vl_api_sflow_sampling_rate_set_reply_t_handler(vl_api_sflow_sampling_rate_set_re
     _(SR_MSG_ID(SR_POLICY_ADD_V2_REPLY), sr_policy_add_v2_reply) \
     _(SR_MSG_ID(SR_POLICY_DEL_REPLY), sr_policy_del_reply) \
     _(SR_MSG_ID(SR_STEERING_ADD_DEL_REPLY), sr_steering_add_del_reply) \
-    _(SR_MSG_ID(SR_SET_ENCAP_SOURCE_REPLY), sr_set_encap_source_reply) \
-    _(IPIP_MSG_ID(IPIP_ADD_TUNNEL_REPLY), ipip_add_tunnel_reply) \
-    _(IPIP_MSG_ID(IPIP_DEL_TUNNEL_REPLY), ipip_del_tunnel_reply)
+    _(SR_MSG_ID(SR_SET_ENCAP_SOURCE_REPLY), sr_set_encap_source_reply)
 
 static void vpp_plugin_vpe_init(void)
 {
@@ -2863,6 +2860,7 @@ int vpp_sflow_enable_disable(const char *hwif_name, bool enable)
 
 int vpp_sflow_sampling_rate_set(uint32_t sampling_n)
 {
+    vat_main_t *vam = &vat_main;
     vl_api_sflow_sampling_rate_set_t *mp;
     int ret;
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1562,6 +1562,11 @@ vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_
     _(SR_MSG_ID(SR_POLICY_DEL_REPLY), sr_policy_del_reply) \
     _(SR_MSG_ID(SR_STEERING_ADD_DEL_REPLY), sr_steering_add_del_reply) \
     _(SR_MSG_ID(SR_SET_ENCAP_SOURCE_REPLY), sr_set_encap_source_reply)
+    _(SR_MSG_ID(SR_SET_ENCAP_SOURCE_REPLY), sr_set_encap_source_reply) \
+    _(SFLOW_MSG_ID(SFLOW_ENABLE_DISABLE_REPLY), sflow_enable_disable_reply) \
+    _(SFLOW_MSG_ID(SFLOW_SAMPLING_RATE_SET_REPLY), sflow_sampling_rate_set_reply) \
+    _(IPIP_MSG_ID(IPIP_ADD_TUNNEL_REPLY), ipip_add_tunnel_reply) \
+    _(IPIP_MSG_ID(IPIP_DEL_TUNNEL_REPLY), ipip_del_tunnel_reply)
 
 static void vpp_plugin_vpe_init(void)
 {

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -389,6 +389,8 @@ typedef enum {
     extern int vpp_sidlist_del(vpp_ip_addr_t *bsid);
     extern int vpp_sr_steer_add_del(vpp_sr_steer_t *sr_steer, bool is_del);
     extern int vpp_sr_set_encap_source(vpp_ip_addr_t *encap_src);
+    extern int vpp_sflow_enable_disable(const char *hwif_name, bool enable);
+    extern int vpp_sflow_sampling_rate_set(uint32_t sampling_n);
     extern int vpp_ipip_tunnel_add(vpp_ipip_tunnel_t *tunnel, uint32_t *sw_if_index);
     extern int vpp_ipip_tunnel_del(uint32_t sw_if_index);
     extern int sw_interface_set_unnumbered(uint32_t unnumbered_sw_if_index,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR contains an implementation of the SaiVppSflow skeleton, specifically for the four tasks:
- create/remove/set for SAI_OBJECT_TYPE_SAMPLEPACKET.
- SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE set handler that calls sflow_enable_disable and sflow_sampling_rate_set for the global rate (per-port rate honored only if all ports use the same rate; otherwise last-writer-wins, log a WARNING).
- SAI_HOSTIF_TRAP_TYPE_SAMPLEPACKET create/remove as bookkeeping
- SAI_HOSTIF of type GENETLINK + table entry as bookkeeping

This is PR 1/2 for phase one. The second one can be found here: https://github.com/sonic-net/sonic-platform-vpp/pull/254 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

The majority of changes needed for phase one of sFlow. The main change is the implementation of the SaiVppSflow translator. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

Used past code as a reference to develop the new sFlow features

#### How did you verify/test it?

The HLD specifies 3 conditions for the exit criteria:
- config sflow enable; config sflow interface enable Ethernet0; config sflow collector add c1 1.1.1.1 6343 results in flow samples reaching sflowtool -p 6343.
- show sflow interface reflects configured state.
- COUNTERS_DB-based counter samples appear at the configured polling interval.

I tested my code changes in a test environment and verified that their results matched and everything worked.

For conditions 1 & 3:

<img width="751" height="287" alt="Screenshot 2026-06-18 at 11 22 35 AM" src="https://github.com/user-attachments/assets/1422b3a1-28bb-48e8-8355-e758b6ecc081" />

This screenshot shows `sflowtool -p 6343` output on the collector switch, with both record types:
- `Flow` record: Condition 1 (sample packets). These are sampled packets captured on ingress to a sampled port. The fields show `10.0.0.1 -> 10.0.0.2`, ethertype `0x0800` (IPv4), protocol 1 (ICMP), the ping traffic sent from the peer switch (r1) into the sampled interface on the collector switch (r2). Their appearance confirms VPP's sFlow plugin is sampling live dataplane traffic and the samples are reaching the collector via hsflowd. 
- `CNTR` records: Condition 3 (counter samples). These are the periodic traffic independent interface counters read from COUNTERS_DB and exported at the configured polling interval (20s). 

I used a two-switch topology (r1 <-> r2, connected on Ethernet 0), so that real cross-switch traffic could ingress on a sampled port. r1 was given `10.0.0.1/24` and  r2 `10.0.0.2/24` on the connected interface. A ping from r1 -> r2 produced ingress packets on r2's port. sFlow was configured and the collector run on r2:

```
sudo config sflow enable
sudo config sflow interface enable Ethernet0
sudo config sflow collector add c1 127.0.0.1 --port 6343
sudo config sflow interface sample-rate Ethernet0 256
sudo config save -y
docker exec sflow sflowtool -p 6343 -l -k
```

I used `127.0.0.1` instead of the HLD's example `1.1.1.1` so the collector and sflowtool run on the same switch via looback. 

For condition 2:

<img width="531" height="184" alt="Screenshot 2026-06-18 at 11 32 19 AM" src="https://github.com/user-attachments/assets/33bd70c1-d2db-4d0a-aa50-75dcd29b08e5" />

- Admin state: `up` on all sampled interfaces - sFlow is enabled per port
- Sampling rate: Ethernet0 shows 256, which was set by `sudo config sFlow interface sample-rate Ethernet0 256`, while Ethernet4/Ethernet8 show the default 40000
- Sampling direction: `rx`, ingress sampling. This is the default set in `sflowmgr`

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?

N/A
-->
