### PR TITLE
[TEST/DO NOT MERGE] Combined #1932 + #1927 to verify CI interdependency

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -101,7 +101,7 @@ jobs:
       source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
-      artifact: vpp
+      artifact: vpp-bookworm
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       allowPartiallySucceededBuilds: true

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -149,7 +149,7 @@ jobs:
       source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
-      artifact: vpp
+      artifact: vpp-${{ parameters.debian_version }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       allowPartiallySucceededBuilds: true

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -192,7 +192,7 @@ jobs:
       source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
-      artifact: vpp
+      artifact: vpp-${{ parameters.debian_version }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       allowPartiallySucceededBuilds: true

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -613,7 +613,7 @@ config_syncd_nvidia_bluefield()
         mkdir -p "$SDK_DUMP_PATH"
     fi
 
-    echo 11700 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+    echo 16000 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
     mkdir -p /mnt/huge
     mount -t hugetlbfs pagesize=1GB /mnt/huge
 


### PR DESCRIPTION
### Description of PR

**Test-only / DO NOT MERGE** — combined branch to verify whether #1932 and #1927 pass CI when applied together.

Both PRs are cherry-picks targeting `202605` and are currently failing CI individually:
- #1932 — Use Debian-version-specific VPP artifacts (cherry-pick of #1926)
- #1927 — [DPU] Increase hugepages to 16000 for nvidia-bluefield kernel (cherry-pick of #1915)

#### Motivation
#1927 is a one-line `syncd_init_common.sh` change that cannot break a build, yet it fails on `Build amd64` in ~57s — consistent with the old `vpp` artifact no longer being published. #1932 switches the pipeline to versioned VPP artifacts (`vpp-bookworm` / `vpp-${{ debian_version }}`). This combined PR tests the hypothesis that #1932's pipeline fix unblocks #1927's build.

#### How I did it
Cherry-picked both commits onto current `202605` HEAD (no conflicts).

#### How to verify it
CI pipeline.

Closes nothing — this is a throwaway test branch.
