### PR TITLE
[sairedis] Add libswsscommon-dev Build-Depends for swss/logger.h

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: sonic
 Maintainer: Kamil Cudnik <kcudnik@microsoft.com>
 Section: net
 Priority: optional
-Build-Depends: debhelper (>= 12), autotools-dev, libzmq5-dev
+Build-Depends: debhelper (>= 12), autotools-dev, libzmq5-dev, libswsscommon-dev
 Standards-Version: 1.0.0
 
 Package: syncd


### PR DESCRIPTION
#### Why I did it

Fixes intermittent `libsairedis` build failures where `meta/sai_serialize.h` includes `swss/logger.h` but `libswsscommon-dev` is not declared in package Build-Depends for `sonic-sairedis`.

Observed failure in downstream build:

```text
In file included from AttrKeyMap.cpp:3:
sai_serialize.h:18:10: fatal error: swss/logger.h: No such file or directory
   18 | #include "swss/logger.h"
```

#### How I did it

Added `libswsscommon-dev` to `Build-Depends` in `debian/control`:

```text
Build-Depends: debhelper (>= 12), autotools-dev, libzmq5-dev, libswsscommon-dev
```

#### How to verify it

1. Clean sairedis artifacts and install stamps:
```bash
rm -f target/debs/bookworm/{libsairedis,libsaimetadata,syncd}*.deb
rm -f target/debs/bookworm/*-install.log
```
2. Rebuild:
```bash
make PLATFORM=<platform> SONIC_CONFIG_MAKE_JOBS=30 SONIC_BUILD_JOBS=32 \
  ENABLE_DEBUG_SYMBOLS=n SKIP_BUILD_TEST=y \
  target/debs/bookworm/libsairedis_1.0.0_amd64.deb
```
3. Confirm build completes and no `swss/logger.h` include failure appears in logs.

#### Which release branch to backport (provide reason below if selected)

202505
202511
202605

Reason: same packaging structure and include dependency pattern.

#### Tested branch (Please provide the tested image version)

master (packaging metadata fix; validated against reproducible downstream failure signature).

#### Description for the changelog

[sairedis] Add libswsscommon-dev to Build-Depends so `swss/logger.h` is available during `libsairedis` build.

#### Link to config_db schema for YANG module changes

N/A - build/packaging only.

#### A picture of a cute animal (not mandatory but encouraged)

N/A
