### PR TITLE
Add clang-format config and GitHub Actions CI check

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,66 @@
+# sonic-sairedis C/C++ formatting configuration
+# Based on existing codebase conventions:
+#   - Allman brace style (every { on its own line)
+#   - 4-space indentation, no tabs
+#   - Namespace body indented
+#   - Pointer attached to variable name (type *var)
+#   - No hard line length limit (soft 120)
+
+BasedOnStyle: Google
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 8
+
+# Allman brace style — every opening brace on its own line
+BreakBeforeBraces: Allman
+
+# Access modifiers indented 4 spaces inside class body
+# (i.e., same indent as class keyword, not as members)
+AccessModifierOffset: -4
+
+# No short constructs on single lines (matches codebase style)
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+
+# Pointer/reference attached to variable name (majority convention)
+PointerAlignment: Right
+
+# Soft line length limit (120 matches current practice)
+ColumnLimit: 120
+
+# Namespace — indent body (matches current style)
+NamespaceIndentation: All
+
+# Includes — do NOT auto-sort (existing grouping is intentional)
+SortIncludes: false
+IncludeBlocks: Preserve
+
+# Constructor initializer list
+BreakConstructorInitializers: BeforeColon
+ConstructorInitializerIndentWidth: 8
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+
+# Function parameters — break before all if they don't fit
+BinPackParameters: false
+BinPackArguments: false
+
+# Template parameters
+AlwaysBreakTemplateDeclarations: Yes
+
+# Misc
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Cpp11BracedListStyle: true
+Standard: c++17
+
+# Empty lines
+MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtTheStartOfBlocks: false

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,79 @@
+name: C++ clang-format check
+
+on:
+  pull_request:
+    branches:
+      - master
+      - "202???*"
+      - "201???*"
+    paths:
+      - "**.cpp"
+      - "**.h"
+      - ".clang-format"
+      - ".github/workflows/clang-format.yml"
+
+jobs:
+  clang-format:
+    name: clang-format (changed files only)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y clang-format-14
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100
+          clang-format --version
+
+      - name: Check formatting on changed C/C++ files
+        run: |
+          # Get list of C/C++ files changed in this PR vs base branch
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" \
+            | grep -E '\.(cpp|h)$' \
+            | grep -vE '^SAI/' \
+            | grep -vE '^debian/' \
+            || true)
+
+          if [ -z "$CHANGED" ]; then
+            echo "No C/C++ files changed — skipping format check."
+            exit 0
+          fi
+
+          echo "Checking format for:"
+          echo "$CHANGED"
+          echo ""
+
+          FORMAT_ERRORS=0
+          while IFS= read -r file; do
+            if [ ! -f "$file" ]; then
+              continue
+            fi
+            DIFF=$(clang-format --style=file "$file" | diff "$file" - || true)
+            if [ -n "$DIFF" ]; then
+              echo "::error file=$file::Format violation detected"
+              echo "--- $file"
+              echo "$DIFF"
+              FORMAT_ERRORS=$((FORMAT_ERRORS + 1))
+            fi
+          done <<< "$CHANGED"
+
+          if [ "$FORMAT_ERRORS" -gt 0 ]; then
+            echo ""
+            echo "❌ $FORMAT_ERRORS file(s) have formatting issues."
+            echo ""
+            echo "Fix with:"
+            echo "  clang-format -i <file>"
+            echo "Or fix all changed files:"
+            echo "  git diff --name-only HEAD~1 | grep -E '\\.(cpp|h)$' | xargs clang-format -i"
+            exit 1
+          fi
+
+          echo "✅ All changed files pass clang-format check."


### PR DESCRIPTION
### Description of PR

Adds C++ code formatting enforcement to sonic-sairedis using clang-format.

### Type of change

- [X] Code quality improvement
- [X] CI/CD improvement

### What is included

**.clang-format** - project style config derived from analysis of existing source conventions across syncd/, lib/, meta/, vslib/, and proxylib/:
- Allman brace style (every { on its own line - matches existing code)
- 4-space indentation, no tabs
- Pointer attached to variable name (type *var - matches majority convention)
- Namespace body indented (matches existing style)
- Soft 120-char line limit
- Includes not auto-sorted (preserves existing intentional grouping)

**.github/workflows/clang-format.yml** - PR check that:
- Runs on PRs to master and versioned branches
- Only checks C/C++ files changed in the PR (not the full codebase) - pre-existing code is unaffected
- Excludes SAI/ submodule and debian/ directory
- Uses clang-format-14 for consistency
- Fails with clear error messages showing exactly which files need fixing

### Why diff-only?

Enforcing format on the entire existing codebase at once would create a massive diff that breaks git blame. The diff-only approach allows gradual adoption: new/modified code must be formatted, existing untouched code is not flagged.

### Developer workflow

Fix format issues locally before pushing:

    sudo apt-get install -y clang-format-14
    git diff --name-only HEAD~1 | grep -E '\.(cpp|h)$' | xargs clang-format -i

This follows the pattern established by sonic-net/sonic-linkmgrd which is currently the only other SONiC C++ repo with clang-format enforcement.

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
