### PR TITLE
feat: handle LAG egress disable updates

### DIFF
--- a/unittest/vslib/Makefile.am
+++ b/unittest/vslib/Makefile.am
@@ -51,6 +51,10 @@ tests_SOURCES = main.cpp \
 				TestVirtualSwitchSaiInterface.cpp \
 				TestTAM.cpp
 
+if USE_VPP
+tests_SOURCES += TestSwitchVpp.cpp
+endif
+
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) -fno-access-control
 tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/vslib/libSaiVS.a -lhiredis -lswsscommon -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 \
 			  -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS) $(VPP_LIBS)

--- a/unittest/vslib/TestSwitchVpp.cpp
+++ b/unittest/vslib/TestSwitchVpp.cpp
@@ -1,0 +1,17 @@
+#include "vpp/SwitchVpp.h"
+
+#include <gtest/gtest.h>
+
+using namespace saivs;
+
+TEST(SwitchVpp, getLagMemberEgressDisableAction)
+{
+    using Action = SwitchVpp::LagMemberEgressDisableAction;
+
+    EXPECT_EQ(Action::NONE, SwitchVpp::getLagMemberEgressDisableAction(false, true, false));
+    EXPECT_EQ(Action::DISABLE, SwitchVpp::getLagMemberEgressDisableAction(true, true, false));
+    EXPECT_EQ(Action::ENABLE, SwitchVpp::getLagMemberEgressDisableAction(false, true, true));
+    EXPECT_EQ(Action::NONE, SwitchVpp::getLagMemberEgressDisableAction(true, true, true));
+    EXPECT_EQ(Action::NONE, SwitchVpp::getLagMemberEgressDisableAction(false, false, false));
+    EXPECT_EQ(Action::DISABLE, SwitchVpp::getLagMemberEgressDisableAction(true, false, false));
+}

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -2088,6 +2088,13 @@ sai_status_t SwitchVpp::set(
         return setLag(objectId, attr);
     }
 
+    if (objectType == SAI_OBJECT_TYPE_LAG_MEMBER)
+    {
+        sai_object_id_t objectId;
+        sai_deserialize_object_id(serializedObjectId, objectId);
+        return setLagMember(objectId, attr);
+    }
+
     return set_internal(objectType, serializedObjectId, attr);
 }
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1167,8 +1167,10 @@ namespace saivs
             std::shared_ptr<std::thread> m_vpp_thread;
 
         private: // VPP
+	    // m_lag_bond_map and m_egress_disabled_lag_member_ports are only accessed on
+	    // the LAG create/set/remove path, which the VS layer serializes through a
+	    // single queue, so they require no additional locking.
 	    std::map<sai_object_id_t, platform_bond_info_t> m_lag_bond_map;
-	    std::mutex LagMapMutex;
 	    std::set<sai_object_id_t> m_egress_disabled_lag_member_ports;
 
             static int currentMaxInstance;

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -390,6 +390,21 @@ namespace saivs
             virtual sai_status_t setLag(
                     _In_ sai_object_id_t lagId,
                     _In_ const sai_attribute_t* attr);
+            virtual sai_status_t setLagMember(
+                    _In_ sai_object_id_t lagMemberId,
+                    _In_ const sai_attribute_t* attr);
+
+            enum class LagMemberEgressDisableAction
+            {
+                NONE,
+                DISABLE,
+                ENABLE,
+            };
+
+            static LagMemberEgressDisableAction getLagMemberEgressDisableAction(
+                    _In_ bool requested_egress_disable,
+                    _In_ bool current_attr_found,
+                    _In_ bool current_egress_disable);
 
             sai_status_t vpp_create_lag(
                     _In_ sai_object_id_t lag_id,
@@ -411,6 +426,17 @@ namespace saivs
                     _In_ sai_object_id_t lag_member_oid);
 	    sai_status_t vpp_remove_lag_member(
                     _In_ sai_object_id_t lag_member_oid);
+	    sai_status_t vpp_ensure_lag_lcp(
+                    _In_ sai_object_id_t lag_oid);
+	    sai_status_t vpp_set_lag_member_egress_disable(
+                    _In_ sai_object_id_t lag_member_oid,
+                    _In_ bool egress_disable);
+	    sai_status_t get_lag_member_port(
+                    _In_ sai_object_id_t lag_member_oid,
+                    _Out_ sai_object_id_t& port_oid);
+	    sai_status_t get_lag_member_bond_index(
+                    _In_ sai_object_id_t lag_member_oid,
+                    _Out_ uint32_t& bond_sw_if_index);
 
             /* FDB Entry and Flush SAI Objects */
             sai_status_t FdbEntryadd(
@@ -1143,6 +1169,7 @@ namespace saivs
         private: // VPP
 	    std::map<sai_object_id_t, platform_bond_info_t> m_lag_bond_map;
 	    std::mutex LagMapMutex;
+	    std::set<sai_object_id_t> m_egress_disabled_lag_member_ports;
 
             static int currentMaxInstance;
 

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -772,7 +772,19 @@ sai_status_t SwitchVpp::createLagMember(
     auto sid = sai_serialize_object_id(object_id);
 
     CHECK_STATUS(create_internal(SAI_OBJECT_TYPE_LAG_MEMBER, sid, switch_id, attr_count, attr_list));
-    return vpp_create_lag_member(attr_count, attr_list);
+
+    // Add the member to the VPP bond first so the bond (and its LCP/tap) inherits
+    // the member MAC, then detach it from the bond if it is created egress-disabled.
+    CHECK_STATUS(vpp_create_lag_member(attr_count, attr_list));
+
+    auto egress_disable = sai_metadata_get_attr_by_id(SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE, attr_count, attr_list);
+    if (egress_disable != NULL && egress_disable->value.booldata)
+    {
+        SWSS_LOG_NOTICE("LAG member %s created with egress disabled, detach from VPP bond", sid.c_str());
+        CHECK_STATUS(vpp_set_lag_member_egress_disable(object_id, true));
+    }
+
+    return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t SwitchVpp::vpp_create_lag_member(
@@ -785,7 +797,6 @@ sai_status_t SwitchVpp::vpp_create_lag_member(
     bool is_passive = false;
     int ret;
     uint32_t bond_if_idx;
-    uint32_t bond_id;
     sai_object_id_t lag_oid, lag_port_oid;
 
     //Get the bond interface index from attr SAI_LAG_MEMBER_ATTR_LAG_ID
@@ -849,26 +860,244 @@ sai_status_t SwitchVpp::vpp_create_lag_member(
         return SAI_STATUS_FAILURE;
     }
 
-    if (!bond_info.lcp_created) {
-        // create tap and lcp for the Bond intf after first member is added to ensure tap mac = member mac = bond mac
-        std::ostringstream tap_stream;
-        bond_id = bond_info.id;
-        tap_stream << "be" << bond_id;
-        std::string tap = tap_stream.str();
+    CHECK_STATUS(vpp_ensure_lag_lcp(lag_oid));
 
-        const char *hw_ifname;
-        hw_ifname = vpp_get_swif_name(bond_if_idx);
-        configure_lcp_interface(hw_ifname, tap.c_str(), true);
+    return SAI_STATUS_SUCCESS;
+}
 
-        // add tc filter to redirect traffic from tap to PortChannel
-        std::string portchannel = std::string("PortChannel") + std::to_string(bond_id);
-        std::string be = std::string("be") + std::to_string(bond_id);
-        CHECK_STATUS(add_tc_filter_redirect(be, portchannel));
+sai_status_t SwitchVpp::vpp_ensure_lag_lcp(
+        _In_ sai_object_id_t lag_oid)
+{
+    SWSS_LOG_ENTER();
 
-        // update the lag to bond map
-        bond_info.lcp_created = true;
-        m_lag_bond_map[lag_oid] = bond_info;
+    platform_bond_info_t bond_info;
+    CHECK_STATUS(get_lag_bond_info(lag_oid, bond_info));
+
+    if (bond_info.lcp_created)
+    {
+        return SAI_STATUS_SUCCESS;
     }
+
+    uint32_t bond_id = bond_info.id;
+    std::ostringstream tap_stream;
+    tap_stream << "be" << bond_id;
+    std::string tap = tap_stream.str();
+
+    const char *hw_ifname = vpp_get_swif_name(bond_info.sw_if_index);
+    if (hw_ifname == NULL)
+    {
+        SWSS_LOG_ERROR("failed to get VPP bond interface name for %s", sai_serialize_object_id(lag_oid).c_str());
+        return SAI_STATUS_FAILURE;
+    }
+
+    configure_lcp_interface(hw_ifname, tap.c_str(), true);
+
+    std::string portchannel = std::string("PortChannel") + std::to_string(bond_id);
+    std::string be = std::string("be") + std::to_string(bond_id);
+    CHECK_STATUS(add_tc_filter_redirect(be, portchannel));
+
+    bond_info.lcp_created = true;
+    m_lag_bond_map[lag_oid] = bond_info;
+
+    SWSS_LOG_NOTICE("Created LCP and tc redirect for LAG %s", sai_serialize_object_id(lag_oid).c_str());
+
+    return SAI_STATUS_SUCCESS;
+}
+
+SwitchVpp::LagMemberEgressDisableAction SwitchVpp::getLagMemberEgressDisableAction(
+        _In_ bool requested_egress_disable,
+        _In_ bool current_attr_found,
+        _In_ bool current_egress_disable)
+{
+    SWSS_LOG_ENTER();
+
+    if (current_attr_found && current_egress_disable == requested_egress_disable)
+    {
+        return LagMemberEgressDisableAction::NONE;
+    }
+
+    if (!current_attr_found && !requested_egress_disable)
+    {
+        return LagMemberEgressDisableAction::NONE;
+    }
+
+    return requested_egress_disable ? LagMemberEgressDisableAction::DISABLE : LagMemberEgressDisableAction::ENABLE;
+}
+
+sai_status_t SwitchVpp::setLagMember(
+        _In_ sai_object_id_t lagMemberId,
+        _In_ const sai_attribute_t* attr)
+{
+    SWSS_LOG_ENTER();
+
+    if (attr == nullptr)
+    {
+        SWSS_LOG_ERROR("LAG member set attribute is null");
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    auto sid = sai_serialize_object_id(lagMemberId);
+
+    auto &objectHash = m_objectHash.at(SAI_OBJECT_TYPE_LAG_MEMBER);
+    if (objectHash.find(sid) == objectHash.end())
+    {
+        SWSS_LOG_ERROR("not found %s:%s",
+                sai_serialize_object_type(SAI_OBJECT_TYPE_LAG_MEMBER).c_str(),
+                sid.c_str());
+
+        return SAI_STATUS_ITEM_NOT_FOUND;
+    }
+
+    if (attr->id != SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE)
+    {
+        return set_internal(SAI_OBJECT_TYPE_LAG_MEMBER, sid, attr);
+    }
+
+    sai_attribute_t current_attr = {};
+    current_attr.id = SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE;
+    sai_status_t status = get(SAI_OBJECT_TYPE_LAG_MEMBER, lagMemberId, 1, &current_attr);
+
+    // Missing EGRESS_DISABLE means the SAI default is false. Object existence
+    // was checked above, so get failure here is treated as missing attr.
+    auto action = getLagMemberEgressDisableAction(
+            attr->value.booldata,
+            status == SAI_STATUS_SUCCESS,
+            current_attr.value.booldata);
+
+    if (action == LagMemberEgressDisableAction::NONE)
+    {
+        return set_internal(SAI_OBJECT_TYPE_LAG_MEMBER, sid, attr);
+    }
+
+    if (action == LagMemberEgressDisableAction::DISABLE)
+    {
+        SWSS_LOG_NOTICE("Disable egress on LAG member %s, detach from VPP bond", sid.c_str());
+        CHECK_STATUS(vpp_set_lag_member_egress_disable(lagMemberId, true));
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("Enable egress on LAG member %s, re-attach to VPP bond", sid.c_str());
+        CHECK_STATUS(vpp_set_lag_member_egress_disable(lagMemberId, false));
+    }
+
+    return set_internal(SAI_OBJECT_TYPE_LAG_MEMBER, sid, attr);
+}
+
+sai_status_t SwitchVpp::get_lag_member_port(
+        _In_ sai_object_id_t lag_member_oid,
+        _Out_ sai_object_id_t& port_oid)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    attr.id = SAI_LAG_MEMBER_ATTR_PORT_ID;
+    sai_status_t status = get(SAI_OBJECT_TYPE_LAG_MEMBER, lag_member_oid, 1, &attr);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("attr SAI_LAG_MEMBER_ATTR_PORT_ID is not present");
+        return SAI_STATUS_FAILURE;
+    }
+
+    port_oid = attr.value.oid;
+    sai_object_type_t obj_type = objectTypeQuery(port_oid);
+
+    if (obj_type != SAI_OBJECT_TYPE_PORT)
+    {
+        SWSS_LOG_ERROR("SAI_LAG_MEMBER_ATTR_PORT_ID=%s expected to be PORT but is: %s",
+                sai_serialize_object_id(port_oid).c_str(),
+                sai_serialize_object_type(obj_type).c_str());
+        return SAI_STATUS_FAILURE;
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::get_lag_member_bond_index(
+        _In_ sai_object_id_t lag_member_oid,
+        _Out_ uint32_t& bond_sw_if_index)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    attr.id = SAI_LAG_MEMBER_ATTR_LAG_ID;
+    sai_status_t status = get(SAI_OBJECT_TYPE_LAG_MEMBER, lag_member_oid, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("attr SAI_LAG_MEMBER_ATTR_LAG_ID is not present");
+        return SAI_STATUS_FAILURE;
+    }
+
+    sai_object_id_t lag_oid = attr.value.oid;
+    if (objectTypeQuery(lag_oid) != SAI_OBJECT_TYPE_LAG)
+    {
+        SWSS_LOG_ERROR("attr SAI_LAG_MEMBER_ATTR_LAG_ID is not a valid LAG");
+        return SAI_STATUS_FAILURE;
+    }
+
+    platform_bond_info_t bond_info;
+    CHECK_STATUS(get_lag_bond_info(lag_oid, bond_info));
+    bond_sw_if_index = bond_info.sw_if_index;
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::vpp_set_lag_member_egress_disable(
+        _In_ sai_object_id_t lag_member_oid,
+        _In_ bool egress_disable)
+{
+    SWSS_LOG_ENTER();
+
+    // Egress-disable removes the member from the VPP bond's egress distribution by
+    // detaching it from the bond, while leaving the member link administratively up.
+    // The bond runs in XOR mode and LACP is handled by teamd in Linux over the
+    // member's LCP tap, whose link state follows the VPP member link. The member
+    // link must therefore stay up so LACP PDUs keep flowing and the PortChannel can
+    // converge, so only the bond membership is toggled here. The member's own
+    // SAI_PORT_ATTR_ADMIN_STATE is left untouched.
+    sai_object_id_t port_oid;
+    CHECK_STATUS(get_lag_member_port(lag_member_oid, port_oid));
+
+    std::string if_name;
+    if (!getTapNameFromPortId(port_oid, if_name))
+    {
+        SWSS_LOG_ERROR("No port found for lag member port id: %s", sai_serialize_object_id(port_oid).c_str());
+        return SAI_STATUS_FAILURE;
+    }
+
+    const char *hwif_name = tap_to_hwif_name(if_name.c_str());
+
+    int ret;
+    if (egress_disable)
+    {
+        ret = delete_bond_member(hwif_name);
+    }
+    else
+    {
+        uint32_t bond_sw_if_index;
+        CHECK_STATUS(get_lag_member_bond_index(lag_member_oid, bond_sw_if_index));
+        ret = create_bond_member(bond_sw_if_index, hwif_name, false, false);
+    }
+
+    if (ret != 0)
+    {
+        SWSS_LOG_ERROR("failed to %s VPP bond member %s",
+                egress_disable ? "detach" : "re-attach", hwif_name);
+        return SAI_STATUS_FAILURE;
+    }
+
+    if (egress_disable)
+    {
+        m_egress_disabled_lag_member_ports.insert(port_oid);
+    }
+    else
+    {
+        m_egress_disabled_lag_member_ports.erase(port_oid);
+    }
+
+    SWSS_LOG_NOTICE("%s VPP bond member %s for egress %s",
+            egress_disable ? "Detached" : "Re-attached", hwif_name,
+            egress_disable ? "disable" : "enable");
 
     return SAI_STATUS_SUCCESS;
 }
@@ -878,7 +1107,24 @@ sai_status_t SwitchVpp::removeLagMember(
 {
     SWSS_LOG_ENTER();
 
-    CHECK_STATUS_QUIET(vpp_remove_lag_member(lag_member_oid));
+    // An egress-disabled member is already detached from the VPP bond, so skip the
+    // detach to avoid acting on a non-member; otherwise detach it from the bond now.
+    sai_object_id_t port_oid = SAI_NULL_OBJECT_ID;
+    bool egress_disabled = false;
+
+    if (get_lag_member_port(lag_member_oid, port_oid) == SAI_STATUS_SUCCESS)
+    {
+        egress_disabled = m_egress_disabled_lag_member_ports.count(port_oid) > 0;
+    }
+
+    if (egress_disabled)
+    {
+        m_egress_disabled_lag_member_ports.erase(port_oid);
+    }
+    else
+    {
+        CHECK_STATUS_QUIET(vpp_remove_lag_member(lag_member_oid));
+    }
 
     auto sid = sai_serialize_object_id(lag_member_oid);
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -376,14 +376,18 @@ void os_exit(int code) {}
 #include "../SaiVppLog.h"
 
 /*
- * Normalize VPP return code for delete operations.
- * If the operation is a delete and VPP returns NO_SUCH_ENTRY,
- * the entry is already gone — treat it as success.
+ * Normalize VPP return code for idempotent operations.
+ * If the operation is a delete and VPP returns NO_SUCH_ENTRY, the entry is
+ * already gone; if it is an add and VPP returns VALUE_EXIST, the entry is
+ * already present. In both cases treat it as success.
  */
 static inline int vpp_normalize_ret(int ret, bool is_del, const char *func)
 {
     if (is_del && ret == VNET_API_ERROR_NO_SUCH_ENTRY) {
 	    SAIVPP_INFO("%s: ignoring NO_SUCH_ENTRY(%d) on delete", func, ret);
+	    ret = 0;
+    } else if (!is_del && ret == VNET_API_ERROR_VALUE_EXIST) {
+	    SAIVPP_INFO("%s: ignoring VALUE_EXIST(%d) on add", func, ret);
 	    ret = 0;
     }
     return ret;
@@ -4241,6 +4245,8 @@ int create_bond_member(uint32_t bond_sw_if_index, const char *hwif_name, bool is
     S (mp);
 
     WR (ret);
+
+    ret = vpp_normalize_ret(ret, false, __func__);
 
     if (ret) { SAIVPP_ERROR("%s failed(%d) %s bond_sw_if_index %u", __func__, ret, hwif_name, bond_sw_if_index); }
     else { SAIVPP_INFO("%s %s bond_sw_if_index %u", __func__, hwif_name, bond_sw_if_index); }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add VPP vslib handling for `SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE` so LAG members can be dynamically detached from, or re-added to, the VPP bond when egress is disabled or enabled.

This also defers VPP bond member creation when a LAG member is created with egress disabled. LCP/tap creation remains delayed until the first enabled member is added, which avoids creating an empty bond tap with a stale generated MAC.

Fixes # (issue) https://github.com/sonic-net/sonic-buildimage/issues/25771

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [x] Test improvement

### Approach
#### What is the motivation for this PR?

VPP vslib already creates and removes LAG members in the VPP bond, but it did not handle updates to `SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE`. As a result, a member whose egress state changed after creation would not be reflected in VPP bond membership.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

- Route `SAI_OBJECT_TYPE_LAG_MEMBER` set operations through a new `setLagMember` handler.
- Handle `SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE` transitions by removing the member from the VPP bond when egress is disabled and adding it back when egress is enabled.
- Treat missing `EGRESS_DISABLE` state as the SAI default value, `false`, when deciding whether a VPP bond membership update is needed.
- Skip VPP bond member creation when a LAG member is initially created with egress disabled.
- Extract LCP/tap setup into `vpp_ensure_lag_lcp()` so LCP creation is still performed when the first enabled member is added.

#### How did you verify/test it?

Added VPP-enabled vslib unit coverage for `getLagMemberEgressDisableAction()` to verify the expected no-op, detach, and add decisions for current and requested egress-disable states.

Also ran the `pc/test_lag_member_forwarding.py` sonic-mgmt test to validate this feature (PR https://github.com/sonic-net/sonic-mgmt/pull/25135 to enable it):

<img width="3796" height="1400" alt="image" src="https://github.com/user-attachments/assets/94dcd621-f393-4188-b9f9-db2d0d017dac" />


#### Any platform specific information?

This change is specific to the VPP vslib path.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

HLD: https://github.com/sonic-net/SONiC/pull/2401
