### PR TITLE
Cast temp workaround for N/A counter values on Broadcom platforms from 202412

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -990,24 +990,21 @@ public:
                     auto rid = rids[i];
                     auto vid = vids[i];
                     std::vector<uint64_t> stats(counter_ids.size());
-                    if (collectData(rid, counter_ids, effective_stats_mode, false, stats)) {
-
-                        auto it_vid = m_objectIdsMap.find(vid);
-                        if (it_vid != m_objectIdsMap.end())
-                        {
-                            // Remove and re-add if vid already exists
-                            m_objectIdsMap.erase(it_vid);
-                        }
-
-                        auto counter_data = std::make_shared<CounterIds<StatType>>(rid, counter_ids);
-                        m_objectIdsMap.emplace(vid, counter_data);
-
-                        SWSS_LOG_INFO("Fallback to single call for object 0x%" PRIx64, vid);
-                    } else {
-                        SWSS_LOG_WARN("%s RID %s can't provide the statistic",  m_name.c_str(), sai_serialize_object_id(rid).c_str());
+                    if (!collectData(rid, counter_ids, effective_stats_mode, false, stats))
+                    {
+                        SWSS_LOG_INFO("counter read failed on RID 0x%x on intf 0x%x, adding to objectIdsMap regardless", rid, vid);
                     }
-                }
+                    auto it_vid = m_objectIdsMap.find(vid);
+                    if (it_vid != m_objectIdsMap.end())
+                    {
+                        // Remove and re-add if vid already exists
+                        m_objectIdsMap.erase(it_vid);
+                    }
 
+                    auto counter_data = std::make_shared<CounterIds<StatType>>(rid, counter_ids);
+                    m_objectIdsMap.emplace(vid, counter_data);
+                    SWSS_LOG_INFO("Fallback to single call for object 0x%" PRIx64, vid);
+                }
                 return;
             }
 
@@ -1159,10 +1156,10 @@ public:
                                         kv.second->getStatsMode() == SAI_STATS_MODE_READ_AND_CLEAR) ? SAI_STATS_MODE_READ_AND_CLEAR : SAI_STATS_MODE_READ;
             }
 
-            std::vector<uint64_t> stats(statIds.size());
-            if (!collectData(rid, statIds, effective_stats_mode, true, stats))
+            std::vector<uint64_t> stats(statIds.size(), 0);
+            if (!collectData(rid, statIds, effective_stats_mode, false, stats))
             {
-                continue;
+                SWSS_LOG_INFO("counter read failed on RID 0x%x on intf 0x%x, filling with '0' value", rid, vid);
             }
 
             std::vector<swss::FieldValueTuple> values;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Casting temp-workaround for N/A counters on management ports on 202605. This impacts all hwsku-topo combos that uses management ports (including TH5).

Casting from:
https://github.com/Azure/sonic-sairedis.msft/pull/69

Proper fix under review at:
master: https://github.com/sonic-net/sonic-sairedis/pull/1774
202511: https://github.com/sonic-net/sonic-sairedis/pull/1862
202605: https://github.com/sonic-net/sonic-sairedis/pull/1956
Fixes #1753 (temporary fix)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
To fix `N/A` counters on management ports on Broadcom platforms.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
Temporarily fill in `0` values for counters that are supported in the usual interfaces but not supported in the management ports.

#### How did you verify/test it?
`show interface counters` no longer show `N/A` counters.

#### Any platform specific information?
Broadcom only.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
