### PR TITLE
[ci]: Pin sonic-buildimage to pre-LLDP build to unblock vstests

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -76,8 +76,12 @@ jobs:
       project: build
       pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      # Temporarily pin to build 1141167 (20260617.1, commit f1d42c1a), the last
+      # master sonic-buildimage build before PR #26724 renamed the docker-sonic-vs
+      # supervisor program start.sh -> start and broke DVS readiness in vs tests.
+      # Revert to latestFromBranch once the upstream issue is resolved.
+      runVersion: 'specific'
+      runId: 1141167
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"


### PR DESCRIPTION
### What I did

Temporarily pin the sonic-buildimage `docker-sonic-vs` artifact download to build **1141167** (20260617.1, commit f1d42c1a) — the last master sonic-buildimage build before sonic-buildimage PR #26724 merged and broke DVS tests.

### Why I did it

sonic-buildimage [PR #26724](https://github.com/sonic-net/sonic-buildimage/pull/26724) renamed the docker-sonic-vs supervisor program from `start.sh` to `start` in `platform/vs/docker-sonic-vs/supervisord.conf.j2`. The vs tests' DVS readiness check (`check_services_ready`) polls for the `start.sh` program to be `EXITED`; with the renamed program the poll never succeeds, so every DVS spin-up times out after 60s and all vs test modules fail at setup. This pin unblocks sonic-sairedis CI while the upstream issue is resolved.

This mirrors sonic-swss [PR #4700](https://github.com/sonic-net/sonic-swss/pull/4700), which applied the same pin.

### How I verified it

CI will download the pinned artifact and run DVS tests against the known-good buildimage.

### Details

- The `Azure.sonic-buildimage.official.vs` / `sonic-buildimage.vs` download in `.azure-pipelines/build-docker-sonic-vs-template.yml` is changed from `latestFromBranch` to `specific` with `runId: 1141167`.
- This is the only sonic-sairedis download from that pipeline (it fetches just `docker-sonic-vs.gz`), so no other download needs pinning. Other artifacts (swss-common, sairedis, dash-api, libnexthopgroup/common_libs, ubuntu debs, vpp) remain on `latestFromBranch`.
- **This is a temporary workaround** — revert once sonic-buildimage PR #26724 is fixed.