### PR TITLE
[ci]: Pin sonic-buildimage to pre-LLDP build to unblock vstests

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -76,8 +76,12 @@ jobs:
       project: build
       pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      # Temporarily pin to build 1141167 (20260617.1, commit f1d42c1a), the last
+      # master sonic-buildimage build before PR #26724 renamed the docker-sonic-vs
+      # supervisor program start.sh -> start and broke DVS readiness in vs tests.
+      # Revert to latestFromBranch once the upstream issue is resolved.
+      runVersion: 'specific'
+      runId: 1141167
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"


### PR DESCRIPTION
### Description of PR

Temporarily pin the sonic-buildimage `docker-sonic-vs` artifact download to build **1141167** (20260617.1, commit `f1d42c1a`) — the last master sonic-buildimage build before [PR #26724](https://github.com/sonic-net/sonic-buildimage/pull/26724) merged and broke the DVS (vs) tests.

This mirrors the same workaround applied in sonic-swss [PR #4700](https://github.com/sonic-net/sonic-swss/pull/4700).

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

* Microsoft ADO (number only): 38615544


sonic-buildimage [PR #26724](https://github.com/sonic-net/sonic-buildimage/pull/26724) renamed the docker-sonic-vs supervisor program from `start.sh` to `start` in `platform/vs/docker-sonic-vs/supervisord.conf.j2`. The vs tests' DVS readiness check (`DockerVirtualSwitch.check_services_ready`) polls for the `start.sh` program to be `EXITED`. With the renamed program, `process_status.get("start.sh")` returns `None`, so the readiness poll never succeeds, every DVS spin-up times out after 60s, and all vs test modules fail at setup (with teardown then failing with `'NoneType' object has no attribute 'get_logs'`).

This blocks sonic-sairedis CI. Pinning the buildimage VS artifact to the last known-good build unblocks CI while the upstream issue is resolved.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

In `.azure-pipelines/build-docker-sonic-vs-template.yml`, changed the `Azure.sonic-buildimage.official.vs` / `sonic-buildimage.vs` download from `latestFromBranch` to `specific` with `runId: 1141167`.

This is the only sonic-sairedis download from that pipeline (it fetches just `docker-sonic-vs.gz`), so it is the single place that needs pinning. Unlike sonic-swss PR #4700 — which pins two tasks from that pipeline (the `docker-sonic-vs.gz` image **and** a `framework_*.deb`) — sonic-sairedis never downloads the sonic-framework deb, so only one hunk is required. Other artifacts (swss-common, sairedis, dash-api, `Azure.sonic-buildimage.common_libs` libnexthopgroup, vpp) are from different pipelines unaffected by the rename and remain on `latestFromBranch`.

**This is a temporary workaround** — revert to `latestFromBranch` once sonic-buildimage PR #26724 is fixed.

#### How did you verify/test it?

CI will download the pinned artifact and run DVS tests against the known-good buildimage. YAML validated locally (`yaml.safe_load`).

#### Any platform specific information?

CI/pipeline-only change (`virtual switch` DVS tests). No production code or runtime behavior is affected.

### Documentation

N/A — temporary CI workaround, no documentation/Wiki changes needed.