### PR TITLE
[ci]sonic-ubuntu-2ca agent pool: migrate from python3-pip to uv to address S360 vulnerability

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -87,7 +87,7 @@ jobs:
   - script: |
       set -ex
       # install packages for vs test
-      sudo pip3 install pytest flaky exabgp docker
+      sudo uv pip install --system pytest flaky exabgp docker
 
       # install packages for kvm test
       sudo apt-get update


### PR DESCRIPTION

### Description of PR

Summary:
Fixes # (issue)

The CI agent pool VMSS `sonic-ubuntu-2ca` (Ubuntu 22.04) is flagged by S360 for
pip vulnerabilities **USN-8344-1** and **USN-8344-3** (`python3-pip`). The agent
image is being redeployed without `python3-pip`, so any pipeline step that runs
`pip3` on the agent will break. This PR migrates the vs-test dependency install
from `pip3` to `uv`, which is already provided on the agent by the build-web
`init.sh`.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

Remove the dependency on `python3-pip` from the `sonic-ubuntu-2ca` agents so the
S360 USN-8344-1/USN-8344-3 vulnerabilities are no longer detected. `uv` is a
drop-in replacement already installed on the agent.

##### Work item tracking
- Microsoft ADO **(number only)**: 6035751, 6035790

#### How did you do it?

In `.azure-pipelines/test-docker-sonic-vs-template.yml`, replaced the agent-side
`sudo pip3 install pytest flaky exabgp docker` with
`sudo uv pip install --system pytest flaky exabgp docker`. No uv install step is
needed in the pipeline (the agent `init.sh` already installs uv to
`/usr/local/bin`).

#### How did you verify/test it?

Ran the vstest pipeline on the `sonictest` pool: the dependency install step
succeeds via uv and the vs tests run as before.

#### Any platform specific information?

None. Follow-up: the in-container `docker-sonic-vs/Dockerfile` still uses
`pip3 install scapy`; not scanned on the VMSS, tracked as future work.

### Documentation

N/A.
