### PR TITLE
enable FORTIFY_SOURCE=3

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,12 @@ endif
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 # see ENVIRONMENT in dpkg-buildflags(1)
+# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
+# Guard: FORTIFY_SOURCE is incompatible with AddressSanitizer; skip when
+# the ASAN build passes --enable-asan via DEB_CONFIGURE_EXTRA_FLAGS.
+ifeq ($(findstring --enable-asan,$(DEB_CONFIGURE_EXTRA_FLAGS)),)
+export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
+endif
 # package maintainers to append CFLAGS
 #export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS

--- a/debian/rules
+++ b/debian/rules
@@ -18,8 +18,8 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 # see ENVIRONMENT in dpkg-buildflags(1)
 # Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
 # Guard: FORTIFY_SOURCE is incompatible with AddressSanitizer; skip when
-# the ASAN build passes --enable-asan via DEB_CONFIGURE_EXTRA_FLAGS.
-ifeq ($(findstring --enable-asan,$(DEB_CONFIGURE_EXTRA_FLAGS)),)
+# building with ENABLE_ASAN=y (the variable that controls the ASAN build path).
+ifneq ($(ENABLE_ASAN), y)
 export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
 endif
 # package maintainers to append CFLAGS


### PR DESCRIPTION
#### Why I did it

Upgrade FORTIFY_SOURCE from the dpkg default of =2 to =3 for stronger compile-time buffer overflow detection using `__builtin_dynamic_object_size`.

##### Work item tracking
- Microsoft ADO:

#### How I did it

- `debian/rules`: add `DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3`
  - `-U_FORTIFY_SOURCE` clears the existing `=2` before setting `=3` to avoid duplicate-definition warnings
  - Guard: `FORTIFY_SOURCE` is incompatible with AddressSanitizer (both provide overlapping runtime instrumentation); guarded with `ifneq ($(ENABLE_ASAN), y)` — the same variable `debian/rules` already uses to control the ASAN build path (line 31)

#### How to verify it

Build the package and confirm `-D_FORTIFY_SOURCE=3` appears in compiler invocations. Build with `ENABLE_ASAN=y` and confirm `-D_FORTIFY_SOURCE=3` is absent.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ] 

#### Description for the changelog

debian/rules: upgrade FORTIFY_SOURCE to =3; guard against ASAN builds

#### Link to config_db schema for YANG module changes

N/A — no YANG changes.
