### PR TITLE
[ci]: Add --force-flaky to vstest params to match sonic-swss

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -132,9 +132,9 @@ jobs:
       docker ps
       ip netns list
       pushd sonic-swss/tests
-      params=''
+      params='--force-flaky'
       if [ '${{ parameters.asan }}' == True ]; then
-        params='--graceful-stop'
+        params="${params} --graceful-stop"
       fi
       all_tests=$(ls test_*.py)
       all_tests="${all_tests} p4rt dash"


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

The docker-sonic-vs vstest leg (.azure-pipelines/test-docker-sonic-vs-template.yml) invokes run-tests.sh with an empty params string, so pytest runs every module single-shot with no in-process retry.

Because sonic-sairedis runs sonic-swss's tests (checkout: sonic-swss + git checkout $(BUILD_BRANCH)) against a freshly built swss master image, it inherits swss's flaky cases. The identical swss commit passes in sonic-swss's own CI only because sonic-swss seeds its vstest params with --force-flaky, which lets the flaky pytest plugin retry the failing test in-process. sonic-sairedis passes no such flag, so the same intermittent failure surfaces as a hard vstest failure and blocks unrelated sairedis PRs. This change brings sonic-sairedis's vstest invocation into parity with sonic-swss's.

##### Work item tracking
- Microsoft ADO **(number only)**: 38671337

#### How did you do it?
Add `--force-flaky`

#### How did you verify/test it?


#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
