### PR TITLE
Ship synced custom SAI headers in libsaivs-dev

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -72,6 +72,16 @@ endif
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 endif
+	# SAI may be built with vendor custom headers in SAI/custom/ and the generated
+	# saimetadata.h emitted in that case includes "#include <saicustom.h>". Ship
+	# those custom headers in libsaivs-dev (the VS SAI dev package that is installed
+	# during downstream builds such as sonic-swss) so that include resolves.
+	# libsaivs-dev conflicts with vendor SAI dev packages, so the two never
+	# co-install and there is no file-overwrite clash. Guarded on existence so
+	# builds that don't include custom headers are unaffected.
+	if ls SAI/custom/*custom*.h >/dev/null 2>&1 && [ -d debian/libsaivs-dev/usr/include/sai ]; then \
+		install -m 644 SAI/custom/*custom*.h debian/libsaivs-dev/usr/include/sai/; \
+	fi
 
 override_dh_installinit:
 	dh_installinit --init-script=syncd


### PR DESCRIPTION
When vendor custom SAI headers are present in SAI/custom/, parse.pl emits "#include <saicustom.h>" into the generated saimetadata.h. Install those custom headers into libsaivs-dev so the include resolves in downstream builds (e.g. sonic-swss). libsaivs-dev conflicts with mlnx-sai, so there is no /usr/include/sai/saicustom.h overwrite clash. Guarded on header existence, so it is a no-op for builds without synced custom headers.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
