### PR TITLE
[vslib][HFT] Advertise SAI_TAM_TEL_TYPE_ATTR_MODE capability

### DIFF
--- a/unittest/vslib/TestSwitchStateBase.cpp
+++ b/unittest/vslib/TestSwitchStateBase.cpp
@@ -312,6 +312,38 @@ TEST_F(SwitchStateBaseTest, tamBindPointTypeCapabilitiesGet)
     ASSERT_EQ(static_cast<sai_tam_bind_point_type_t>(values[0]), SAI_TAM_BIND_POINT_TYPE_SWITCH);
 }
 
+TEST_F(SwitchStateBaseTest, tamTelTypeModeCapabilitiesGet)
+{
+    sai_s32_list_t data = { .count = 0, .list = nullptr };
+
+    auto status = m_ss->queryAttrEnumValuesCapability(
+        m_swid, SAI_OBJECT_TYPE_TAM_TEL_TYPE, SAI_TAM_TEL_TYPE_ATTR_MODE, &data
+    );
+    ASSERT_EQ(status, SAI_STATUS_BUFFER_OVERFLOW);
+    ASSERT_EQ(data.count, 2U);
+
+    std::vector<sai_int32_t> values(data.count);
+    data.list = values.data();
+
+    status = m_ss->queryAttrEnumValuesCapability(
+        m_swid, SAI_OBJECT_TYPE_TAM_TEL_TYPE, SAI_TAM_TEL_TYPE_ATTR_MODE, &data
+    );
+    ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+    ASSERT_EQ(data.count, 2U);
+
+    const std::set<sai_tam_tel_type_mode_t> expected = {
+        SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE,
+        SAI_TAM_TEL_TYPE_MODE_MIXED_TYPE,
+    };
+
+    std::set<sai_tam_tel_type_mode_t> actual;
+    std::transform(
+        values.cbegin(), values.cend(), std::inserter(actual, actual.begin()),
+        [](sai_int32_t value) { return static_cast<sai_tam_tel_type_mode_t>(value); }
+    );
+    ASSERT_EQ(expected, actual);
+}
+
 TEST_F(SwitchStateBaseTest, switchQoSMaxNumOfTrafficClasses)
 {
     ASSERT_EQ(m_ss->set_maximum_number_of_traffic_classes(), SAI_STATUS_SUCCESS);

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -4321,6 +4321,27 @@ sai_status_t SwitchStateBase::queryTamBindPointTypeCapability(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchStateBase::queryTamTelTypeModeCapability(
+                   _Inout_ sai_s32_list_t *enum_values_capability)
+{
+    SWSS_LOG_ENTER();
+
+    /* SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE and SAI_TAM_TEL_TYPE_MODE_MIXED_TYPE. */
+    constexpr uint32_t value_count = 2;
+
+    if (enum_values_capability->count < value_count)
+    {
+        enum_values_capability->count = value_count;
+        return SAI_STATUS_BUFFER_OVERFLOW;
+    }
+
+    enum_values_capability->count = value_count;
+    enum_values_capability->list[0] = SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE;
+    enum_values_capability->list[1] = SAI_TAM_TEL_TYPE_MODE_MIXED_TYPE;
+
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t SwitchStateBase::queryIcmpEchoSessionStatsCountModeCapability(
                    _Inout_ sai_s32_list_t *enum_values_capability)
 {
@@ -4389,6 +4410,10 @@ sai_status_t SwitchStateBase::queryAttrEnumValuesCapability(
     else if (object_type == SAI_OBJECT_TYPE_TAM && attr_id == SAI_TAM_ATTR_TAM_BIND_POINT_TYPE_LIST)
     {
         return queryTamBindPointTypeCapability(enum_values_capability);
+    }
+    else if (object_type == SAI_OBJECT_TYPE_TAM_TEL_TYPE && attr_id == SAI_TAM_TEL_TYPE_ATTR_MODE)
+    {
+        return queryTamTelTypeModeCapability(enum_values_capability);
     }
     else if (object_type == SAI_OBJECT_TYPE_ICMP_ECHO_SESSION && attr_id == SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE)
     {

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -785,6 +785,9 @@ namespace saivs
             virtual sai_status_t queryTamBindPointTypeCapability(
                                       _Inout_ sai_s32_list_t *enum_values_capability);
 
+            virtual sai_status_t queryTamTelTypeModeCapability(
+                                      _Inout_ sai_s32_list_t *enum_values_capability);
+
             virtual sai_status_t queryIcmpEchoSessionStatsCountModeCapability(
                                       _Inout_ sai_s32_list_t *enum_values_capability);
 


### PR DESCRIPTION
What I did
Add SwitchStateBase::queryTamTelTypeModeCapability that returns both SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE and SAI_TAM_TEL_TYPE_MODE_MIXED_TYPE, and dispatch SAI_OBJECT_TYPE_TAM_TEL_TYPE / SAI_TAM_TEL_TYPE_ATTR_MODE in queryAttrEnumValuesCapability through it. Mirrors the existing queryTamTransportTypeCapability and queryTamBindPointTypeCapability helpers and their dispatch branches.

Why I did it
The orchagent in sonic-swss now queries this enum capability when selecting between SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE (current default) and SAI_TAM_TEL_TYPE_MODE_MIXED_TYPE on platforms that only support the latter. Previously saivs returned SAI_STATUS_NOT_SUPPORTED for this query, forcing orchagent into a spec-default fallback. Returning both modes lets DVS exercise the orchagent's capability-query path end-to-end; the orchagent's selection rule still picks SINGLE_TYPE when both are advertised, so existing DVS tests that assert SAI_TAM_TEL_TYPE_ATTR_MODE=SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE continue to pass.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
The orchagent in sonic-swss now queries the `SAI_TAM_TEL_TYPE_ATTR_MODE`
enum capability when selecting between `SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE`
(current default) and `SAI_TAM_TEL_TYPE_MODE_MIXED_TYPE` on platforms
that only support the latter. Previously saivs returned
`SAI_STATUS_NOT_SUPPORTED` for this query, forcing orchagent into a
spec-default fallback. Advertising both modes lets DVS exercise the
orchagent's capability-query path end-to-end. The orchagent's selection
rule still picks `SINGLE_TYPE` when both are advertised, so existing DVS
tests that assert `SAI_TAM_TEL_TYPE_ATTR_MODE = SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE`
continue to pass.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
Added `SwitchStateBase::queryTamTelTypeModeCapability` that returns both
`SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE` and `SAI_TAM_TEL_TYPE_MODE_MIXED_TYPE`,
and dispatched `SAI_OBJECT_TYPE_TAM_TEL_TYPE` /
`SAI_TAM_TEL_TYPE_ATTR_MODE` in `queryAttrEnumValuesCapability` through
it. Mirrors the existing `queryTamTransportTypeCapability` and
`queryTamBindPointTypeCapability` helpers and their dispatch branches,
including the same `SAI_STATUS_BUFFER_OVERFLOW` pre-flight behavior for
zero-count probe calls.

#### How did you verify/test it?
- Local build of saivs (`make`) succeeds; no other vslib callers depend
  on the new method signature. 
- Ran the sonic-swss DVS suite against a build that includes both this
  change and the companion orchagent PR — the new HFT MIXED
  capability-query test in `tests/test_hft.py` exercises this code path
  and passes.
- Verified the buffer-overflow handling follows the same pattern as the
  sibling helpers, so callers that pre-flight with `count = 0` get the
  required size back as expected.

#### Any platform specific information?
None. Change is contained to the saivs virtual-switch SAI; physical
platforms continue to report their own mode capability through their
vendor SAI.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
HLD: [sonic-net/SONiC#2379](https://github.com/sonic-net/SONiC/pull/2379)
— "High frequency telemetry support of MIXED tam tel type mode".

