### PR TITLE
[vpp] Fix syncd deadlock on failed sw_index lookup

### DIFF
--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -2846,6 +2846,7 @@ int interface_ip_address_add_del (const char *hwif_name, vpp_ip_route_t *prefix,
             mp->sw_if_index = htonl(idx);
         } else {
             SAIVPP_ERROR("Unable to get sw_index for %s\n", hwif_name);
+            VPP_UNLOCK();
             return -EINVAL;
         }
     } else {


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

Fixes # (issue) https://github.com/sonic-net/sonic-buildimage/issues/28211

On a VPP dual-ToR ToR, syncd deadlocks permanently while programming the Loopback3 IP2ME route, and never recovers. Because syncd processes on a single worker thread, this head-of-line-blocks every subsequent SAI operation: the PortChannel router interfaces are never created, the LAGs stay operationally down, and all BGP sessions stay in Connect/never — the device never establishes routing.

Root cause is a leaked non-recursive VPP binary-API mutex in interface_ip_address_add_del() (vslib/vpp/vppxlate/SaiVppXlate.c):

- The function takes VPP_LOCK() (a non-recursive pthread_mutex), then looks up the hardware interface with get_swif_idx().
- When the lookup fails, the error branch does return -EINVAL without calling VPP_UNLOCK() — every other exit path in the function unlocks, and the sibling interface_ip_address_del_all() unlocks on the identical path. The mutex is leaked.
- On dual-ToR, the Loopback3 address is mirrored onto the kernel mux tunnel netdev tun0 (by swss tunnelmgrd), which has no VPP hwif, so the interface resolves to the sentinel "Unknown" and get_swif_idx("Unknown") fails. The two Loopback3 IP2ME routes are processed back-to-back on the same thread: the IPv4 route (10.1.0.39/32) hits the branch first and leaks the lock; the IPv6 route (fc00:1:0:39::/128) then calls VPP_LOCK() on the already-held non-recursive mutex → self-deadlock, forever.

The missing-unlock has existed since 552cc66c9 but was dormant; it became reachable on dual-ToR once the mux tunnel started carrying the Loopback3 addresses. The companion change that stops the resolver from steering to tun0 is submitted separately.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
Release the mutex on the `get_swif_idx()`-failure branch of `interface_ip_address_add_del()` by adding VPP_UNLOCK() before return -EINVAL, matching the identical error path in interface_ip_address_del_all().

#### How did you verify/test it?
* build image with PR https://github.com/sonic-net/sonic-sairedis/pull/1972, verify that BGPs are up and mux are ready:
```
root@vlab-vpp-03:~# show mux status
PORT        STATUS    SERVER_STATUS    HEALTH     HWSTATUS    LAST_SWITCHOVER_TIME
----------  --------  ---------------  ---------  ----------  ---------------------------
Ethernet4   active    active           unhealthy  consistent  2026-Jul-03 11:44:12.289020
Ethernet8   active    active           unhealthy  consistent  2026-Jul-03 11:44:12.295032
...
root@vlab-vpp-03:~# show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 6409
RIB entries 12807, using 1639296 bytes of memory
Peers 4, using 96288 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       3217       3217      6409      0       0  00:00:37             6400  ARISTA01T1
10.0.0.59      4  64600       3217       3217      6409      0       0  00:00:37             6400  ARISTA02T1
10.0.0.61      4  64600       3217       3217      6409      0       0  00:00:37             6400  ARISTA03T1
10.0.0.63      4  64600       3217       3217      6409      0       0  00:00:37             6400  ARISTA04T1

Total number of neighbors 4
```

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
