### PR TITLE
[vpp] Skip dual-ToR mux tunnel netdev in prefix-to-interface lookup

### DIFF
--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -123,10 +123,12 @@ bool vpp_get_intf_name_for_prefix (
     if (is_v6)
     {
         cmd << IP_CMD << " -6 " << " addr show " << " to " << prefix.to_string();
-        cmd << " scope global | awk -F':' '/[0-9]+: [a-zA-Z]+/ { printf \"%s\", $2 }' | cut -d' ' -f2 -z | sed 's/@[a-zA-Z].*//g'";
+        cmd << " scope global | grep -vw " << DUALTOR_TUNNEL_IF;
+        cmd << " | awk -F':' '/[0-9]+: [a-zA-Z]+/ { printf \"%s\", $2 }' | cut -d' ' -f2 -z | sed 's/@[a-zA-Z].*//g'";
     } else {
         cmd << IP_CMD << " addr show " << " to " << prefix.to_string();
-        cmd << " scope global | awk -F':' '/[0-9]+: [a-zA-Z]+/ { printf \"%s\", $2 }' | cut -d' ' -f2 -z | sed 's/@[a-zA-Z].*//g'";
+        cmd << " scope global | grep -vw " << DUALTOR_TUNNEL_IF;
+        cmd << " | awk -F':' '/[0-9]+: [a-zA-Z]+/ { printf \"%s\", $2 }' | cut -d' ' -f2 -z | sed 's/@[a-zA-Z].*//g'";
     }
     int ret = swss::exec(cmd.str(), ifname);
     if (ret)

--- a/vslib/vpp/SwitchVppUtils.h
+++ b/vslib/vpp/SwitchVppUtils.h
@@ -15,6 +15,15 @@ extern "C" {
 
 #define BONDETHERNET_PREFIX "BondEthernet"
 
+/*
+ * Kernel-only IP-in-IP mux tunnel interface created by swss tunnelmgrd on
+ * dual-ToR devices (must match TUNIF in sonic-swss cfgmgr/tunnelmgr.cpp).
+ * tunnelmgrd mirrors the Loopback3 address onto this netdev, so a prefix
+ * lookup can resolve to it instead of the real SONiC interface. It has no
+ * VPP representation and must never be selected for VPP IP programming.
+ */
+#define DUALTOR_TUNNEL_IF "tun0"
+
 #define CHECK_STATUS_W_MSG(status, msg, ...) {                                  \
     sai_status_t _status = (status);                            \
     if (_status != SAI_STATUS_SUCCESS) { \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

On a VPP dual-ToR ToR, the sairedis host-based interface resolver picks the wrong netdev for the Loopback3 address, steering IP2ME programming to a kernel-only tunnel interface that has no VPP representation.

On dual-ToR, swss tunnelmgrd (cfgmgr/tunnelmgr.cpp, #define LOOPBACK_SRC "Loopback3") mirrors the Loopback3 address onto the mux tunnel netdev tun0 via ip addr add <lo3 ip> dev tun0. The kernel then has the same address on two interfaces:

```
211: tun0@NONE  link/ipip 10.1.0.33 peer 10.1.0.32
    inet 10.1.0.39/32 scope global tun0
    inet6 fc00:1:0:39::/128 scope global
217: Loopback3
    inet 10.1.0.39/32 scope global Loopback3
    inet6 fc00:1:0:39::/128 scope global
```

`vpp_get_intf_name_for_prefix()` (vslib/vpp/SwitchVppRif.cpp) runs` ip addr show to <prefix> scope global` and takes the first match. Because ip lists interfaces in ifindex order, it returns `tun0` instead of `Loopback3`. `tun0` is a kernel-only IPIP device with no VPP LCP hwif, so downstream `tap_to_hwif_name("tun0")` returns the sentinel "Unknown" and the `Loopback3` IP2ME address is never applied to the real interface in VPP.

This is the dual-ToR-specific trigger behind the syncd wedge tracked in [sonic-net/sonic-buildimage#28211](https://github.com/sonic-net/sonic-buildimage/issues/28211). (The independent deadlock hardening — releasing the VPP mutex on the get_swif_idx failure branch — is handled separately in [#1971](https://github.com/sonic-net/sonic-sairedis/pull/1971).)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

`tun0` is the kernel mux tunnel endpoint, which leverages the `Loopback3` address. Let's exclude the dual-ToR mux tunnel interface from the prefix -> interface lookup so the prefix resolves to the real SONiC interface (e.g. `Loopback3`) instead of `tun0`

#### How did you verify/test it?
* build image with PR https://github.com/sonic-net/sonic-sairedis/pull/1971, verify that BGPs are up and mux are ready:
```
root@vlab-vpp-03:~# show mux status
PORT        STATUS    SERVER_STATUS    HEALTH     HWSTATUS    LAST_SWITCHOVER_TIME
----------  --------  ---------------  ---------  ----------  ---------------------------
Ethernet4   active    active           unhealthy  consistent  2026-Jul-03 11:44:12.289020
Ethernet8   active    active           unhealthy  consistent  2026-Jul-03 11:44:12.295032
...
root@vlab-vpp-03:~# show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 6409
RIB entries 12807, using 1639296 bytes of memory
Peers 4, using 96288 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       3217       3217      6409      0       0  00:00:37             6400  ARISTA01T1
10.0.0.59      4  64600       3217       3217      6409      0       0  00:00:37             6400  ARISTA02T1
10.0.0.61      4  64600       3217       3217      6409      0       0  00:00:37             6400  ARISTA03T1
10.0.0.63      4  64600       3217       3217      6409      0       0  00:00:37             6400  ARISTA04T1

Total number of neighbors 4
```

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
