### PR TITLE
Revert "[ci]: Pin sonic-buildimage to pre-LLDP build to unblock vstests"

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -76,12 +76,8 @@ jobs:
       project: build
       pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
-      # Temporarily pin to build 1141167 (20260617.1, commit f1d42c1a), the last
-      # master sonic-buildimage build before PR #26724 renamed the docker-sonic-vs
-      # supervisor program start.sh -> start and broke DVS readiness in vs tests.
-      # Revert to latestFromBranch once the upstream issue is resolved.
-      runVersion: 'specific'
-      runId: 1141167
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"


### PR DESCRIPTION
Reverts sonic-net/sonic-sairedis#1958, similar to https://github.com/sonic-net/sonic-swss/pull/4731. The DVS image in upstream sonic-buildimage has been fixed, so we no longer need to the docker-sonic-vs image to an older version.