### PR TITLE
Ship synced custom SAI headers in libsaivs-dev

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -72,6 +72,18 @@ endif
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 endif
+	# SAI may be built with vendor custom headers in SAI/custom/ and the generated
+	# saimetadata.h emitted in that case includes "#include <saicustom.h>". Ship
+	# those custom headers in libsaivs-dev (the VS SAI dev package that is installed
+	# during downstream builds such as sonic-swss) so that include resolves.
+	# libsaivs-dev conflicts with vendor SAI dev packages, so the two never
+	# co-install and there is no file-overwrite clash. Install all SAI/custom/*.h
+	# (same set parse.pl scans via $CUSTOM_DIR) so saimetadata.h's saicustom.h
+	# aggregator chain resolves. Guarded on existence so builds without custom
+	# headers are unaffected.
+	if ls SAI/custom/*.h >/dev/null 2>&1 && [ -d debian/libsaivs-dev/usr/include/sai ]; then \
+		install -m 644 SAI/custom/*.h debian/libsaivs-dev/usr/include/sai/; \
+	fi
 
 override_dh_installinit:
 	dh_installinit --init-script=syncd


### PR DESCRIPTION
When vendor custom SAI headers are present in SAI/custom/, parse.pl emits "#include <saicustom.h>" into the generated saimetadata.h. Install those custom headers into libsaivs-dev so the include resolves in downstream builds (e.g. sonic-swss). libsaivs-dev conflicts with mlnx-sai, so there is no /usr/include/sai/saicustom.h overwrite clash. Guarded on header existence, so it is a no-op for builds without synced custom headers.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
ASAN-enabled `syncd` aborts with a heap-buffer-overflow when creating an ACL table on Mellanox:
```
AddressSanitizer: heap-buffer-overflow ... READ of size 24 in memcpy
  check_attribs_metadata / check_attribs_on_create_without_oid / mlnx_create_acl_table  (libsai.so.0)
  syncd::VendorSai::create (syncd/VendorSai.cpp:223)
0x... is located 0 bytes after 20-byte region allocated by calloc() in check_attribs_metadata
```
Root cause: SONiC generates the SAI metadata (`libsaimetadata`) from the OCP headers only and drops the vendor `SAI/custom` folder, so `sai_acl_bind_point_type_t` is emitted **without** `SAI_ACL_BIND_POINT_TYPE_CPU_PORT` (`valuescount == 5`). The vendor SAI (36.0.14+) defines a 6th value, `CPU_PORT`, and the vendor `libsai` is linked against this SONiC-generated metadata inside `syncd`, so the two disagree on the enum size. `libsai` sizes a scratch array from the undersized metadata (`calloc(enum_metadata->valuescount, ...)` → room for 5) but walks the full vendor enum space including `CPU_PORT`, touching the 6th entry past the end of the allocation → heap-buffer-overflow. The fix is to build SONiC's metadata **with** the vendor custom headers so it matches the vendor SAI.

This change is a small piece of the overall fix. It updates sonic-sairedis to handle custom SAI headers appropriately. A subsequent PR to sonic-buildimage will implement the rest of the fix for this issue.

##### Work item tracking
- Microsoft ADO **(number only)**: <!-- add ADO number here -->

#### How did you do it?
Ship the headers for downstream consumers. `sonic-sairedis` `debian/rules` installs the synced custom headers into `libsaivs-dev` so downstream builds of the public `saimetadata.h` (e.g. `sonic-swss`). The install is guarded on header presence so builds not including custom headers are unaffected.

#### How did you verify/test it?
This issue can be verified with the following test command (sonic-mgmt):

```
PYTHONPATH=/devts/ /ngts_venv/bin/pytest \
  ngts/tests/nightly/rocev2_acl_counter/test_rocev2_acl_counter.py::TestRocev2AclCounter::test_rocev2_acl_counter[physical] \
  --setup_name=sonic_leopard_r-leopard-32 \
  --rootdir=/root/mars/workspace/sonic-mgmt/ngts \
  -c /root/mars/workspace/sonic-mgmt/ngts/pytest.ini \
  --log-level=INFO --showlocals --timeout 3600 --session-timeout 3600
```

Additionally, simply running `sudo config acl add table ASAN_REPRO L3 -p Ethernet128 -s ingress` is enough to repro the issue. You can then check for ASAN results with `sudo cat /var/log/asan/syncd-asan.log.*`.

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package installation to include vendor-specific SAI custom headers when they are available.
  * Builds without those optional headers continue to work unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->