### PR TITLE
Harden SAI designated initializers against new SAI struct fields

### DIFF
--- a/syncd/SwitchNotifications.h
+++ b/syncd/SwitchNotifications.h
@@ -147,6 +147,15 @@ namespace syncd
         {
             public:
 
+                // SAI periodically adds new members to sai_switch_notifications_t
+                // (e.g. new on_* notification callbacks). Because this designated
+                // initializer is compiled with -Werror -Wextra
+                // -Wmissing-field-initializers, any such addition breaks the build
+                // until this list is updated. New callbacks default to nullptr
+                // (no handler), which is the desired behavior until syncd wires
+                // them up, so suppress the missing-field warning for this init.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
                 Slot():
                     SlotBase({
                             .on_switch_state_change = &Slot<context>::onSwitchStateChange,
@@ -173,6 +182,7 @@ namespace syncd
                             .on_ha_scope_event = &Slot<context>::onHaScopeEvent,
                             .on_flow_bulk_get_session_event = &Slot<context>::onFlowBulkGetSessionEvent,
                             }) { }
+#pragma GCC diagnostic pop
 
                 virtual ~Slot() {}
 

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -1298,9 +1298,16 @@ TEST(SaiSerialize, serialize_qos_map)
 
     attr.id = SAI_QOS_MAP_ATTR_MAP_TO_VALUE_LIST;
 
+    // sai_qos_map_params_t gains new members over SAI releases (e.g. dei, vc);
+    // any addition breaks this designated initializer under -Werror
+    // -Wmissing-field-initializers. The unset members default to 0, which is
+    // fine for this test, so suppress the missing-field warning here.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     sai_qos_map_t qm = {
         .key   = { .tc = 1, .dscp = 2, .dot1p = 3, .prio = 4, .pg = 5, .queue_index = 6, .color = SAI_PACKET_COLOR_RED, .mpls_exp = 0, .fc = 2 },
         .value = { .tc = 11, .dscp = 22, .dot1p = 33, .prio = 44, .pg = 55, .queue_index = 66, .color = SAI_PACKET_COLOR_GREEN, .mpls_exp = 0, .fc = 2 } };
+#pragma GCC diagnostic pop
 
     attr.value.qosmap.count = 1;
     attr.value.qosmap.list = &qm;


### PR DESCRIPTION
#### Why I did it

Fixes #1988.

`sonic-sairedis` fails to compile against a current SAI master. Two SAI structs gained new members that our designated initializers don't list, and the build uses `-Werror -Wextra -Wmissing-field-initializers`, so each addition is a hard build break:

- `on_next_hop_group_hw_protection_switchover` added to `sai_switch_notifications_t` (opencomputeproject/SAI#2269)
- `dei`, `vc` added to `sai_qos_map_params_t` (opencomputeproject/SAI#2263)

```
SwitchNotifications.h: error: missing initializer for member
  '_sai_switch_notifications_t::on_next_hop_group_hw_protection_switchover'
TestSaiSerialize.cpp: error: missing initializer for member '_sai_qos_map_params_t::dei'
TestSaiSerialize.cpp: error: missing initializer for member '_sai_qos_map_params_t::vc'
```

This isn't visible on `master` yet only because the `SAI` submodule is still pinned to `v1.18.1`, which predates both changes. It breaks the moment the SAI pin advances (inevitable) and already breaks any downstream tracking SAI master.

#### How I did it

Wrap the two affected designated initializers in a scoped `#pragma GCC diagnostic push` / `ignored "-Wmissing-field-initializers"` / `pop`:

- `syncd/SwitchNotifications.h` — the `sai_switch_notifications_t` init in `Slot::Slot()`
- `unittest/meta/TestSaiSerialize.cpp` — the `sai_qos_map_t` init in `serialize_qos_map`

New/unset members keep their default (`nullptr` for callbacks, `0` for the test vector), which is the intended behavior until syncd explicitly wires a new notification up. No functional change; the warning stays enabled everywhere else.

Rationale for suppressing rather than adding the fields: adding `.on_next_hop_group_hw_protection_switchover = nullptr` etc. would not compile on `master` today, because those members don't exist in the currently pinned SAI. Suppressing the warning at these two sites is version-independent — it builds against both the current SAI pin and newer SAI.

Alternative considered: bump the SAI submodule and add the members explicitly. That's a larger, separate change and only defers the next break; hardening the init sites fixes the class of problem.

#### How to verify it

- Current pin: `make` builds clean as before (the pragma is inert — no fields are missing).
- Point the `SAI` submodule at current SAI master and rebuild: without this change `syncd`/meta tests fail with the errors above; with it they build.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### A picture of a cute animal (not mandatory but encouraged)
