### PR TITLE
[ci][DO-NOT-MERGE]: Validate against sonic-swss-common migration (#1222, build 1164874)

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -45,8 +45,12 @@ jobs:
       pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
       path: $(Build.ArtifactStagingDirectory)/download
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      # PINNED to sonic-swss-common PR #1222 build 1164874 (CI-unification migration
+      # validation): build against the migration swss-common (stock apt libnl,
+      # published build-env/). Revert to latestFromBranch / runBranch:
+      # refs/heads/$(BUILD_BRANCH) before merge.
+      runVersion: 'specific'
+      runId: '1164874'
       allowPartiallySucceededBuilds: true
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -108,8 +108,12 @@ jobs:
       project: build
       pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      # PINNED to sonic-swss-common PR #1222 build 1164874 (CI-unification migration
+      # validation): build against the migration swss-common (stock apt libnl,
+      # published build-env/). Revert to latestFromBranch / runBranch:
+      # refs/heads/$(BUILD_BRANCH) before merge.
+      runVersion: 'specific'
+      runId: '1164874'
       allowPartiallySucceededBuilds: true
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: |

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -220,8 +220,12 @@ jobs:
       project: build
       pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      # PINNED to sonic-swss-common PR #1222 build 1164874 (CI-unification migration
+      # validation): build against the migration swss-common (stock apt libnl,
+      # published build-env/). Revert to latestFromBranch / runBranch:
+      # refs/heads/$(BUILD_BRANCH) before merge.
+      runVersion: 'specific'
+      runId: '1164874'
       allowPartiallySucceededBuilds: true
       path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic swss common deb packages"

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -54,8 +54,12 @@ jobs:
       pipeline: Azure.sonic-swss-common
       artifact: sonic-swss-common.amd64.ubuntu22_04
       path: $(Build.ArtifactStagingDirectory)/download
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      # PINNED to sonic-swss-common PR #1222 build 1164874 (CI-unification migration
+      # validation): build against the migration swss-common (stock apt libnl,
+      # published build-env/). Revert to latestFromBranch / runBranch:
+      # refs/heads/$(BUILD_BRANCH) before merge.
+      runVersion: 'specific'
+      runId: '1164874'
       allowPartiallySucceededBuilds: true
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
## DO NOT MERGE — CI validation only

Draft PR to validate that **sonic-sairedis** builds and tests green against the
sonic-swss-common **CI-unification migration** PR (sonic-net/sonic-swss-common#1222).

This draft pins sonic-sairedis's swss-common download to **#1222's green build `1164874`**
so its whole pipeline (build + VS test + docker) is exercised against the migration
artifact (which is produced by `buildenv_setup` and publishes `build-env/`).

### Changes
Pin every `Download sonic swss common` step (`build-template`, `build-swss-template`,
`build-docker`, `test-docker`) to `runVersion: specific` / `runId: 1164874` instead of
`latestFromBranch` on `$(BUILD_BRANCH)`.

**No libnl companion changes** — #1222's swss-common builds against **stock apt libnl**, so
`libswsscommon` Depends on the stock libnl already present in every sonic-sairedis
build/test/docker environment.

### Not for merge
The `runId` pin is temporary; revert to `latestFromBranch` / `runBranch: refs/heads/$(BUILD_BRANCH)`
before merge.
