### PR TITLE
Fix saisdkdump profile file handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ unittest/vslib/testslibsaivs
 unittest/proxylib/tests
 unittest/proxylib/testslibsaiproxy
 unittest/saidump/tests
+unittest/saisdkdump/tests
 vslib/tests
 stub/tests
 unittest/stub/stub/testslibsaistub

--- a/configure.ac
+++ b/configure.ac
@@ -306,6 +306,7 @@ AC_OUTPUT(Makefile
           unittest/syncd/Makefile
           unittest/proxylib/Makefile
           unittest/saidump/Makefile
+          unittest/saisdkdump/Makefile
           pyext/Makefile
           pyext/py2/Makefile
           pyext/py3/Makefile)

--- a/saisdkdump/Makefile.am
+++ b/saisdkdump/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = $(SAIINC)
+AM_CXXFLAGS = $(SAIINC) -I$(top_srcdir)/saisdkdump
 
 bin_PROGRAMS = saisdkdump
 
@@ -8,7 +8,13 @@ else
 SAILIB=-lsai
 endif
 
+noinst_LIBRARIES = libsaisdkdump_profile.a
+
+libsaisdkdump_profile_a_SOURCES = ProfileMap.cpp
+libsaisdkdump_profile_a_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
+libsaisdkdump_profile_a_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
+
 saisdkdump_SOURCES = saisdkdump.cpp
 saisdkdump_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 saisdkdump_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
-saisdkdump_LDADD = -lhiredis -lswsscommon $(SAILIB) -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS) $(EXTRA_LIBSAI_LDFLAGS)
+saisdkdump_LDADD = libsaisdkdump_profile.a -lhiredis -lswsscommon $(SAILIB) -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS) $(EXTRA_LIBSAI_LDFLAGS)

--- a/saisdkdump/ProfileMap.cpp
+++ b/saisdkdump/ProfileMap.cpp
@@ -68,6 +68,8 @@ bool ProfileMap::loadFromFile(const std::string& profileMapFile)
 
 void ProfileMap::clear()
 {
+    SWSS_LOG_ENTER();
+
     m_map.clear();
     m_iter = m_map.begin();
 }

--- a/saisdkdump/ProfileMap.cpp
+++ b/saisdkdump/ProfileMap.cpp
@@ -1,0 +1,130 @@
+#include "ProfileMap.h"
+
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+
+#include "swss/logger.h"
+
+ProfileMap::ProfileMap()
+    : m_iter(m_map.begin())
+{
+}
+
+bool ProfileMap::loadFromFile(const std::string& profileMapFile)
+{
+    SWSS_LOG_ENTER();
+
+    m_map.clear();
+    m_iter = m_map.begin();
+
+    if (profileMapFile.empty())
+    {
+        return true;
+    }
+
+    std::ifstream profile(profileMapFile);
+
+    if (!profile.is_open())
+    {
+        SWSS_LOG_ERROR("failed to open profile map file: '%s' : %s",
+                profileMapFile.c_str(), strerror(errno));
+
+        return false;
+    }
+
+    std::string line;
+
+    while (getline(profile, line))
+    {
+        if (!line.empty() && line.back() == '\r')
+        {
+            line.pop_back();
+        }
+
+        if (line.size() > 0 && (line[0] == '#' || line[0] == ';'))
+        {
+            continue;
+        }
+
+        size_t pos = line.find("=");
+
+        if (pos == std::string::npos)
+        {
+            SWSS_LOG_WARN("not found '=' in line %s", line.c_str());
+            continue;
+        }
+
+        std::string key = line.substr(0, pos);
+        std::string value = line.substr(pos + 1);
+
+        m_map[key] = value;
+
+        SWSS_LOG_INFO("inserted: %s:%s", key.c_str(), value.c_str());
+    }
+
+    return true;
+}
+
+void ProfileMap::clear()
+{
+    m_map.clear();
+    m_iter = m_map.begin();
+}
+
+const char* ProfileMap::getValue(const char* variable) const
+{
+    SWSS_LOG_ENTER();
+
+    if (variable == NULL)
+    {
+        SWSS_LOG_WARN("variable is null");
+        return NULL;
+    }
+
+    auto it = m_map.find(variable);
+
+    if (it == m_map.end())
+    {
+        SWSS_LOG_NOTICE("%s: NULL", variable);
+        return NULL;
+    }
+
+    SWSS_LOG_NOTICE("%s: %s", variable, it->second.c_str());
+
+    return it->second.c_str();
+}
+
+int ProfileMap::getNextValue(const char** variable, const char** value)
+{
+    SWSS_LOG_ENTER();
+
+    if (value == NULL)
+    {
+        SWSS_LOG_INFO("resetting profile map iterator");
+
+        m_iter = m_map.begin();
+        return 0;
+    }
+
+    if (variable == NULL)
+    {
+        SWSS_LOG_WARN("variable is null");
+        return -1;
+    }
+
+    if (m_iter == m_map.end())
+    {
+        SWSS_LOG_INFO("iterator reached end");
+        return -1;
+    }
+
+    *variable = m_iter->first.c_str();
+    *value = m_iter->second.c_str();
+
+    SWSS_LOG_INFO("key: %s:%s", *variable, *value);
+
+    m_iter++;
+
+    return 0;
+}

--- a/saisdkdump/ProfileMap.cpp
+++ b/saisdkdump/ProfileMap.cpp
@@ -42,7 +42,12 @@ bool ProfileMap::loadFromFile(const std::string& profileMapFile)
             line.pop_back();
         }
 
-        if (line.size() > 0 && (line[0] == '#' || line[0] == ';'))
+        if (line.find_first_not_of(" \t") == std::string::npos)
+        {
+            continue;
+        }
+
+        if (line[0] == '#' || line[0] == ';')
         {
             continue;
         }

--- a/saisdkdump/ProfileMap.h
+++ b/saisdkdump/ProfileMap.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+class ProfileMap
+{
+public:
+    ProfileMap();
+
+    bool loadFromFile(const std::string& profileMapFile);
+
+    void clear();
+
+    const char* getValue(const char* variable) const;
+
+    int getNextValue(const char** variable, const char** value);
+
+private:
+    std::map<std::string, std::string> m_map;
+    mutable std::map<std::string, std::string>::iterator m_iter;
+};

--- a/saisdkdump/saisdkdump.cpp
+++ b/saisdkdump/saisdkdump.cpp
@@ -1,11 +1,12 @@
 #include <iostream>
 #include <sstream>
 #include <ctime>
-#include <sstream>
 
 #include <unistd.h>
 #include <getopt.h>
+#include <cstring>
 
+#include "ProfileMap.h"
 #include "swss/logger.h"
 
 extern "C" {
@@ -15,6 +16,8 @@ extern "C" {
 // TODO split to multiple cpp
 
 std::string sai_profile = "/tmp/sai.profile";
+
+static ProfileMap g_profileMap;
 
 void print_usage()
 {
@@ -46,7 +49,7 @@ const char* profile_get_value(
 {
     SWSS_LOG_ENTER();
 
-    return sai_profile.c_str();
+    return g_profileMap.getValue(variable);
 }
 
 int profile_get_next_value(
@@ -55,7 +58,8 @@ int profile_get_next_value(
         _Out_ const char** value)
 {
     SWSS_LOG_ENTER();
-    return -1;
+
+    return g_profileMap.getNextValue(variable, value);
 }
 
 sai_service_method_table_t test_services = {
@@ -118,6 +122,11 @@ int main(int argc, char **argv)
         strStream << "/tmp/saisdkdump_" << now->tm_mday << "_" << now->tm_mon + 1 << "_" << now->tm_year + 1900 << "_" << now->tm_hour << "_" << now->tm_min << "_" << now->tm_sec;
         fileName = strStream.str();
         SWSS_LOG_INFO("The dump file is not specified, generated \"%s\" file name", fileName.c_str());
+    }
+
+    if (!g_profileMap.loadFromFile(sai_profile))
+    {
+        exit(EXIT_FAILURE);
     }
 
     sai_status_t status = sai_api_initialize(0, (sai_service_method_table_t*)&test_services);

--- a/saisdkdump/saisdkdump.cpp
+++ b/saisdkdump/saisdkdump.cpp
@@ -4,6 +4,7 @@
 
 #include <unistd.h>
 #include <getopt.h>
+#include <cerrno>
 #include <cstring>
 
 #include "ProfileMap.h"
@@ -26,7 +27,8 @@ void print_usage()
     std::cerr << "Following SAI dump options can be specified:" << std::endl;
     std::cerr << "-------------------------------------------" << std::endl;
     std::cerr << "--dump_file -f   Full path for dump file" << std::endl;
-    std::cerr << "--profile -p     Full path to SAI profile file [ default is " << sai_profile << " ]" << std::endl;
+    std::cerr << "--profile -p     Full path to SAI profile file [ default is " << sai_profile
+              << "; if missing, an empty profile is used ]" << std::endl;
     std::cerr << "--help  -h       usage" << std::endl;
 }
 
@@ -81,6 +83,7 @@ int main(int argc, char **argv)
     };
 
     bool fileSpecified = false;
+    bool profileSpecified = false;
     std::string fileName;
     int option_index = 0;
     int c = 0;
@@ -100,6 +103,7 @@ int main(int argc, char **argv)
                 if (optarg != NULL)
                 {
                     sai_profile = std::string(optarg);
+                    profileSpecified = true;
                 }
                 break;
 
@@ -122,6 +126,14 @@ int main(int argc, char **argv)
         strStream << "/tmp/saisdkdump_" << now->tm_mday << "_" << now->tm_mon + 1 << "_" << now->tm_year + 1900 << "_" << now->tm_hour << "_" << now->tm_min << "_" << now->tm_sec;
         fileName = strStream.str();
         SWSS_LOG_INFO("The dump file is not specified, generated \"%s\" file name", fileName.c_str());
+    }
+
+    if (!profileSpecified && access(sai_profile.c_str(), F_OK) != 0 && errno == ENOENT)
+    {
+        SWSS_LOG_NOTICE("default SAI profile '%s' does not exist, using empty profile",
+                sai_profile.c_str());
+
+        sai_profile.clear();
     }
 
     if (!g_profileMap.loadFromFile(sai_profile))

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = meta lib vslib syncd proxylib saidump
+SUBDIRS = meta lib vslib syncd proxylib saidump saisdkdump

--- a/unittest/saisdkdump/Makefile.am
+++ b/unittest/saisdkdump/Makefile.am
@@ -1,0 +1,13 @@
+AM_CXXFLAGS = $(SAIINC) -I$(top_srcdir)/saisdkdump
+
+bin_PROGRAMS = tests
+
+LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
+
+tests_SOURCES = main.cpp TestProfileMap.cpp
+
+tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
+tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/saisdkdump/libsaisdkdump_profile.a \
+              -lswsscommon -lpthread $(CODE_COVERAGE_LIBS)
+
+TESTS = tests

--- a/unittest/saisdkdump/TestProfileMap.cpp
+++ b/unittest/saisdkdump/TestProfileMap.cpp
@@ -15,6 +15,8 @@ namespace
     public:
         explicit TempProfile(const std::string& content)
         {
+            SWSS_LOG_ENTER();
+
             char path[] = "/tmp/saisdkdump_profile_test.XXXXXX";
             int fd = mkstemp(path);
             EXPECT_GE(fd, 0);
@@ -32,6 +34,8 @@ namespace
 
         ~TempProfile()
         {
+            SWSS_LOG_ENTER();
+
             if (!m_path.empty())
             {
                 unlink(m_path.c_str());
@@ -40,6 +44,8 @@ namespace
 
         const std::string& path() const
         {
+            SWSS_LOG_ENTER();
+
             return m_path;
         }
 
@@ -53,6 +59,8 @@ namespace
 
 TEST(ProfileMap, emptyPathLoadsNoEntries)
 {
+    SWSS_LOG_ENTER();
+
     ProfileMap profileMap;
 
     EXPECT_TRUE(profileMap.loadFromFile(""));
@@ -61,6 +69,8 @@ TEST(ProfileMap, emptyPathLoadsNoEntries)
 
 TEST(ProfileMap, missingFileReturnsFalse)
 {
+    SWSS_LOG_ENTER();
+
     ProfileMap profileMap;
 
     EXPECT_FALSE(profileMap.loadFromFile("/tmp/saisdkdump_profile_missing_file"));
@@ -68,6 +78,8 @@ TEST(ProfileMap, missingFileReturnsFalse)
 
 TEST(ProfileMap, parsesKeyValuePairs)
 {
+    SWSS_LOG_ENTER();
+
     ProfileMap profileMap;
     const TempProfile profile(
             "# comment line\n"
@@ -83,6 +95,8 @@ TEST(ProfileMap, parsesKeyValuePairs)
 
 TEST(ProfileMap, parsesCrLfLineEndings)
 {
+    SWSS_LOG_ENTER();
+
     ProfileMap profileMap;
     const TempProfile profile(
             "CT_TABLE_DUMP_ENABLE=true\r\n"
@@ -95,6 +109,8 @@ TEST(ProfileMap, parsesCrLfLineEndings)
 
 TEST(ProfileMap, skipsMalformedLines)
 {
+    SWSS_LOG_ENTER();
+
     ProfileMap profileMap;
     const TempProfile profile(
             "VALID=yes\n"
@@ -108,6 +124,8 @@ TEST(ProfileMap, skipsMalformedLines)
 
 TEST(ProfileMap, getNextValueIteratesAndResets)
 {
+    SWSS_LOG_ENTER();
+
     ProfileMap profileMap;
     const TempProfile profile(
             "FIRST=one\n"
@@ -139,6 +157,8 @@ TEST(ProfileMap, getNextValueIteratesAndResets)
 
 TEST(ProfileMap, clearRemovesEntries)
 {
+    SWSS_LOG_ENTER();
+
     ProfileMap profileMap;
     const TempProfile profile("CT_TABLE_DUMP_ENABLE=true\n");
 

--- a/unittest/saisdkdump/TestProfileMap.cpp
+++ b/unittest/saisdkdump/TestProfileMap.cpp
@@ -8,6 +8,8 @@
 
 #include "ProfileMap.h"
 
+#include "swss/logger.h"
+
 namespace
 {
     class TempProfile

--- a/unittest/saisdkdump/TestProfileMap.cpp
+++ b/unittest/saisdkdump/TestProfileMap.cpp
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#include "ProfileMap.h"
+
+namespace
+{
+    class TempProfile
+    {
+    public:
+        explicit TempProfile(const std::string& content)
+        {
+            char path[] = "/tmp/saisdkdump_profile_test.XXXXXX";
+            int fd = mkstemp(path);
+            EXPECT_GE(fd, 0);
+            if (fd < 0)
+            {
+                return;
+            }
+
+            m_path = path;
+            close(fd);
+
+            std::ofstream out(m_path);
+            out << content;
+        }
+
+        ~TempProfile()
+        {
+            if (!m_path.empty())
+            {
+                unlink(m_path.c_str());
+            }
+        }
+
+        const std::string& path() const
+        {
+            return m_path;
+        }
+
+        TempProfile(const TempProfile&) = delete;
+        TempProfile& operator=(const TempProfile&) = delete;
+
+    private:
+        std::string m_path;
+    };
+}
+
+TEST(ProfileMap, emptyPathLoadsNoEntries)
+{
+    ProfileMap profileMap;
+
+    EXPECT_TRUE(profileMap.loadFromFile(""));
+    EXPECT_EQ(nullptr, profileMap.getValue("CT_TABLE_DUMP_ENABLE"));
+}
+
+TEST(ProfileMap, missingFileReturnsFalse)
+{
+    ProfileMap profileMap;
+
+    EXPECT_FALSE(profileMap.loadFromFile("/tmp/saisdkdump_profile_missing_file"));
+}
+
+TEST(ProfileMap, parsesKeyValuePairs)
+{
+    ProfileMap profileMap;
+    const TempProfile profile(
+            "# comment line\n"
+            "; comment line\n"
+            "CT_TABLE_DUMP_ENABLE=true\n"
+            "OTHER_KEY=value\n");
+
+    EXPECT_TRUE(profileMap.loadFromFile(profile.path()));
+    EXPECT_STREQ("true", profileMap.getValue("CT_TABLE_DUMP_ENABLE"));
+    EXPECT_STREQ("value", profileMap.getValue("OTHER_KEY"));
+    EXPECT_EQ(nullptr, profileMap.getValue("UNKNOWN_KEY"));
+}
+
+TEST(ProfileMap, parsesCrLfLineEndings)
+{
+    ProfileMap profileMap;
+    const TempProfile profile(
+            "CT_TABLE_DUMP_ENABLE=true\r\n"
+            "OTHER_KEY=value\r\n");
+
+    EXPECT_TRUE(profileMap.loadFromFile(profile.path()));
+    EXPECT_STREQ("true", profileMap.getValue("CT_TABLE_DUMP_ENABLE"));
+    EXPECT_STREQ("value", profileMap.getValue("OTHER_KEY"));
+}
+
+TEST(ProfileMap, skipsMalformedLines)
+{
+    ProfileMap profileMap;
+    const TempProfile profile(
+            "VALID=yes\n"
+            "no_equals_sign\n"
+            "CT_TABLE_DUMP_ENABLE=true\n");
+
+    EXPECT_TRUE(profileMap.loadFromFile(profile.path()));
+    EXPECT_STREQ("yes", profileMap.getValue("VALID"));
+    EXPECT_STREQ("true", profileMap.getValue("CT_TABLE_DUMP_ENABLE"));
+}
+
+TEST(ProfileMap, getNextValueIteratesAndResets)
+{
+    ProfileMap profileMap;
+    const TempProfile profile(
+            "FIRST=one\n"
+            "SECOND=two\n");
+
+    EXPECT_TRUE(profileMap.loadFromFile(profile.path()));
+
+    const char* variable = nullptr;
+    const char* value = nullptr;
+
+    EXPECT_EQ(0, profileMap.getNextValue(nullptr, nullptr));
+
+    std::vector<std::pair<std::string, std::string>> entries;
+    while (profileMap.getNextValue(&variable, &value) == 0)
+    {
+        entries.emplace_back(variable, value);
+    }
+
+    ASSERT_EQ(2u, entries.size());
+    EXPECT_EQ("FIRST", entries[0].first);
+    EXPECT_EQ("one", entries[0].second);
+    EXPECT_EQ("SECOND", entries[1].first);
+    EXPECT_EQ("two", entries[1].second);
+
+    EXPECT_EQ(0, profileMap.getNextValue(nullptr, nullptr));
+    EXPECT_EQ(0, profileMap.getNextValue(&variable, &value));
+    EXPECT_EQ("FIRST", std::string(variable));
+}
+
+TEST(ProfileMap, clearRemovesEntries)
+{
+    ProfileMap profileMap;
+    const TempProfile profile("CT_TABLE_DUMP_ENABLE=true\n");
+
+    EXPECT_TRUE(profileMap.loadFromFile(profile.path()));
+    EXPECT_STREQ("true", profileMap.getValue("CT_TABLE_DUMP_ENABLE"));
+
+    profileMap.clear();
+    EXPECT_EQ(nullptr, profileMap.getValue("CT_TABLE_DUMP_ENABLE"));
+}

--- a/unittest/saisdkdump/TestProfileMap.cpp
+++ b/unittest/saisdkdump/TestProfileMap.cpp
@@ -124,6 +124,24 @@ TEST(ProfileMap, skipsMalformedLines)
     EXPECT_STREQ("true", profileMap.getValue("CT_TABLE_DUMP_ENABLE"));
 }
 
+TEST(ProfileMap, skipsWhitespaceOnlyLines)
+{
+    SWSS_LOG_ENTER();
+
+    ProfileMap profileMap;
+    const TempProfile profile(
+            "VALID=yes\n"
+            "\n"
+            "   \n"
+            "\t\t\n"
+            " \t \r\n"
+            "CT_TABLE_DUMP_ENABLE=true\n");
+
+    EXPECT_TRUE(profileMap.loadFromFile(profile.path()));
+    EXPECT_STREQ("yes", profileMap.getValue("VALID"));
+    EXPECT_STREQ("true", profileMap.getValue("CT_TABLE_DUMP_ENABLE"));
+}
+
 TEST(ProfileMap, getNextValueIteratesAndResets)
 {
     SWSS_LOG_ENTER();

--- a/unittest/saisdkdump/main.cpp
+++ b/unittest/saisdkdump/main.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char *argv[])
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
#### Why I did it
`saisdkdump` did not parse the SAI profile file passed with `-p`: `profile_get_value` returned the file path for every key, and `profile_get_next_value` always failed. A new feature on the nvidia-bluefield platform, DASH CT dumps from the SDK in techsupport, needs a profile key (`CT_TABLE_DUMP_ENABLE`) to reach SAI to trigger the CT dump in the SDK dump.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Add `ProfileMap` (based on `saidiscovery`) to parse `key=value` lines, skip comments, and back SAI profile callbacks.
- Load the profile in `saisdkdump` before `sai_api_initialize`; build `libsaisdkdump_profile.a`.
- Add gtest coverage in `unittest/saisdkdump/` (KV parsing, malformed lines, iterator reset, clear).

#### How to verify it
```bash
./autogen.sh && ./configure --disable-static --disable-python2 --with-sai=vs
make -C saisdkdump libsaisdkdump_profile.a
make -C unittest/saisdkdump check
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Tested branch (Please provide the tested image version)
- [x] master, between 202605–202611

#### Description for the changelog
Fix saisdkdump profile file flag.
