### PR TITLE
[Mellanox] Sentinel file management for sdk techsupport CT dumps on NVIDIA Bluefield DPUs.

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -613,6 +613,13 @@ config_syncd_marvell_teralynx()
 
 config_syncd_nvidia_bluefield()
 {
+    # SDK techsupport CT dump sentinel path. Keep in sync across:
+    #   sonic-utilities/config/plugins/nvidia_bluefield.py (SDK_TECHSUPPORT_CT_DUMP_SENTINEL)
+    #   sonic-utilities/scripts/generate_dump (sdk_techsupport_ct_dump_sentinel)
+    #   syncd/scripts/syncd_init_common.sh (config_syncd_nvidia_bluefield)
+    mkdir -p /var/run/sonic-platform-nvidia-bluefield
+    rm -f /var/run/sonic-platform-nvidia-bluefield/sdk-techsupport-ct-dump.enabled
+
     # Read MAC addresses
     base_mac="$(echo $SYNCD_VARS | jq -r '.mac')"
     hwsku=$(sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]')


### PR DESCRIPTION
#### Why I did it
SDK techsupport CT dumps on NVIDIA BlueField SmartSwitch DPUs use a sentinel file to signal that the feature is enabled. The file must not persist across syncd container restarts; its lifetime should match the SDN application.

This PR is required for the parent feature PR https://github.com/sonic-net/sonic-utilities/pull/4696

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- In `config_syncd_nvidia_bluefield()`, create `/var/run/sonic-platform-nvidia-bluefield/` at container startup.
- Remove `sdk-techsupport-ct-dump.enabled` on startup so a stale sentinel is not left after restart.

#### How to verify it
On a BlueField DPU image with the companion `sonic-utilities` changes:
1. Enable: `config platform nvidia-bluefield sdk techsupport-ct-dump enabled`
2. Confirm sentinel exists: `ls /var/run/sonic-platform-nvidia-bluefield/sdk-techsupport-ct-dump.enabled`
3. Restart syncd container; confirm sentinel is gone until re-enabled.
4. Run `show techsupport` and confirm CT dump output when enabled.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Tested branch (Please provide the tested image version)
- [x] master (202605–202611)

#### Description for the changelog
nvidia-bluefield sentinel file management for sdk techsupport CT dump feature.

