### PR TITLE
Set fabric port defaults for vs platform

### DIFF
--- a/unittest/vslib/TestSwitchStateBase.cpp
+++ b/unittest/vslib/TestSwitchStateBase.cpp
@@ -324,6 +324,24 @@ TEST_F(SwitchStateBaseTest, switchQoSMaxNumOfTrafficClasses)
     ASSERT_EQ(attr.value.u8, maxTcNum);
 }
 
+TEST_F(SwitchStateBaseTest, switchFabricPortDefaults)
+{
+    ASSERT_EQ(m_ss->set_switch_default_attributes(), SAI_STATUS_SUCCESS);
+
+    // A switch without a fabric lane map must report 0 fabric ports rather than
+    // SAI_STATUS_NOT_IMPLEMENTED, matching hardware on a fabric-less box.
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_NUMBER_OF_FABRIC_PORTS;
+    ASSERT_EQ(m_ss->get(SAI_OBJECT_TYPE_SWITCH, sai_serialize_object_id(m_swid), 1, &attr), SAI_STATUS_SUCCESS);
+    ASSERT_EQ(attr.value.u32, 0U);
+
+    attr.id = SAI_SWITCH_ATTR_FABRIC_PORT_LIST;
+    attr.value.objlist.count = 0;
+    attr.value.objlist.list = nullptr;
+    ASSERT_EQ(m_ss->get(SAI_OBJECT_TYPE_SWITCH, sai_serialize_object_id(m_swid), 1, &attr), SAI_STATUS_SUCCESS);
+    ASSERT_EQ(attr.value.objlist.count, 0U);
+}
+
 TEST_F(SwitchStateBaseTest, processFipsPostConfig)
 {
     std::ofstream post_config_file(VS_SAI_FIPS_POST_CONFIG_FILE);

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -1196,6 +1196,20 @@ sai_status_t SwitchStateBase::set_switch_default_attributes()
 
     CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
 
+    // Default to no fabric ports so a GET returns 0 rather than
+    // SAI_STATUS_NOT_IMPLEMENTED. Switches with a fabric lane map overwrite
+    // these in set_fabric_port_list().
+    attr.id = SAI_SWITCH_ATTR_NUMBER_OF_FABRIC_PORTS;
+    attr.value.u32 = 0;
+
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
+    attr.id = SAI_SWITCH_ATTR_FABRIC_PORT_LIST;
+    attr.value.objlist.count = 0;
+    attr.value.objlist.list = nullptr;
+
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
     return set_switch_supported_object_types();
 }
 


### PR DESCRIPTION

### Description of PR
For UT2 kvm, running test_bgp_facts.py is causing an error due to fabric ports not initialized to default values.
ut2 is the first voq switch in VS platform. And the fabric lanemap is not set, but the default values are not set in the vslib. This caused the API getFabricPortList (in fabricport orch) to return error.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
Support kvm ut2

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
set the fabric port default values to be 0 (for count) and null for ports.

#### How did you verify/test it?
ran test_bgp_facts.py on vtb and it passed without error

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
