### PR TITLE
[ci]: install libyang with uv instead of pip3 in VS test

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -118,9 +118,11 @@ jobs:
       # from PyPI instead — same fallback as the inline amd64/ubuntu-22.04
       # job. --no-build-isolation + apt's python3-cffi sidesteps a cffi
       # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
-      # env otherwise triggers.
-      sudo apt-get install -y python3-cffi
-      sudo pip3 install --no-build-isolation 'libyang==3.3.0'
+      # env otherwise triggers. --no-build-isolation needs wheel present in
+      # the environment to provide bdist_wheel, so install it first.
+      sudo apt-get install -y python3-cffi python3-dev
+      sudo uv pip install --system wheel
+      sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'
 
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb


### PR DESCRIPTION
### Description of PR

Summary:
The VS test template's "Install dependencies" step installs the `libyang` Python bindings with `sudo pip3 install --no-build-isolation 'libyang==3.3.0'`. Now that `python3-pip` has been removed from the `sonictest` pool host, this fails with `pip3: command not found`, breaking the docker-sonic-vs test job.

The rest of the same step already installs Python packages with `sudo uv pip install --system` (e.g. `pytest flaky exabgp docker`), so this switches the `libyang` install to uv the same way.

### Type of change

- [x] Bug fix

### Approach
#### What is the motivation for this PR?

`python3-pip` was removed from the build/test hosts (uv migration / S360). The `libyang` install in `.azure-pipelines/test-docker-sonic-vs-template.yml` was the only Python install in that step still using `pip3`, so it now fails with `pip3: command not found`. Switching it to `uv pip install --system` matches the already-migrated `pytest/flaky/exabgp/docker` install in the same step and restores the VS test.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

Replaced `sudo pip3 install --no-build-isolation 'libyang==3.3.0'` with `sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'`. `--no-build-isolation` (with apt's `python3-cffi`) is preserved to keep the cffi workaround; `sudo` + `--system` install into the host system interpreter exactly as before.

#### How did you verify/test it?

The VS test pipeline's "Install dependencies" step now proceeds past the libyang install (previously failed at `pip3: command not found`). uv is already present and used by the preceding `sudo uv pip install --system pytest ...` line in the same step.

#### Any platform specific information?

CI-only change to `.azure-pipelines/test-docker-sonic-vs-template.yml`; no functional/runtime code change.
