### PR TITLE
Auto-use enablePerPortCounterDiscovery syncd arg on Broadcom ASICs

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -66,6 +66,12 @@ if [ "$SUPPORTING_BULK_COUNTER_GROUPS" != "" ]; then
     CMD_ARGS+=" -B $SUPPORTING_BULK_COUNTER_GROUPS"
 fi
 
+case "$SONIC_ASIC_TYPE" in
+    broadcom)
+        CMD_ARGS+=" -G"
+        ;;
+esac
+
 case "$(cat /proc/cmdline)" in
   *SONIC_BOOT_TYPE=fastfast*)
     if [ -e /var/warmboot/warm-starting ]; then

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -66,6 +66,8 @@ if [ "$SUPPORTING_BULK_COUNTER_GROUPS" != "" ]; then
     CMD_ARGS+=" -B $SUPPORTING_BULK_COUNTER_GROUPS"
 fi
 
+# Enable per-port counter capability discovery (see sonic-buildimage#28460, #1774).
+# Add ASIC types that needs this feature here
 case "$SONIC_ASIC_TYPE" in
     broadcom)
         CMD_ARGS+=" -G"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Auto-use the `enablePerPortCounterDiscovery` `syncd` arg for Broadcom ASICs in an easily expandable way such that other ASIC types can be easily added to use this behavior.

This is part 2 of 2 fix in addressing https://github.com/sonic-net/sonic-buildimage/issues/28460. There are two fix methods under consideration, this PR outlines the method of deciding code path via the ASIC type.

This change requires the changes in https://github.com/sonic-net/sonic-sairedis/pull/2000 to work.

Fixes -
Partially Fixes: https://github.com/sonic-net/sonic-buildimage/issues/28460

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
In #1774 , a new counter support discovery method is introduced for being able to read counter support for platforms where different ports can have different capabilities.
The method worked well for some platforms, not so much for some others.

This change auto-uses the new `syncd` arg `enablePerPortCounterDiscovery` (introduced in https://github.com/sonic-net/sonic-sairedis/pull/2000) when the `broadcom` ASIC type is detected in `syncd_init_common.sh`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
Add logic in `syncd_init_common.sh` to auto apply the `syncd` arg when `broadcom` ASIC type is detected.

#### How did you verify/test it?
`syncd` unit tests pass on master and on 202605.
On physical hardware, an image is built with the changes cherry-picked to 202605 and tests are ran in 2 scenarios:
1) With the change as is
2) `syncd_init_common.sh` hotpatched to filter on another asic type.

In both scenarios, `syncd` enters the expected code path.
Additionally, a subset of counters-focused `sonic-mgmt` tests are ran. There is no test result difference compared to tests done without this change.
Tests were ran on `Arista-7260CX3-D108C8` and `Arista-7060X6-64PE-B-C512S2`.

The list of `sonic-mgmt` tests ran:
```
test_pretest.py
dhcp_relay/test_dhcp_counter_stress.py
drop_packets/test_drop_counters.py
drop_packets/test_configurable_drop_counters.py
gnmi/test_gnmi_countersdb.py
snmp/test_snmp_queue_counters.py
test_posttest.py
```

To ensure no warm and fast reboot issues from any potential time increase from `syncd`, some reboot-related tests are also ran. The following `sonic-mgmt` tests pass with this change casted, tested on `Arista-7260CX3-D108C8` and `Arista-7060CX-32S-C32`:
```
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad*
platform_tests/test_advanced_reboot.py::test_warm_reboot_mac_jump
platform_tests/test_advanced_reboot.py::test_warm_reboot
platform_tests/test_advanced_reboot.py::test_fast_reboot
```

#### Any platform specific information?
Broadcom

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
