### PR TITLE
Toggle enablePerPortCounterDiscovery based on HWSKU config

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -66,6 +66,11 @@ if [ "$SUPPORTING_BULK_COUNTER_GROUPS" != "" ]; then
     CMD_ARGS+=" -B $SUPPORTING_BULK_COUNTER_GROUPS"
 fi
 
+ENABLE_PER_PORT_COUNTER_DISCOVERY=$(echo $SYNCD_VARS | jq -r '.enable_per_port_counter_discovery')
+if [ "$ENABLE_PER_PORT_COUNTER_DISCOVERY" == "true" ]; then
+    CMD_ARGS+=" -G"
+fi
+
 case "$(cat /proc/cmdline)" in
   *SONIC_BOOT_TYPE=fastfast*)
     if [ -e /var/warmboot/warm-starting ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Apply the `enablePerPortCounterDiscovery` `syncd` arg when the file `enable_per_port_counter_discovery` exists and has the contents `true` in the machine's HWSKU config in `sonic-buildimage/device/...`.

This is part 2 of 2 fix in addressing https://github.com/sonic-net/sonic-buildimage/issues/28460. There are two fix methods under consideration, this PR outlines the method of deciding code path via the HWSKU config and needs to be used together with https://github.com/sonic-net/sonic-buildimage/pull/28506.

This change also requires the changes in https://github.com/sonic-net/sonic-sairedis/pull/2000, https://github.com/sonic-net/sonic-sairedis/pull/2001, and https://github.com/sonic-net/sonic-buildimage/pull/28506 to work.

Fixes https://github.com/sonic-net/sonic-buildimage/issues/28460

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
In #1774 , a new counter support discovery method is introduced for being able to read counter support for platforms where different ports can have different capabilities.
The method worked well for some platforms, not so much for some others.

This change applies the new `syncd` arg `enablePerPortCounterDiscovery` (introduced in https://github.com/sonic-net/sonic-sairedis/pull/2000) when `enable_per_port_counter_discovery` is populated as `true` in `SYNCD_VARS`, which is retrieved from `DEVICE_METADATA` in `CONFIG_DB`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
Add logic in `syncd_init_common.sh` to apply the `syncd` arg `enablePerPortCounterDiscovery` when it is defined as so in `SYNCD_VARS`. 
#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
`syncd` unit tests pass on master and on 202605, internal Arista build from Jul 24, 2026.
On physical hardware, an image is built with the changes cherry-picked to 202605 and tests are ran in 6 scenarios:
1):
- ASIC check: use arg on `broadcom`
- HWSKU config: not defined
- Result: per-port counter discovery code path used

2):
- ASIC check: use arg on `broadcom`
- HWSKU config: `enable_per_port_counter_discovery` set to `true`
- Result: per-port counter discovery code path used

3):
- ASIC check: use arg on `broadcom`
- HWSKU config: `enable_per_port_counter_discovery` set to `false`
- Result: legacy code path used

4):
- ASIC check: use arg on `mellanox`
- HWSKU config: not defined
- Result: legacy code path used

5):
- ASIC check: use arg on `mellanox`
- HWSKU config: `enable_per_port_counter_discovery` set to `true`
- Result: per-port counter discovery code path used

6):
- ASIC check: use arg on `mellanox`
- HWSKU config: `enable_per_port_counter_discovery` set to `false`
- Result: legacy code path used

In all 6 scenarios, `syncd` enters the expected code path.

Additionally, a subset of counters-focused `sonic-mgmt` tests are ran. There is no test result difference compared to tests done without this change.
Tests were ran on `Arista-7260CX3-D108C8`.

The list of `sonic-mgmt` tests ran:
```
test_pretest.py
dhcp_relay/test_dhcp_counter_stress.py
drop_packets/test_drop_counters.py
drop_packets/test_configurable_drop_counters.py
gnmi/test_gnmi_countersdb.py
snmp/test_snmp_queue_counters.py
test_posttest.py
```

#### Any platform specific information?
Broadcom

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
