### PR TITLE
[vpp]: Handle port RIF before LAG member removal

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1167,11 +1167,11 @@ namespace saivs
             std::shared_ptr<std::thread> m_vpp_thread;
 
         private: // VPP
-	    // m_lag_bond_map and m_egress_disabled_lag_member_ports are only accessed on
-	    // the LAG create/set/remove path, which the VS layer serializes through a
-	    // single queue, so they require no additional locking.
+	    // These LAG maps and sets are only accessed on the serialized VS object
+	    // create/set/remove path, so they require no additional locking.
 	    std::map<sai_object_id_t, platform_bond_info_t> m_lag_bond_map;
 	    std::set<sai_object_id_t> m_egress_disabled_lag_member_ports;
+	    std::set<sai_object_id_t> m_rif_detached_lag_member_ports;
 
             static int currentMaxInstance;
 

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1490,15 +1490,21 @@ sai_status_t SwitchVpp::removeLagMember(
     // detach to avoid acting on a non-member; otherwise detach it from the bond now.
     sai_object_id_t port_oid = SAI_NULL_OBJECT_ID;
     bool egress_disabled = false;
+    bool rif_detached = false;
 
     if (get_lag_member_port(lag_member_oid, port_oid) == SAI_STATUS_SUCCESS)
     {
         egress_disabled = m_egress_disabled_lag_member_ports.count(port_oid) > 0;
+        rif_detached = m_rif_detached_lag_member_ports.count(port_oid) > 0;
     }
 
     if (egress_disabled)
     {
         m_egress_disabled_lag_member_ports.erase(port_oid);
+    }
+    else if (rif_detached)
+    {
+        m_rif_detached_lag_member_ports.erase(port_oid);
     }
     else
     {

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1565,6 +1565,39 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
 
         return SAI_STATUS_FAILURE;
     }
+
+    if (ot == SAI_OBJECT_TYPE_PORT)
+    {
+        auto object_hash_it = m_objectHash.find(SAI_OBJECT_TYPE_LAG_MEMBER);
+
+        if (object_hash_it != m_objectHash.end())
+        {
+            for (const auto& lag_member : object_hash_it->second)
+            {
+                sai_object_id_t lag_member_oid;
+                sai_deserialize_object_id(lag_member.first, lag_member_oid);
+
+                sai_object_id_t lag_member_port_oid;
+                if (get_lag_member_port(lag_member_oid, lag_member_port_oid) != SAI_STATUS_SUCCESS ||
+                    lag_member_port_oid != obj_id)
+                {
+                    continue;
+                }
+
+                SWSS_LOG_NOTICE(
+                        "Detach port %s from VPP LAG member %s before creating its router interface",
+                        sai_serialize_object_id(obj_id).c_str(),
+                        lag_member.first.c_str());
+                if (m_egress_disabled_lag_member_ports.count(obj_id) == 0)
+                {
+                    CHECK_STATUS_QUIET(vpp_remove_lag_member(lag_member_oid));
+                    m_rif_detached_lag_member_ports.insert(obj_id);
+                }
+                break;
+            }
+        }
+    }
+
     auto attr_vlan_id = sai_metadata_get_attr_by_id(SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID, attr_count, attr_list);
 
     uint16_t vlan_id = 0;


### PR DESCRIPTION
### Description of PR
Summary:
Handle out-of-order VPP SAI operations where a physical-port router interface is created before the delayed LAG member removal is processed.


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

`arp/test_neighbor_mac.py::TestNeighborMac::testNeighborMac[0]` is flaky on the `t1-lag-vpp` topology. Below is the error message we have been observing: 
```
failed on setup with:

Failed to ping DUT interface 20.0.0.1
from PTF IP 20.0.0.2 within 30 seconds

PING 20.0.0.1 (20.0.0.1) from 20.0.0.2:
3 packets transmitted, 0 received,
100% packet loss
```

The test removes `Ethernet0` from a PortChannel and immediately creates a routed interface on the same physical port.

Failure logs and a deterministic local reproduction show that ConfigDB and Linux can already contain `20.0.0.1/24` while VPP has not completed the LAG-to-routed transition. PTF then fails with `Destination Host Unreachable`.

The same ping succeeds after syncd/VPP catches up, confirming this is a backend ordering issue rather than a PTF configuration failure.

#### How did you do it?

When a physical-port router interface is created, the VPP SAI implementation checks whether the port still has an existing LAG member object.

If it does, the implementation synchronously detaches the physical port from the VPP bond before creating the router interface.

It records the early detach so the delayed normal LAG member removal can remove the SAI object without attempting to detach the VPP member twice. So post fix, the resulting order should look like: 

```
Router-interface request arrives
        ↓
Is Ethernet0 still recorded as a LAG member?
        ↓ yes
Detach Ethernet0 from VPP bond
        ↓
Record the early detach
        ↓
Create routed interface
        ↓
Delayed LAG removal arrives
        ↓
Skip duplicate detach and delete the SAI object 
```

This handles the observed out-of-order operation stream without adding sleeps or longer PTF retries.

#### How did you verify/test it?

- Reproduced the failure on `vms-kvm-vpp-t1-lag` by delaying syncd/VPP processing.
- Confirmed ConfigDB and Linux contained `20.0.0.1/24` while PTF ping failed with `Destination Host Unreachable`.
- Confirmed the same ping recovered after VPP completed the transition.
#### Any platform specific information?

VPP only. Other SAI backends are unaffected.

### Documentation

N/A
