### PR TITLE
syncd: support cisco ASIC name

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -713,7 +713,7 @@ config_syncd()
 
     cleanup_stale_flow_dump_files
 
-    if [ "$SONIC_ASIC_TYPE" == "cisco-8000" ]; then
+    if [ "$SONIC_ASIC_TYPE" == "cisco-8000" ] || [ "$SONIC_ASIC_TYPE" == "cisco" ]; then
         config_syncd_cisco_8000
     elif [ "$SONIC_ASIC_TYPE" == "broadcom" ]; then
         config_syncd_bcm


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Support the `cisco` ASIC name as an alias for the existing Cisco-8000 syncd initialization path.

Fixes # (issue)
N/A

Related: sonic-net/sonic-buildimage#27281

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

The buildimage platform change uses the shorter `cisco` ASIC name, while sairedis still needs to run the existing Cisco-8000 syncd initialization path.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

Allow `config_syncd()` to call `config_syncd_cisco_8000` when `SONIC_ASIC_TYPE` is either `cisco-8000` or `cisco`.

#### How did you verify/test it?

- `git diff --check`
- `bash -n syncd/scripts/syncd_init_common.sh`

#### Any platform specific information?

Cisco platforms using `asic_type: cisco`.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
