### PR TITLE
[vpp] Add MPLS data-plane support (INSEG + IP-route push)

### DIFF
--- a/vslib/Makefile.am
+++ b/vslib/Makefile.am
@@ -92,6 +92,7 @@ libSaiVS_a_SOURCES +=\
 					  vpp/SwitchVppSRv6.cpp \
 					  vpp/SwitchVppMirror.cpp \
 					  vpp/SwitchVppSflow.cpp \
+					  vpp/SwitchVppMpls.cpp \
 					  vpp/TunnelManager.cpp \
 					  vpp/SaiVppLog.cpp \
 					  vpp/vppxlate/SaiVppXlate.c \

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1415,6 +1415,11 @@ sai_status_t SwitchVpp::create(
         return status;
     }
 
+    if (object_type == SAI_OBJECT_TYPE_INSEG_ENTRY)
+    {
+        return addMplsRoute(serializedObjectId, switch_id, attr_count, attr_list);
+    }
+
     if (object_type == SAI_OBJECT_TYPE_MY_SID_ENTRY)
     {
         sai_status_t status = m_tunnel_mgr_srv6.create_my_sid_entry(serializedObjectId, switch_id, attr_count, attr_list);
@@ -1840,6 +1845,11 @@ sai_status_t SwitchVpp::remove(
         // by counter OID) need cleanup here.
         m_routeCounterStatsBaseMap.erase(objectId);
         m_routeCounterStatsCarryMap.erase(objectId);
+    }
+
+    if (object_type == SAI_OBJECT_TYPE_INSEG_ENTRY)
+    {
+        return removeMplsRoute(serializedObjectId);
     }
 
     if (object_type == SAI_OBJECT_TYPE_MY_SID_ENTRY)

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -788,6 +788,11 @@ namespace saivs
             sai_status_t fillMplsNexthop(
                     _In_ const SaiObject *nh_obj,
                     _Out_ vpp_mpls_nexthop_t *vnh);
+            void getOutsegTtl(
+                    _In_ const SaiObject *nh_obj,
+                    _Out_ uint8_t *ttl,
+                    _Out_ uint8_t *exp,
+                    _Out_ uint8_t *is_uniform);
             sai_status_t ensureMplsTable();
 
             sai_status_t IpRouteNexthopEntry(

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -781,7 +781,7 @@ namespace saivs
                     _In_ const sai_attribute_t *attr_list);
             sai_status_t removeMplsRoute(
                     _In_ const std::string &serializedObjectId);
-            sai_status_t MplsRouteAddRemove(
+            sai_status_t mplsRouteAddRemove(
                     _In_ const SaiObject *inseg_obj,
                     _In_ const std::string &serializedObjectId,
                     _In_ bool is_add);

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -774,6 +774,22 @@ namespace saivs
             sai_status_t removeIpRoute(
                     _In_ const std::string &serializedObjectId);
 
+            sai_status_t addMplsRoute(
+                    _In_ const std::string &serializedObjectId,
+                    _In_ sai_object_id_t switch_id,
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list);
+            sai_status_t removeMplsRoute(
+                    _In_ const std::string &serializedObjectId);
+            sai_status_t MplsRouteAddRemove(
+                    _In_ const SaiObject *inseg_obj,
+                    _In_ const std::string &serializedObjectId,
+                    _In_ bool is_add);
+            sai_status_t fillMplsNexthop(
+                    _In_ const SaiObject *nh_obj,
+                    _Out_ vpp_mpls_nexthop_t *vnh);
+            sai_status_t ensureMplsTable();
+
             sai_status_t IpRouteNexthopEntry(
                     _In_ uint32_t attr_count,
                     _In_ const sai_attribute_t *attr_list,
@@ -1325,6 +1341,7 @@ namespace saivs
             // SRv6 object tracking for CRM
             constexpr static const int m_maxMySidEntries = 1000;
             uint32_t m_srv6_my_sid_count = 0;
+            bool m_mpls_table_created = false;
 
             std::shared_ptr<RealObjectIdManager> m_realObjectIdManager;
 

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -207,13 +207,20 @@ sai_status_t SwitchVpp::MplsRouteAddRemove(
     route->label = inseg_entry.label;
     route->is_multipath = false;
     route->nexthop_cnt = 1;
-    route->eos_proto_af = AF_INET;
 
     sai_status_t status = fillMplsNexthop(nh_obj.get(), &route->nexthop[0]);
     if (status != SAI_STATUS_SUCCESS) {
         free(route);
         return status;
     }
+
+    /*
+     * Protocol of the payload exposed once the end-of-stack label is popped.
+     * The SAI INSEG entry does not carry it, so derive it from the resolved
+     * next hop's address family. Must run after fillMplsNexthop() has populated
+     * the address.
+     */
+    route->eos_proto_af = route->nexthop[0].addr.sa_family;
 
     bool has_outlabels = (route->nexthop[0].n_labels > 0);
 

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -1,0 +1,279 @@
+/*
+ * VPP MPLS backend for SAI INSEG (MPLS in-segment / local label) entries.
+ * Issue: sonic-buildimage#25782 - enable MPLS data plane testing on VPP.
+ *
+ * Translates SAI_OBJECT_TYPE_INSEG_ENTRY into VPP MPLS FIB programming via
+ * mpls_route_add_del(). Pop (IP next-hop, no out-labels) and swap/push
+ * (SAI_NEXT_HOP_TYPE_MPLS next-hop carrying an out-label stack) are supported.
+ */
+#include "SwitchVpp.h"
+#include "SwitchVppUtils.h"
+
+#include "meta/sai_serialize.h"
+
+#include "swss/logger.h"
+
+#include "vppxlate/SaiVppXlate.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <cstdlib>
+#include <cstring>
+
+using namespace saivs;
+
+/* VPP MPLS FIB table used for all SONiC in-segment entries. */
+#define MPLS_TABLE_ID 0
+/* Reserved MPLS implicit-null label (RFC 3032): pop and forward on the payload. */
+#define MPLS_IMPLICIT_NULL_LABEL 3
+/* Default TTL for an imposed label; SAI carries no per-outsegment TTL here. */
+#define MPLS_DEFAULT_OUT_TTL 64
+
+sai_status_t SwitchVpp::ensureMplsTable()
+{
+    SWSS_LOG_ENTER();
+
+    if (m_mpls_table_created) {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    int ret = mpls_table_add_del(MPLS_TABLE_ID, true);
+    if (ret != 0) {
+        SWSS_LOG_ERROR("Failed to create VPP MPLS table %u: %d", MPLS_TABLE_ID, ret);
+        return SAI_STATUS_FAILURE;
+    }
+
+    m_mpls_table_created = true;
+    SWSS_LOG_NOTICE("Created VPP MPLS table %u", MPLS_TABLE_ID);
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::fillMplsNexthop(
+        _In_ const SaiObject *nh_obj,
+        _Out_ vpp_mpls_nexthop_t *vnh)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+
+    memset(vnh, 0, sizeof(*vnh));
+    vnh->sw_if_index = (uint32_t)~0;   /* let VPP resolve egress recursively by IP */
+    vnh->hwif_name = NULL;
+    vnh->weight = 1;
+    vnh->preference = 0;
+    vnh->type = VPP_NEXTHOP_NORMAL;
+    vnh->n_labels = 0;
+
+    attr.id = SAI_NEXT_HOP_ATTR_TYPE;
+    CHECK_STATUS_W_MSG(nh_obj->get_attr(attr), "MPLS path nexthop missing TYPE");
+    int32_t nh_type = attr.value.s32;
+
+    if (nh_type != SAI_NEXT_HOP_TYPE_IP && nh_type != SAI_NEXT_HOP_TYPE_MPLS) {
+        SWSS_LOG_ERROR("Unsupported MPLS path nexthop type %d", nh_type);
+        return SAI_STATUS_NOT_IMPLEMENTED;
+    }
+
+    attr.id = SAI_NEXT_HOP_ATTR_IP;
+    CHECK_STATUS_W_MSG(nh_obj->get_attr(attr), "MPLS path nexthop missing IP");
+    sai_ip_address_t_to_vpp_ip_addr_t(attr.value.ipaddr, vnh->addr);
+
+    if (nh_type == SAI_NEXT_HOP_TYPE_MPLS) {
+        /*
+         * LABELSTACK is a list attribute: the caller must supply the output
+         * buffer (list pointer + count) before calling get_attr, otherwise the
+         * read fails and the out labels are silently dropped (turning a
+         * swap/push into a bare pop).
+         */
+        uint32_t label_buf[VPP_MPLS_MAX_LABELS];
+        attr.id = SAI_NEXT_HOP_ATTR_LABELSTACK;
+        attr.value.u32list.count = VPP_MPLS_MAX_LABELS;
+        attr.value.u32list.list = label_buf;
+        if (nh_obj->get_attr(attr) == SAI_STATUS_SUCCESS && attr.value.u32list.count > 0) {
+            uint32_t cnt = attr.value.u32list.count;
+            if (cnt > VPP_MPLS_MAX_LABELS) {
+                cnt = VPP_MPLS_MAX_LABELS;
+            }
+            vnh->n_labels = (uint8_t)cnt;
+            for (uint32_t i = 0; i < cnt; i++) {
+                vnh->label_stack[i].label = attr.value.u32list.list[i];
+                vnh->label_stack[i].ttl = MPLS_DEFAULT_OUT_TTL;
+                vnh->label_stack[i].exp = 0;
+                vnh->label_stack[i].is_uniform = 1;
+            }
+        }
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::MplsRouteAddRemove(
+        _In_ const SaiObject *inseg_obj,
+        _In_ const std::string &serializedObjectId,
+        _In_ bool is_add)
+{
+    SWSS_LOG_ENTER();
+
+    sai_inseg_entry_t inseg_entry;
+    sai_deserialize_inseg_entry(serializedObjectId, inseg_entry);
+
+    sai_attribute_t attr;
+    int32_t action = SAI_PACKET_ACTION_FORWARD;
+    attr.id = SAI_INSEG_ENTRY_ATTR_PACKET_ACTION;
+    if (inseg_obj->get_attr(attr) == SAI_STATUS_SUCCESS) {
+        action = attr.value.s32;
+    }
+    if (action != SAI_PACKET_ACTION_FORWARD) {
+        SWSS_LOG_NOTICE("Ignoring inseg label %u: packet action %d is not forward",
+                        inseg_entry.label, action);
+        return SAI_STATUS_SUCCESS;
+    }
+
+    auto nh_obj = inseg_obj->get_linked_object(SAI_OBJECT_TYPE_NEXT_HOP,
+                                               SAI_INSEG_ENTRY_ATTR_NEXT_HOP_ID);
+    if (!nh_obj) {
+        SWSS_LOG_NOTICE("Ignoring inseg label %u: no resolvable nexthop", inseg_entry.label);
+        return SAI_STATUS_SUCCESS;
+    }
+
+    CHECK_STATUS(ensureMplsTable());
+
+    vpp_mpls_route_t *route = (vpp_mpls_route_t *)
+        calloc(1, sizeof(vpp_mpls_route_t) + sizeof(vpp_mpls_nexthop_t));
+    if (!route) {
+        return SAI_STATUS_FAILURE;
+    }
+    route->table_id = MPLS_TABLE_ID;
+    route->label = inseg_entry.label;
+    route->is_multipath = false;
+    route->nexthop_cnt = 1;
+    route->eos_proto_af = AF_INET;
+
+    sai_status_t status = fillMplsNexthop(nh_obj.get(), &route->nexthop[0]);
+    if (status != SAI_STATUS_SUCCESS) {
+        free(route);
+        return status;
+    }
+
+    bool has_outlabels = (route->nexthop[0].n_labels > 0);
+
+    /*
+     * Resolve the next hop's router interface to its VPP egress hwif so the
+     * path is programmed as *attached* rather than recursive. This is required
+     * for both forwarding cases:
+     *   - pop  (disposition): VPP only inserts the MPLS disposition (and thus
+     *     honours the uniform LSP mode) for an attached next hop; a recursive
+     *     next hop collapses to a plain IP forward and ignores the mode.
+     *   - swap/push (imposition): a recursive labelled path fails to resolve
+     *     and the packet is dropped at the MPLS DROP DPO.
+     * If resolution fails we fall back to the recursive (~0) path.
+     */
+    std::string egress_hwif;
+    {
+        sai_attribute_t rif_attr;
+        rif_attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
+        if (nh_obj->get_attr(rif_attr) == SAI_STATUS_SUCCESS) {
+            sai_object_id_t rif_id = rif_attr.value.oid;
+            sai_attribute_t port_attr;
+            port_attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
+            if (get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &port_attr) == SAI_STATUS_SUCCESS &&
+                vpp_get_hwif_name(port_attr.value.oid, 0, egress_hwif)) {
+                route->nexthop[0].hwif_name = egress_hwif.c_str();
+            }
+        }
+    }
+
+    if (!has_outlabels) {
+        /*
+         * Pop/disposition case (no out labels). Inject an implicit-null out
+         * label with uniform LSP mode so VPP builds a UNIFORM-mode MPLS
+         * disposition: the popped inner IP TTL is derived from the popped MPLS
+         * TTL (mpls_ttl - 1). This matches the SAI default POP TTL mode
+         * (SAI_INSEG_ENTRY_POP_TTL_MODE_UNIFORM) and typical hardware. Without
+         * it VPP defaults the disposition to PIPE (inner TTL left untouched and
+         * only decremented once by the IP forwarding stage).
+         */
+        route->nexthop[0].n_labels = 1;
+        route->nexthop[0].label_stack[0].label = MPLS_IMPLICIT_NULL_LABEL;
+        route->nexthop[0].label_stack[0].ttl = 0;
+        route->nexthop[0].label_stack[0].exp = 0;
+        route->nexthop[0].label_stack[0].is_uniform = 1;
+    }
+
+    /*
+     * The SAI INSEG entry carries a single local label with no End-of-Stack
+     * qualifier, but the VPP MPLS FIB is keyed by {label, eos}. Always program
+     * the eos=1 entry (single-label / disposition case). For swap/push (out
+     * labels present) also program eos=0 so a non-bottom label in a stack is
+     * handled (e.g. test_swap_labelstack).
+     */
+    uint8_t eos_list[2];
+    int n_eos = 0;
+    if (has_outlabels) {
+        eos_list[n_eos++] = 0;
+    }
+    eos_list[n_eos++] = 1;
+
+    int ret = 0;
+    for (int e = 0; e < n_eos; e++) {
+        route->eos = eos_list[e];
+        ret = mpls_route_add_del(route, is_add);
+        if (ret != 0) {
+            break;
+        }
+    }
+
+    SWSS_LOG_NOTICE("%s inseg label %u out_labels %u status %d",
+                    (is_add ? "Add" : "Remove"), inseg_entry.label,
+                    route->nexthop[0].n_labels, ret);
+
+    free(route);
+
+    return (ret == 0) ? SAI_STATUS_SUCCESS : SAI_STATUS_FAILURE;
+}
+
+sai_status_t SwitchVpp::addMplsRoute(
+        _In_ const std::string &serializedObjectId,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    SaiCachedObject inseg_obj(this, SAI_OBJECT_TYPE_INSEG_ENTRY, serializedObjectId, attr_count, attr_list);
+
+    bool route_programmed = false;
+
+    if (is_ip_nbr_active() == true) {
+        CHECK_STATUS(MplsRouteAddRemove(&inseg_obj, serializedObjectId, true));
+        route_programmed = true;
+    }
+
+    sai_status_t status = create_internal(SAI_OBJECT_TYPE_INSEG_ENTRY, serializedObjectId, switch_id, attr_count, attr_list);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        // The entry was not committed, so undo the VPP programming to keep the
+        // MPLS FIB in sync with the SAI object database.
+        if (route_programmed) {
+            MplsRouteAddRemove(&inseg_obj, serializedObjectId, false);
+        }
+        return status;
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchVpp::removeMplsRoute(
+        _In_ const std::string &serializedObjectId)
+{
+    SWSS_LOG_ENTER();
+
+    auto inseg_obj = get_sai_object(SAI_OBJECT_TYPE_INSEG_ENTRY, serializedObjectId);
+    if (inseg_obj && is_ip_nbr_active() == true) {
+        CHECK_STATUS(MplsRouteAddRemove(inseg_obj.get(), serializedObjectId, false));
+    }
+
+    CHECK_STATUS(remove_internal(SAI_OBJECT_TYPE_INSEG_ENTRY, serializedObjectId));
+
+    return SAI_STATUS_SUCCESS;
+}

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -253,18 +253,30 @@ sai_status_t SwitchVpp::MplsRouteAddRemove(
     if (!has_outlabels) {
         /*
          * Pop/disposition case (no out labels). Inject an implicit-null out
-         * label with uniform LSP mode so VPP builds a UNIFORM-mode MPLS
-         * disposition: the popped inner IP TTL is derived from the popped MPLS
-         * TTL (mpls_ttl - 1). This matches the SAI default POP TTL mode
-         * (SAI_INSEG_ENTRY_POP_TTL_MODE_UNIFORM) and typical hardware. Without
-         * it VPP defaults the disposition to PIPE (inner TTL left untouched and
-         * only decremented once by the IP forwarding stage).
+         * label so VPP builds an MPLS disposition rather than leaving the
+         * default. The LSP mode follows SAI_INSEG_ENTRY_ATTR_POP_TTL_MODE:
+         *
+         *   UNIFORM (SAI default) -> is_uniform=1: the popped inner IP TTL is
+         *       derived from the MPLS TTL (mpls_ttl - 1), matching typical
+         *       hardware.
+         *   PIPE                  -> is_uniform=0: the inner TTL is left
+         *       untouched and only decremented once by the IP stage.
+         *
+         * Without the injected label VPP defaults the disposition to PIPE.
          */
+        int32_t pop_ttl_mode = SAI_INSEG_ENTRY_POP_TTL_MODE_UNIFORM;
+        sai_attribute_t ttl_attr;
+        ttl_attr.id = SAI_INSEG_ENTRY_ATTR_POP_TTL_MODE;
+        if (inseg_obj->get_attr(ttl_attr) == SAI_STATUS_SUCCESS) {
+            pop_ttl_mode = ttl_attr.value.s32;
+        }
+
         route->nexthop[0].n_labels = 1;
         route->nexthop[0].label_stack[0].label = MPLS_IMPLICIT_NULL_LABEL;
         route->nexthop[0].label_stack[0].ttl = 0;
         route->nexthop[0].label_stack[0].exp = 0;
-        route->nexthop[0].label_stack[0].is_uniform = 1;
+        route->nexthop[0].label_stack[0].is_uniform =
+            (pop_ttl_mode == SAI_INSEG_ENTRY_POP_TTL_MODE_PIPE) ? 0 : 1;
     }
 
     /*

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -251,9 +251,14 @@ sai_status_t SwitchVpp::MplsRouteAddRemove(
         }
     }
 
+    /*
+     * Report the SAI-visible out-label count, not route->nexthop[0].n_labels:
+     * the pop case injects an implicit-null label and sets n_labels to 1, which
+     * would otherwise log a pop as having one out-label.
+     */
     SWSS_LOG_NOTICE("%s inseg label %u out_labels %u status %d",
                     (is_add ? "Add" : "Remove"), inseg_entry.label,
-                    route->nexthop[0].n_labels, ret);
+                    (has_outlabels ? route->nexthop[0].n_labels : 0), ret);
 
     free(route);
 

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -26,8 +26,6 @@ using namespace saivs;
 #define MPLS_TABLE_ID 0
 /* Reserved MPLS implicit-null label (RFC 3032): pop and forward on the payload. */
 #define MPLS_IMPLICIT_NULL_LABEL 3
-/* Default TTL for an imposed label; SAI carries no per-outsegment TTL here. */
-#define MPLS_DEFAULT_OUT_TTL 64
 
 sai_status_t SwitchVpp::ensureMplsTable()
 {

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -27,6 +27,48 @@ using namespace saivs;
 /* Reserved MPLS implicit-null label (RFC 3032): pop and forward on the payload. */
 #define MPLS_IMPLICIT_NULL_LABEL 3
 
+void SwitchVpp::getOutsegTtl(
+        _In_ const SaiObject *nh_obj,
+        _Out_ uint8_t *ttl,
+        _Out_ uint8_t *exp,
+        _Out_ uint8_t *is_uniform)
+{
+    SWSS_LOG_ENTER();
+
+    /*
+     * SAI models the imposed-label treatment per next hop. Both attributes
+     * default to UNIFORM, and the explicit TTL/EXP values are only valid in
+     * PIPE mode (@validonly in sainexthop.h), so read the mode first and only
+     * take the value when it applies. Attributes that were never set come back
+     * as ITEM_NOT_FOUND, which leaves the SAI defaults in place.
+     */
+    sai_attribute_t attr;
+
+    *is_uniform = 1;
+    *ttl = MPLS_DEFAULT_OUT_TTL;
+    *exp = 0;
+
+    attr.id = SAI_NEXT_HOP_ATTR_OUTSEG_TTL_MODE;
+    if (nh_obj->get_attr(attr) == SAI_STATUS_SUCCESS &&
+        attr.value.s32 == SAI_OUTSEG_TTL_MODE_PIPE) {
+        *is_uniform = 0;
+
+        attr.id = SAI_NEXT_HOP_ATTR_OUTSEG_TTL_VALUE;
+        if (nh_obj->get_attr(attr) == SAI_STATUS_SUCCESS) {
+            *ttl = attr.value.u8;
+        }
+    }
+
+    attr.id = SAI_NEXT_HOP_ATTR_OUTSEG_EXP_MODE;
+    if (nh_obj->get_attr(attr) == SAI_STATUS_SUCCESS &&
+        attr.value.s32 == SAI_OUTSEG_EXP_MODE_PIPE) {
+        attr.id = SAI_NEXT_HOP_ATTR_OUTSEG_EXP_VALUE;
+        if (nh_obj->get_attr(attr) == SAI_STATUS_SUCCESS) {
+            *exp = attr.value.u8;
+        }
+    }
+}
+
 sai_status_t SwitchVpp::ensureMplsTable()
 {
     SWSS_LOG_ENTER();
@@ -108,12 +150,16 @@ sai_status_t SwitchVpp::fillMplsNexthop(
          */
         if (label_status == SAI_STATUS_SUCCESS && attr.value.u32list.count > 0) {
             uint32_t cnt = attr.value.u32list.count;
+            uint8_t out_ttl, out_exp, out_is_uniform;
+
+            getOutsegTtl(nh_obj, &out_ttl, &out_exp, &out_is_uniform);
+
             vnh->n_labels = (uint8_t)cnt;
             for (uint32_t i = 0; i < cnt; i++) {
                 vnh->label_stack[i].label = attr.value.u32list.list[i];
-                vnh->label_stack[i].ttl = MPLS_DEFAULT_OUT_TTL;
-                vnh->label_stack[i].exp = 0;
-                vnh->label_stack[i].is_uniform = 1;
+                vnh->label_stack[i].ttl = out_ttl;
+                vnh->label_stack[i].exp = out_exp;
+                vnh->label_stack[i].is_uniform = out_is_uniform;
             }
         }
     }

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -89,11 +89,27 @@ sai_status_t SwitchVpp::fillMplsNexthop(
         attr.id = SAI_NEXT_HOP_ATTR_LABELSTACK;
         attr.value.u32list.count = VPP_MPLS_MAX_LABELS;
         attr.value.u32list.list = label_buf;
-        if (nh_obj->get_attr(attr) == SAI_STATUS_SUCCESS && attr.value.u32list.count > 0) {
+
+        sai_status_t label_status = nh_obj->get_attr(attr);
+
+        /*
+         * A stack deeper than the buffer yields SAI_STATUS_BUFFER_OVERFLOW with
+         * count set to the required size and nothing copied. Fail explicitly:
+         * falling through with zero labels would turn a swap/push into a bare
+         * pop and silently misforward traffic.
+         */
+        if (label_status == SAI_STATUS_BUFFER_OVERFLOW) {
+            SWSS_LOG_ERROR("MPLS out-label stack of %u labels exceeds maximum %u",
+                    attr.value.u32list.count, VPP_MPLS_MAX_LABELS);
+            return SAI_STATUS_NOT_SUPPORTED;
+        }
+
+        /*
+         * Any other failure means the nexthop carries no label stack, which is
+         * a valid pop/disposition path.
+         */
+        if (label_status == SAI_STATUS_SUCCESS && attr.value.u32list.count > 0) {
             uint32_t cnt = attr.value.u32list.count;
-            if (cnt > VPP_MPLS_MAX_LABELS) {
-                cnt = VPP_MPLS_MAX_LABELS;
-            }
             vnh->n_labels = (uint8_t)cnt;
             for (uint32_t i = 0; i < cnt; i++) {
                 vnh->label_stack[i].label = attr.value.u32list.list[i];
@@ -215,11 +231,25 @@ sai_status_t SwitchVpp::MplsRouteAddRemove(
     eos_list[n_eos++] = 1;
 
     int ret = 0;
+    int programmed = 0;
     for (int e = 0; e < n_eos; e++) {
         route->eos = eos_list[e];
         ret = mpls_route_add_del(route, is_add);
         if (ret != 0) {
             break;
+        }
+        programmed++;
+    }
+
+    /*
+     * A multi-EOS add that fails part way through would leave an orphaned FIB
+     * entry behind that no SAI object refers to, because the caller aborts
+     * before recording the route. Undo the entries that did get programmed.
+     */
+    if (ret != 0 && is_add) {
+        for (int e = 0; e < programmed; e++) {
+            route->eos = eos_list[e];
+            mpls_route_add_del(route, false);
         }
     }
 

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -167,7 +167,7 @@ sai_status_t SwitchVpp::fillMplsNexthop(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t SwitchVpp::MplsRouteAddRemove(
+sai_status_t SwitchVpp::mplsRouteAddRemove(
         _In_ const SaiObject *inseg_obj,
         _In_ const std::string &serializedObjectId,
         _In_ bool is_add)
@@ -343,7 +343,7 @@ sai_status_t SwitchVpp::addMplsRoute(
     bool route_programmed = false;
 
     if (is_ip_nbr_active() == true) {
-        CHECK_STATUS(MplsRouteAddRemove(&inseg_obj, serializedObjectId, true));
+        CHECK_STATUS(mplsRouteAddRemove(&inseg_obj, serializedObjectId, true));
         route_programmed = true;
     }
 
@@ -353,7 +353,7 @@ sai_status_t SwitchVpp::addMplsRoute(
         // The entry was not committed, so undo the VPP programming to keep the
         // MPLS FIB in sync with the SAI object database.
         if (route_programmed) {
-            MplsRouteAddRemove(&inseg_obj, serializedObjectId, false);
+            mplsRouteAddRemove(&inseg_obj, serializedObjectId, false);
         }
         return status;
     }
@@ -368,7 +368,7 @@ sai_status_t SwitchVpp::removeMplsRoute(
 
     auto inseg_obj = get_sai_object(SAI_OBJECT_TYPE_INSEG_ENTRY, serializedObjectId);
     if (inseg_obj && is_ip_nbr_active() == true) {
-        CHECK_STATUS(MplsRouteAddRemove(inseg_obj.get(), serializedObjectId, false));
+        CHECK_STATUS(mplsRouteAddRemove(inseg_obj.get(), serializedObjectId, false));
     }
 
     CHECK_STATUS(remove_internal(SAI_OBJECT_TYPE_INSEG_ENTRY, serializedObjectId));

--- a/vslib/vpp/SwitchVppNexthop.cpp
+++ b/vslib/vpp/SwitchVppNexthop.cpp
@@ -209,10 +209,23 @@ SwitchVpp::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_object_id_t
             attr.id = SAI_NEXT_HOP_ATTR_LABELSTACK;
             attr.value.u32list.count = VPP_MPLS_MAX_LABELS;
             attr.value.u32list.list = lbuf;
-            if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS &&
-                attr.value.u32list.count > 0) {
-                uint32_t cnt = attr.value.u32list.count > VPP_MPLS_MAX_LABELS ?
-                               VPP_MPLS_MAX_LABELS : attr.value.u32list.count;
+
+            sai_status_t label_status = get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr);
+
+            /*
+             * A stack deeper than the buffer yields SAI_STATUS_BUFFER_OVERFLOW
+             * with count set to the required size and nothing copied. Fail
+             * explicitly rather than programming a bare IP nexthop, which would
+             * silently drop the imposed labels.
+             */
+            if (label_status == SAI_STATUS_BUFFER_OVERFLOW) {
+                SWSS_LOG_ERROR("MPLS out-label stack of %u labels exceeds maximum %u",
+                        attr.value.u32list.count, VPP_MPLS_MAX_LABELS);
+                return SAI_STATUS_NOT_SUPPORTED;
+            }
+
+            if (label_status == SAI_STATUS_SUCCESS && attr.value.u32list.count > 0) {
+                uint32_t cnt = attr.value.u32list.count;
                 nxt_grp_member->n_labels = (uint8_t)cnt;
                 for (uint32_t li = 0; li < cnt; li++) {
                     nxt_grp_member->label_stack[li] = attr.value.u32list.list[li];

--- a/vslib/vpp/SwitchVppNexthop.cpp
+++ b/vslib/vpp/SwitchVppNexthop.cpp
@@ -190,15 +190,18 @@ SwitchVpp::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_object_id_t
     nxt_grp_member->sw_if_index = ~0;
     nxt_grp_member->n_labels = 0;
 
-    bool have_rif = false;
+    std::shared_ptr<SaiDBObject> rif_obj;
 
     switch (next_hop_type) {
     case SAI_NEXT_HOP_TYPE_MPLS:
     case SAI_NEXT_HOP_TYPE_IP:
-        attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
-        have_rif = (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS);
-        if (have_rif) {
-            nxt_grp_member->rif_oid = attr.value.oid;
+        rif_obj = nh_obj->get_linked_object(SAI_OBJECT_TYPE_ROUTER_INTERFACE,
+                                            SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID);
+        if (rif_obj) {
+            attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
+            if (nh_obj->get_attr(attr) == SAI_STATUS_SUCCESS) {
+                nxt_grp_member->rif_oid = attr.value.oid;
+            }
         }
         if (next_hop_type == SAI_NEXT_HOP_TYPE_MPLS) {
             /*
@@ -239,8 +242,8 @@ SwitchVpp::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_object_id_t
             std::string mpls_hwif;
             sai_attribute_t port_attr;
             port_attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
-            if (have_rif &&
-                get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, nxt_grp_member->rif_oid, 1, &port_attr) == SAI_STATUS_SUCCESS &&
+            if (rif_obj &&
+                rif_obj->get_attr(port_attr) == SAI_STATUS_SUCCESS &&
                 vpp_get_hwif_name(port_attr.value.oid, 0, mpls_hwif)) {
                 int idx = get_sw_if_idx(mpls_hwif.c_str());
                 if (idx >= 0) {

--- a/vslib/vpp/SwitchVppNexthop.cpp
+++ b/vslib/vpp/SwitchVppNexthop.cpp
@@ -229,6 +229,11 @@ SwitchVpp::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_object_id_t
 
             if (label_status == SAI_STATUS_SUCCESS && attr.value.u32list.count > 0) {
                 uint32_t cnt = attr.value.u32list.count;
+
+                getOutsegTtl(nh_obj.get(), &nxt_grp_member->out_ttl,
+                             &nxt_grp_member->out_exp,
+                             &nxt_grp_member->out_is_uniform);
+
                 nxt_grp_member->n_labels = (uint8_t)cnt;
                 for (uint32_t li = 0; li < cnt; li++) {
                     nxt_grp_member->label_stack[li] = attr.value.u32list.list[li];

--- a/vslib/vpp/SwitchVppNexthop.cpp
+++ b/vslib/vpp/SwitchVppNexthop.cpp
@@ -174,7 +174,8 @@ SwitchVpp::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_object_id_t
     attr.id = SAI_NEXT_HOP_ATTR_TYPE;
     CHECK_STATUS_QUIET(nh_obj->get_mandatory_attr(attr));
     int32_t next_hop_type = attr.value.s32;
-    if (next_hop_type != SAI_NEXT_HOP_TYPE_IP && next_hop_type != SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP) {
+    if (next_hop_type != SAI_NEXT_HOP_TYPE_IP && next_hop_type != SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP &&
+        next_hop_type != SAI_NEXT_HOP_TYPE_MPLS) {
         return SAI_STATUS_NOT_IMPLEMENTED;
     }
 
@@ -187,12 +188,52 @@ SwitchVpp::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_object_id_t
     nxt_grp_member->weight = next_hop_weight;
     nxt_grp_member->seq_id = next_hop_sequence;
     nxt_grp_member->sw_if_index = ~0;
+    nxt_grp_member->n_labels = 0;
+
+    bool have_rif = false;
 
     switch (next_hop_type) {
+    case SAI_NEXT_HOP_TYPE_MPLS:
     case SAI_NEXT_HOP_TYPE_IP:
         attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
-        if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS) {
+        have_rif = (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS);
+        if (have_rif) {
             nxt_grp_member->rif_oid = attr.value.oid;
+        }
+        if (next_hop_type == SAI_NEXT_HOP_TYPE_MPLS) {
+            /*
+             * Read the imposed (push) label stack. LABELSTACK is a list
+             * attribute, so the output buffer must be supplied before the get.
+             */
+            uint32_t lbuf[VPP_MPLS_MAX_LABELS];
+            attr.id = SAI_NEXT_HOP_ATTR_LABELSTACK;
+            attr.value.u32list.count = VPP_MPLS_MAX_LABELS;
+            attr.value.u32list.list = lbuf;
+            if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS &&
+                attr.value.u32list.count > 0) {
+                uint32_t cnt = attr.value.u32list.count > VPP_MPLS_MAX_LABELS ?
+                               VPP_MPLS_MAX_LABELS : attr.value.u32list.count;
+                nxt_grp_member->n_labels = (uint8_t)cnt;
+                for (uint32_t li = 0; li < cnt; li++) {
+                    nxt_grp_member->label_stack[li] = attr.value.u32list.list[li];
+                }
+            }
+            /*
+             * Program an attached path (resolve the router interface to its VPP
+             * egress hwif) so VPP actually imposes the label; a recursive
+             * labelled path is dropped at the MPLS DROP DPO.
+             */
+            std::string mpls_hwif;
+            sai_attribute_t port_attr;
+            port_attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
+            if (have_rif &&
+                get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, nxt_grp_member->rif_oid, 1, &port_attr) == SAI_STATUS_SUCCESS &&
+                vpp_get_hwif_name(port_attr.value.oid, 0, mpls_hwif)) {
+                int idx = get_sw_if_idx(mpls_hwif.c_str());
+                if (idx >= 0) {
+                    nxt_grp_member->sw_if_index = (uint32_t)idx;
+                }
+            }
         }
         break;
     case SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP: {

--- a/vslib/vpp/SwitchVppNexthop.h
+++ b/vslib/vpp/SwitchVppNexthop.h
@@ -14,6 +14,10 @@ typedef struct nexthop_grp_member_ {
     uint32_t sw_if_index;
     uint8_t n_labels;
     uint32_t label_stack[VPP_MPLS_MAX_LABELS];
+    /* Imposed-label treatment; SAI carries this per next hop, not per label. */
+    uint8_t out_ttl;
+    uint8_t out_exp;
+    uint8_t out_is_uniform;
 } nexthop_grp_member_t;
 
 typedef struct nexthop_grp_config_ {

--- a/vslib/vpp/SwitchVppNexthop.h
+++ b/vslib/vpp/SwitchVppNexthop.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "vppxlate/SaiVppXlate.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -10,6 +12,8 @@ typedef struct nexthop_grp_member_ {
     uint32_t weight;
     uint32_t seq_id;
     uint32_t sw_if_index;
+    uint8_t n_labels;
+    uint32_t label_stack[VPP_MPLS_MAX_LABELS];
 } nexthop_grp_member_t;
 
 typedef struct nexthop_grp_config_ {

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1947,6 +1947,28 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
         vpp_set_interface_mtu(obj_id, vlan_id, attr_type_mtu->value.u32);
     }
 
+    auto attr_type_mpls = sai_metadata_get_attr_by_id(SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE, attr_count, attr_list);
+
+    if (attr_type_mpls != NULL)
+    {
+        std::string mpls_hwif_name;
+        if (vpp_get_hwif_name(obj_id, vlan_id, mpls_hwif_name))
+        {
+            CHECK_STATUS(ensureMplsTable());
+            int mpls_ret = sw_interface_set_mpls_enable(mpls_hwif_name.c_str(), attr_type_mpls->value.booldata);
+            if (mpls_ret != 0)
+            {
+                SWSS_LOG_ERROR("Failed to %s MPLS on router interface %s: %d",
+                               attr_type_mpls->value.booldata ? "enable" : "disable",
+                               mpls_hwif_name.c_str(), mpls_ret);
+                return SAI_STATUS_FAILURE;
+            }
+            SWSS_LOG_NOTICE("MPLS %s on router interface %s",
+                            attr_type_mpls->value.booldata ? "enabled" : "disabled",
+                            mpls_hwif_name.c_str());
+        }
+    }
+
     bool v4_is_up = false, v6_is_up = false;
 
     auto attr_type_v4 = sai_metadata_get_attr_by_id(SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE, attr_count, attr_list);
@@ -2047,6 +2069,28 @@ sai_status_t SwitchVpp::vpp_update_router_interface(
     if (attr_type_mtu != NULL)
     {
         vpp_set_interface_mtu(obj_id, vlan_id, attr_type_mtu->value.u32);
+    }
+
+    auto attr_type_mpls = sai_metadata_get_attr_by_id(SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE, attr_count, attr_list);
+
+    if (attr_type_mpls != NULL)
+    {
+        std::string mpls_hwif_name;
+        if (vpp_get_hwif_name(obj_id, vlan_id, mpls_hwif_name))
+        {
+            CHECK_STATUS(ensureMplsTable());
+            int mpls_ret = sw_interface_set_mpls_enable(mpls_hwif_name.c_str(), attr_type_mpls->value.booldata);
+            if (mpls_ret != 0)
+            {
+                SWSS_LOG_ERROR("Failed to %s MPLS on router interface %s: %d",
+                               attr_type_mpls->value.booldata ? "enable" : "disable",
+                               mpls_hwif_name.c_str(), mpls_ret);
+                return SAI_STATUS_FAILURE;
+            }
+            SWSS_LOG_NOTICE("MPLS %s on router interface %s",
+                            attr_type_mpls->value.booldata ? "enabled" : "disabled",
+                            mpls_hwif_name.c_str());
+        }
     }
 
     bool v4_is_up = false, v6_is_up = false;

--- a/vslib/vpp/SwitchVppRoute.cpp
+++ b/vslib/vpp/SwitchVppRoute.cpp
@@ -101,6 +101,10 @@ void create_vpp_nexthop_entry (
     vpp_nexthop->sw_if_index = nxt_grp_member->sw_if_index;
     vpp_nexthop->weight = (uint8_t) nxt_grp_member->weight;
     vpp_nexthop->preference = 0;
+    vpp_nexthop->n_labels = nxt_grp_member->n_labels;
+    for (uint8_t li = 0; li < nxt_grp_member->n_labels && li < VPP_MPLS_MAX_LABELS; li++) {
+        vpp_nexthop->label_stack[li] = nxt_grp_member->label_stack[li];
+    }
 }
 
 const char* SwitchVpp::resolveNexthopMemberHwif(

--- a/vslib/vpp/SwitchVppRoute.cpp
+++ b/vslib/vpp/SwitchVppRoute.cpp
@@ -102,6 +102,9 @@ void create_vpp_nexthop_entry (
     vpp_nexthop->weight = (uint8_t) nxt_grp_member->weight;
     vpp_nexthop->preference = 0;
     vpp_nexthop->n_labels = nxt_grp_member->n_labels;
+    vpp_nexthop->out_ttl = nxt_grp_member->out_ttl;
+    vpp_nexthop->out_exp = nxt_grp_member->out_exp;
+    vpp_nexthop->out_is_uniform = nxt_grp_member->out_is_uniform;
     for (uint8_t li = 0; li < nxt_grp_member->n_labels && li < VPP_MPLS_MAX_LABELS; li++) {
         vpp_nexthop->label_stack[li] = nxt_grp_member->label_stack[li];
     }

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -3205,7 +3205,7 @@ int ip_route_add_del_get_stats (vpp_ip_route_t *prefix, bool is_add, uint32_t *s
         fib_path->n_labels = nexthop->n_labels;
         for (uint8_t l = 0; l < nexthop->n_labels && l < VPP_MPLS_MAX_LABELS; l++) {
             fib_path->label_stack[l].label = htonl(nexthop->label_stack[l]);
-            fib_path->label_stack[l].ttl = 64;
+            fib_path->label_stack[l].ttl = MPLS_DEFAULT_OUT_TTL;
             fib_path->label_stack[l].exp = 0;
             fib_path->label_stack[l].is_uniform = 1;
         }

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -2670,17 +2670,6 @@ int configure_lcp_interface (const char *hwif_name, const char *hostif_name, boo
     return config_lcp_hostif(vam, idx, hostif_name, is_add);
 }
 
-int get_sw_if_idx (const char *ifname)
-{
-    vat_main_t *vam = &vat_main;
-    u32 idx = get_swif_idx(vam, ifname);
-
-    if (idx == (u32) -1) {
-        return -1;
-    }
-    return (int) idx;
-}
-
 int create_loopback_instance (const char *hwif_name, u32 instance)
 {
     vat_main_t *vam = &vat_main;

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -73,6 +73,8 @@
 
 #include <vnet/srv6/sr.api_enum.h>
 #include <vnet/srv6/sr.api_types.h>
+#include <vnet/mpls/mpls.api_enum.h>
+#include <vnet/mpls/mpls.api_types.h>
 
 #include <vnet/ipip/ipip.api_enum.h>
 #include <vnet/ipip/ipip.api_types.h>
@@ -207,6 +209,24 @@
 
 #define vl_api_version(n, v) static u32 sr_api_version = v;
 #include <vnet/srv6/sr.api.h>
+#undef vl_api_version
+
+/* MPLS API inclusion */
+
+#define vl_typedefs
+#include <vnet/mpls/mpls.api.h>
+#undef vl_typedefs
+
+#define  vl_endianfun
+#include <vnet/mpls/mpls.api.h>
+#undef vl_endianfun
+
+#define vl_calcsizefun
+#include <vnet/mpls/mpls.api.h>
+#undef vl_calcsizefun
+
+#define vl_api_version(n, v) static u32 mpls_api_version = v;
+#include <vnet/mpls/mpls.api.h>
 #undef vl_api_version
 
 /* ipv4 API inclusion */
@@ -1775,6 +1795,7 @@ static u16 l2_msg_id_base, vxlan_msg_id_base, ipip_msg_id_base;
 static u16 tunterm_msg_id_base;
 static u16 bfd_msg_id_base;
 static u16 sr_msg_id_base;
+static u16 mpls_msg_id_base;
 static u16 bond_msg_id_base;
 static u16 span_msg_id_base;
 static u16 classify_msg_id_base;
@@ -1951,6 +1972,26 @@ vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_
     set_reply_status(retval);
 }
 
+static void
+vl_api_sw_interface_set_mpls_enable_reply_t_handler (vl_api_sw_interface_set_mpls_enable_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void
+vl_api_mpls_table_add_del_reply_t_handler (vl_api_mpls_table_add_del_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void
+vl_api_mpls_route_add_del_reply_t_handler (vl_api_mpls_route_add_del_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
 
 #define LCP_MSG_ID(id) \
     (VL_API_##id + lcp_msg_id_base)
@@ -1969,6 +2010,9 @@ vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_
 
 #define SR_MSG_ID(id) \
     (VL_API_##id + sr_msg_id_base)
+
+#define MPLS_MSG_ID(id) \
+    (VL_API_##id + mpls_msg_id_base)
 
 #define foreach_vpe_plugin_api_reply_msg                                \
     _(LCP_MSG_ID(LCP_ITF_PAIR_ADD_DEL_REPLY), lcp_itf_pair_add_del_reply) \
@@ -1989,7 +2033,10 @@ vl_api_acl_interface_add_del_reply_t_handler(vl_api_acl_interface_add_del_reply_
     _(SFLOW_MSG_ID(SFLOW_ENABLE_DISABLE_REPLY), sflow_enable_disable_reply) \
     _(SFLOW_MSG_ID(SFLOW_SAMPLING_RATE_SET_REPLY), sflow_sampling_rate_set_reply) \
     _(IPIP_MSG_ID(IPIP_ADD_TUNNEL_REPLY), ipip_add_tunnel_reply) \
-    _(IPIP_MSG_ID(IPIP_DEL_TUNNEL_REPLY), ipip_del_tunnel_reply)
+    _(IPIP_MSG_ID(IPIP_DEL_TUNNEL_REPLY), ipip_del_tunnel_reply) \
+    _(MPLS_MSG_ID(SW_INTERFACE_SET_MPLS_ENABLE_REPLY), sw_interface_set_mpls_enable_reply) \
+    _(MPLS_MSG_ID(MPLS_TABLE_ADD_DEL_REPLY), mpls_table_add_del_reply) \
+    _(MPLS_MSG_ID(MPLS_ROUTE_ADD_DEL_REPLY), mpls_route_add_del_reply)
 
 static void vpp_plugin_vpe_init(void)
 {
@@ -2047,6 +2094,10 @@ static void get_base_msg_id()
     msg_base_lookup_name = format (0, "sr_%08x%c", sr_api_version, 0);
     sr_msg_id_base = vl_client_get_first_plugin_msg_id ((char *) msg_base_lookup_name);
     assert(sr_msg_id_base != (u16) ~0);
+    msg_base_lookup_name = format (0, "mpls_%08x%c", mpls_api_version, 0);
+    mpls_msg_id_base = vl_client_get_first_plugin_msg_id ((char *) msg_base_lookup_name);
+    assert(mpls_msg_id_base != (u16) ~0);
+
 
     memclnt_msg_id_base = 0;
 
@@ -2619,6 +2670,17 @@ int configure_lcp_interface (const char *hwif_name, const char *hostif_name, boo
     return config_lcp_hostif(vam, idx, hostif_name, is_add);
 }
 
+int get_sw_if_idx (const char *ifname)
+{
+    vat_main_t *vam = &vat_main;
+    u32 idx = get_swif_idx(vam, ifname);
+
+    if (idx == (u32) -1) {
+        return -1;
+    }
+    return (int) idx;
+}
+
 int create_loopback_instance (const char *hwif_name, u32 instance)
 {
     vat_main_t *vam = &vat_main;
@@ -2874,6 +2936,172 @@ int ip6_nbr_add_del (const char *hwif_name, uint32_t sw_if_index, struct sockadd
     return ip_nbr_add_del(hwif_name, sw_if_index, (struct sockaddr *) addr, is_static, no_fib_entry, mac, is_add);
 }
 
+int sw_interface_set_mpls_enable (const char *hwif_name, bool enable)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_sw_interface_set_mpls_enable_t *mp;
+    u32 sw_if_index;
+    int ret;
+
+    VPP_LOCK();
+
+    sw_if_index = get_swif_idx(vam, hwif_name);
+    if (sw_if_index == (u32) -1) {
+        SAIVPP_ERROR("%s: unknown interface %s", __func__, hwif_name);
+        VPP_UNLOCK();
+        return -EINVAL;
+    }
+
+    __plugin_msg_base = mpls_msg_id_base;
+
+    M (SW_INTERFACE_SET_MPLS_ENABLE, mp);
+    mp->sw_if_index = htonl(sw_if_index);
+    mp->enable = enable;
+
+    S (mp);
+    WR (ret);
+
+    ret = vpp_normalize_ret(ret, false, __func__);
+
+    if (ret) { SAIVPP_ERROR("%s failed(%d) intf %s enable %d", __func__, ret, hwif_name, enable); }
+    else { SAIVPP_INFO("%s intf %s enable %d", __func__, hwif_name, enable); }
+
+    VPP_UNLOCK();
+
+    return ret;
+}
+
+int mpls_table_add_del (uint32_t table_id, bool is_add)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_mpls_table_add_del_t *mp;
+    int ret;
+
+    VPP_LOCK();
+
+    __plugin_msg_base = mpls_msg_id_base;
+
+    M (MPLS_TABLE_ADD_DEL, mp);
+    mp->mt_is_add = is_add;
+    mp->mt_table.mt_table_id = htonl(table_id);
+
+    S (mp);
+    WR (ret);
+
+    ret = vpp_normalize_ret(ret, !is_add, __func__);
+
+    if (ret) { SAIVPP_ERROR("%s failed(%d) table %u is_add %d", __func__, ret, table_id, is_add); }
+    else { SAIVPP_INFO("%s table %u is_add %d", __func__, table_id, is_add); }
+
+    VPP_UNLOCK();
+
+    return ret;
+}
+
+int mpls_route_add_del (vpp_mpls_route_t *route, bool is_add)
+{
+    u32 idx, path_count;
+    vat_main_t *vam = &vat_main;
+    vl_api_mpls_route_t *mr;
+    vl_api_mpls_route_add_del_t *mp;
+    int ret;
+
+    VPP_LOCK();
+
+    path_count = route->nexthop_cnt;
+
+    /*
+     * Validate every path before allocating the API message: the message is
+     * only freed once it is sent, so an early return afterwards would leak it.
+     */
+    for (unsigned int i = 0; i < path_count; i++) {
+        if (route->nexthop[i].addr.sa_family != AF_INET &&
+            route->nexthop[i].addr.sa_family != AF_INET6) {
+            VPP_UNLOCK();
+            return -EINVAL;
+        }
+        if (route->nexthop[i].n_labels > VPP_MPLS_MAX_LABELS) {
+            VPP_UNLOCK();
+            return -EINVAL;
+        }
+    }
+
+    __plugin_msg_base = mpls_msg_id_base;
+
+    M22 (MPLS_ROUTE_ADD_DEL, mp, sizeof (vl_api_fib_path_t) * path_count);
+    mr = &mp->mr_route;
+
+    mr->mr_table_id = htonl(route->table_id);
+    mr->mr_label = htonl(route->label);
+    mr->mr_eos = route->eos;
+    mr->mr_eos_proto = (u8)((route->eos_proto_af == AF_INET6) ?
+        FIB_API_PATH_NH_PROTO_IP6 : FIB_API_PATH_NH_PROTO_IP4);
+    mr->mr_is_multicast = false;
+    mr->mr_n_paths = (u8)path_count;
+
+    for (unsigned int i = 0; i < path_count; i++) {
+        vpp_mpls_nexthop_t *nexthop = &route->nexthop[i];
+        vl_api_fib_path_t *fib_path = &mr->mr_paths[i];
+        vl_api_address_union_t *nh_addr = &fib_path->nh.address;
+        vpp_ip_addr_t *addr = &nexthop->addr;
+
+        memset(fib_path, 0, sizeof(*fib_path));
+
+        if (nexthop->sw_if_index != (u32) -1) {
+            fib_path->sw_if_index = htonl(nexthop->sw_if_index);
+        } else if (nexthop->hwif_name) {
+            idx = get_swif_idx(vam, nexthop->hwif_name);
+            fib_path->sw_if_index = htonl(idx != (u32) -1 ? idx : (uint32_t)~0);
+        } else {
+            fib_path->sw_if_index = htonl((uint32_t)~0);
+        }
+
+        if (addr->sa_family == AF_INET) {
+            struct sockaddr_in *ip4 = &addr->addr.ip4;
+            memcpy(nh_addr->ip4, &ip4->sin_addr.s_addr, sizeof(nh_addr->ip4));
+            fib_path->proto = htonl(FIB_API_PATH_NH_PROTO_IP4);
+        } else if (addr->sa_family == AF_INET6) {
+            struct sockaddr_in6 *ip6 = &addr->addr.ip6;
+            memcpy(nh_addr->ip6, &ip6->sin6_addr.s6_addr, sizeof(nh_addr->ip6));
+            fib_path->proto = htonl(FIB_API_PATH_NH_PROTO_IP6);
+        }
+
+        if (nexthop->type == VPP_NEXTHOP_LOCAL) {
+            fib_path->type = htonl(FIB_API_PATH_TYPE_LOCAL);
+        } else {
+            fib_path->type = htonl(FIB_API_PATH_TYPE_NORMAL);
+        }
+
+        fib_path->table_id = 0;
+        fib_path->rpf_id = htonl((uint32_t)~0);
+        fib_path->weight = nexthop->weight;
+        fib_path->preference = nexthop->preference;
+
+        fib_path->n_labels = nexthop->n_labels;
+        for (uint8_t l = 0; l < nexthop->n_labels && l < VPP_MPLS_MAX_LABELS; l++) {
+            fib_path->label_stack[l].label = htonl(nexthop->label_stack[l].label);
+            fib_path->label_stack[l].ttl = nexthop->label_stack[l].ttl;
+            fib_path->label_stack[l].exp = nexthop->label_stack[l].exp;
+            fib_path->label_stack[l].is_uniform = nexthop->label_stack[l].is_uniform;
+        }
+    }
+
+    mp->mr_is_add = is_add;
+    mp->mr_is_multipath = route->is_multipath;
+
+    S (mp);
+    WR (ret);
+
+    ret = vpp_normalize_ret(ret, !is_add, __func__);
+
+    if (ret) { SAIVPP_ERROR("%s failed(%d) label %u eos %u is_add %d", __func__, ret, route->label, route->eos, is_add); }
+    else { SAIVPP_INFO("%s label %u eos %u paths %u is_add %d", __func__, route->label, route->eos, path_count, is_add); }
+
+    VPP_UNLOCK();
+
+    return ret;
+}
+
 int ip_route_add_del_get_stats (vpp_ip_route_t *prefix, bool is_add, uint32_t *stats_index)
 {
     u32 idx, path_count = 1;
@@ -2974,7 +3202,13 @@ int ip_route_add_del_get_stats (vpp_ip_route_t *prefix, bool is_add, uint32_t *s
         fib_path->rpf_id = htonl((uint32_t)~0);
         fib_path->weight = nexthop->weight;
         fib_path->preference = nexthop->preference;
-        fib_path->n_labels = 0;
+        fib_path->n_labels = nexthop->n_labels;
+        for (uint8_t l = 0; l < nexthop->n_labels && l < VPP_MPLS_MAX_LABELS; l++) {
+            fib_path->label_stack[l].label = htonl(nexthop->label_stack[l]);
+            fib_path->label_stack[l].ttl = 64;
+            fib_path->label_stack[l].exp = 0;
+            fib_path->label_stack[l].is_uniform = 1;
+        }
     }
     ip_route->table_id = htonl(prefix->vrf_id);
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -3202,8 +3202,15 @@ int ip_route_add_del_get_stats (vpp_ip_route_t *prefix, bool is_add, uint32_t *s
         fib_path->rpf_id = htonl((uint32_t)~0);
         fib_path->weight = nexthop->weight;
         fib_path->preference = nexthop->preference;
-        fib_path->n_labels = nexthop->n_labels;
-        for (uint8_t l = 0; l < nexthop->n_labels && l < VPP_MPLS_MAX_LABELS; l++) {
+        /*
+         * Clamp before assigning: only VPP_MPLS_MAX_LABELS entries are ever
+         * populated below, so an unclamped n_labels would tell VPP the message
+         * carries more labels than it actually does.
+         */
+        uint8_t n_labels = nexthop->n_labels > VPP_MPLS_MAX_LABELS ?
+                           VPP_MPLS_MAX_LABELS : nexthop->n_labels;
+        fib_path->n_labels = n_labels;
+        for (uint8_t l = 0; l < n_labels; l++) {
             fib_path->label_stack[l].label = htonl(nexthop->label_stack[l]);
             fib_path->label_stack[l].ttl = MPLS_DEFAULT_OUT_TTL;
             fib_path->label_stack[l].exp = 0;

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -3201,9 +3201,9 @@ int ip_route_add_del_get_stats (vpp_ip_route_t *prefix, bool is_add, uint32_t *s
         fib_path->n_labels = n_labels;
         for (uint8_t l = 0; l < n_labels; l++) {
             fib_path->label_stack[l].label = htonl(nexthop->label_stack[l]);
-            fib_path->label_stack[l].ttl = MPLS_DEFAULT_OUT_TTL;
-            fib_path->label_stack[l].exp = 0;
-            fib_path->label_stack[l].is_uniform = 1;
+            fib_path->label_stack[l].ttl = nexthop->out_ttl;
+            fib_path->label_stack[l].exp = nexthop->out_exp;
+            fib_path->label_stack[l].is_uniform = nexthop->out_is_uniform;
         }
     }
     ip_route->table_id = htonl(prefix->vrf_id);

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -29,6 +29,8 @@ extern "C" {
 
     /* Maximum MPLS label stack depth carried on a single fib path (VPP API limit). */
 #define VPP_MPLS_MAX_LABELS 16
+    /* Default TTL for an imposed label; SAI carries no per-outsegment TTL. */
+#define MPLS_DEFAULT_OUT_TTL 64
 
 typedef struct vpp_ip_addr_ {
 	int sa_family;
@@ -47,6 +49,12 @@ typedef struct vpp_ip_addr_ {
 	vpp_nexthop_type_e type;
         uint32_t flags;
         uint8_t n_labels;
+        /*
+         * Labels imposed on an IP route. Only the label value is carried here:
+         * the TTL of an imposed label on an IP path is derived from the IP
+         * header (uniform mode), so unlike vpp_mpls_nexthop_t below there is no
+         * per-label ttl/exp to express.
+         */
         uint32_t label_stack[VPP_MPLS_MAX_LABELS];
     } vpp_ip_nexthop_t;
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -27,7 +27,10 @@ extern "C" {
 	VPP_NEXTHOP_LOCAL = 2
     } vpp_nexthop_type_e;
 
-    typedef struct vpp_ip_addr_ {
+    /* Maximum MPLS label stack depth carried on a single fib path (VPP API limit). */
+#define VPP_MPLS_MAX_LABELS 16
+
+typedef struct vpp_ip_addr_ {
 	int sa_family;
 	union {
 	    struct sockaddr_in ip4;
@@ -43,6 +46,8 @@ extern "C" {
         uint8_t preference;
 	vpp_nexthop_type_e type;
         uint32_t flags;
+        uint8_t n_labels;
+        uint32_t label_stack[VPP_MPLS_MAX_LABELS];
     } vpp_ip_nexthop_t;
 
     typedef struct vpp_ip_route_ {
@@ -179,6 +184,35 @@ extern "C" {
         uint32_t fib_table;
         vpp_prefix_t prefix;
     } vpp_sr_steer_t;
+
+    typedef struct vpp_mpls_label_ {
+        uint32_t label;
+        uint8_t  ttl;
+        uint8_t  exp;
+        uint8_t  is_uniform;
+    } vpp_mpls_label_t;
+
+    typedef struct vpp_mpls_nexthop_ {
+        vpp_ip_addr_t addr;
+        uint32_t      sw_if_index;
+        const char   *hwif_name;
+        uint8_t       weight;
+        uint8_t       preference;
+        vpp_nexthop_type_e type;
+        uint8_t       n_labels;
+        vpp_mpls_label_t label_stack[VPP_MPLS_MAX_LABELS];
+    } vpp_mpls_nexthop_t;
+
+    typedef struct vpp_mpls_route_ {
+        uint32_t      table_id;
+        uint32_t      label;
+        uint8_t       eos;
+        int           eos_proto_af;   /* AF_INET / AF_INET6 for post-pop lookup proto */
+        bool          is_multipath;
+        unsigned int  nexthop_cnt;
+        vpp_mpls_nexthop_t nexthop[0];
+    } vpp_mpls_route_t;
+
 
     typedef struct vpp_event_info_ {
 	struct vpp_event_info_ *next;
@@ -430,6 +464,9 @@ typedef enum {
                                                     bool is_input);
     extern int vpp_add_node_next(const char *node_name, const char *next_name,
                                        uint32_t *next_index);
+    extern int sw_interface_set_mpls_enable(const char *hwif_name, bool enable);
+    extern int mpls_table_add_del(uint32_t table_id, bool is_add);
+    extern int mpls_route_add_del(vpp_mpls_route_t *route, bool is_add);
 #ifdef __cplusplus
 }
 #endif

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -29,7 +29,12 @@ extern "C" {
 
     /* Maximum MPLS label stack depth carried on a single fib path (VPP API limit). */
 #define VPP_MPLS_MAX_LABELS 16
-    /* Default TTL for an imposed label; SAI carries no per-outsegment TTL. */
+    /*
+     * TTL used for an imposed label when the SAI next hop does not carry an
+     * explicit one, i.e. when SAI_NEXT_HOP_ATTR_OUTSEG_TTL_MODE is UNIFORM (the
+     * SAI default) and the TTL is therefore taken from the payload rather than
+     * from SAI_NEXT_HOP_ATTR_OUTSEG_TTL_VALUE.
+     */
 #define MPLS_DEFAULT_OUT_TTL 64
 
 typedef struct vpp_ip_addr_ {
@@ -50,12 +55,16 @@ typedef struct vpp_ip_addr_ {
         uint32_t flags;
         uint8_t n_labels;
         /*
-         * Labels imposed on an IP route. Only the label value is carried here:
-         * the TTL of an imposed label on an IP path is derived from the IP
-         * header (uniform mode), so unlike vpp_mpls_nexthop_t below there is no
-         * per-label ttl/exp to express.
+         * Labels imposed on an IP route (ingress LER). SAI models the TTL and
+         * EXP treatment per next hop rather than per label
+         * (SAI_NEXT_HOP_ATTR_OUTSEG_{TTL,EXP}_{MODE,VALUE}), so the label
+         * values are carried here and the treatment below is applied to every
+         * label in the stack when the VPP fib path is built.
          */
         uint32_t label_stack[VPP_MPLS_MAX_LABELS];
+        uint8_t out_ttl;         /* TTL for imposed labels (PIPE mode uses the SAI value) */
+        uint8_t out_exp;         /* EXP for imposed labels */
+        uint8_t out_is_uniform;  /* 1 = UNIFORM (derive from payload), 0 = PIPE */
     } vpp_ip_nexthop_t;
 
     typedef struct vpp_ip_route_ {


### PR DESCRIPTION
### Description of PR

Summary:
Part of sonic-net/sonic-buildimage#25782

Adds MPLS data-plane support to the VPP SAI backend so the `tests/mpls` data-plane
tests can run on the sonic-vpp testbed. Today `SAI_OBJECT_TYPE_INSEG_ENTRY` is not
handled at all in `vslib/vpp`, so MPLS traffic is never programmed into VPP.

> [!NOTE]
> Companion PR sonic-net/sonic-mgmt#26619 enables `mpls/test_mpls.py` on sonic-vpp and
> depends on this change being in the image, so it merges after this one.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

sonic-buildimage#25782 asks for MPLS support in sonic-vpp so that `mpls/test_mpls.py`
can be enabled on the VPP KVM testbed. The tests currently can't run because the VPP
SAI backend has no INSEG handling.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

10 files, +737 / -5, all under `vslib/vpp`:

| File | Change |
|---|---|
| `vslib/vpp/SwitchVppMpls.cpp` (new) | INSEG create/remove: pop, swap and push disposition into the VPP MPLS FIB. |
| `vslib/vpp/SwitchVpp.{cpp,h}` | Dispatch `SAI_OBJECT_TYPE_INSEG_ENTRY` from `create()`/`remove()`; declare the MPLS helpers and the MPLS-table state. |
| `vslib/vpp/SwitchVppNexthop.{cpp,h}` | Carry the out-label stack on next hops; `n_labels` is explicitly zeroed in `fillNHGrpMember()`. |
| `vslib/vpp/SwitchVppRoute.cpp` | Impose the out-label stack on IP routes (ingress LER), gated on `n_labels > 0`. |
| `vslib/vpp/SwitchVppRif.cpp` | Honour `SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE` (`sw_interface_set_mpls_enable`, ensure the MPLS table exists). |
| `vslib/vpp/vppxlate/SaiVppXlate.{c,h}` | `mpls_table_add_del()`, `mpls_route_add_del()`, and the label stack on fib paths for both MPLS and IP routes. |
| `vslib/Makefile.am` | Build the new source file. |

Details worth a reviewer's attention:

- *pop*: inject an implicit-null out-label in UNIFORM LSP mode so the disposition
  derives the inner IP TTL from the popped MPLS TTL. Without it VPP defaults the
  disposition to PIPE and the inner TTL is only decremented once by the IP stage.
- *swap/push*: read the SAI next hop's out-label stack. `SAI_NEXT_HOP_ATTR_LABELSTACK`
  is a list attribute, so the output buffer has to be supplied before the get,
  otherwise the read fails and the labels are silently dropped - which turns a swap
  into a bare pop.
- Resolve the next hop's router interface to its VPP egress hwif so the path is
  programmed *attached* rather than recursive. VPP only inserts the MPLS disposition
  for an attached next hop, and a recursive labelled path fails to resolve and is
  dropped at the MPLS DROP DPO.
- The SAI INSEG key has no end-of-stack qualifier but the VPP MPLS FIB is keyed by
  `{label, eos}`, so eos=1 is always programmed and eos=0 as well when out-labels are
  present, so a non-bottom label in a stack is handled.
- `mpls_route_add_del()` validates every path (address family and label count) *before*
  allocating the API message, matching what `ip_route_add_del_get_stats()` already does,
  so the error path can't leak the message.

Status is propagated the same way the neighbouring `addIpRoute()`/`removeIpRoute()`
do it: `addMplsRoute()` rolls back the VPP programming if `create_internal()` fails,
and `ensureMplsTable()` only latches its "created" flag once the table really exists.

#### How did you verify/test it?

**With this change in the image.** A throwaway sonic-buildimage build carrying this PR
produced image `SONiC.master-28652.1177040-4e2ccc26c`. Run on a `vms-kvm-vpp-t1-lag` KVM
testbed together with the companion sonic-mgmt PR, ElasticTest plan
`6a69da68f481df03c4e59c5e` - **SUCCESS, 22 tests, 17 passed / 5 skipped / 0 failed /
0 errors**:

```
mpls/test_mpls.py::TestBasicMpls::test_pop_label        PASSED
mpls/test_mpls.py::TestBasicMpls::test_swap_label       PASSED
mpls/test_mpls.py::TestBasicMpls::test_push_label       SKIPPED
mpls/test_mpls.py::TestBasicMpls::test_swap_labelstack  PASSED

3 passed, 1 skipped
```

**Without this change in the image (negative control).** The dependency was verified
rather than assumed. The identical test code, run by the `t1-lag-vpp` PR checker on a
stock sonic-vpp image that does *not* carry this PR, fails:

```
mpls/test_mpls.py|||2 failed for RUN_TEST_CASE_FAILED
```

(ElasticTest plan `6a70603deb2c1b23503d2e2f`, build 1182699; same signature on the
earlier build 1178163.) `mpls/test_mpls.py` is the only failure in that run - the job
executes the whole `t1-lag-vpp` list. That is exactly the gap this PR closes.

**Regression check.** The same image also ran the full `t1-lag-vpp` suite
(1762 tests, 1222 passed) to check this doesn't regress anything else on VPP.

`test_push_label` is skipped for a reason outside this change: it injects the push
route directly into `ROUTE_TABLE` and orchagent does not install that route into
ASIC_DB, so it never reaches the SAI backend.

#### Any platform specific information?

sonic-vpp only - everything is under `vslib/vpp`. Non-MPLS traffic is unaffected: the
INSEG path only runs for INSEG objects, the next-hop label handling is gated on
`SAI_NEXT_HOP_TYPE_MPLS`, and label imposition is gated on `n_labels > 0`.

Known limitations, called out deliberately rather than half-implemented - happy to
follow up on any of these if reviewers would prefer them in scope:

- IPv6 payloads: `eos_proto_af` is IPv4.
- ECMP / next-hop-group MPLS next hops are not programmed.
- INSEG `set()` does not reprogram VPP (create/remove only).
- `NUM_OF_POP` > 1, and non-default POP TTL/QoS modes, are not implemented.

### Documentation

No user-facing documentation change.
