### PR TITLE
Revert "Ship synced custom SAI headers in libsaivs-dev (#1984)"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -72,18 +72,6 @@ endif
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 endif
-	# SAI may be built with vendor custom headers in SAI/custom/ and the generated
-	# saimetadata.h emitted in that case includes "#include <saicustom.h>". Ship
-	# those custom headers in libsaivs-dev (the VS SAI dev package that is installed
-	# during downstream builds such as sonic-swss) so that include resolves.
-	# libsaivs-dev conflicts with vendor SAI dev packages, so the two never
-	# co-install and there is no file-overwrite clash. Install all SAI/custom/*.h
-	# (same set parse.pl scans via $CUSTOM_DIR) so saimetadata.h's saicustom.h
-	# aggregator chain resolves. Guarded on existence so builds without custom
-	# headers are unaffected.
-	if ls SAI/custom/*.h >/dev/null 2>&1 && [ -d debian/libsaivs-dev/usr/include/sai ]; then \
-		install -m 644 SAI/custom/*.h debian/libsaivs-dev/usr/include/sai/; \
-	fi
 
 override_dh_installinit:
 	dh_installinit --init-script=syncd


### PR DESCRIPTION
### Description of PR

Reverts #1984 ("Ship synced custom SAI headers in libsaivs-dev").

This reverts commit 9bd6103824e4590b24fbce2bc014d8902b51eccb.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

Revert of #1984.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

`git revert` of the squash-merge commit 9bd6103. Clean revert, no conflicts — `debian/rules` has not been touched upstream since #1984 merged, so this restores the file to exactly its pre-#1984 content (-12 lines, the exact inverse of the original +12).

#### How did you verify/test it?

- Confirmed the diff is the byte-exact inverse of 9bd6103, and that `debian/rules` at this commit is identical to `9bd6103^:debian/rules`.
- Confirmed no other file in the repository references the removed `SAI/custom/*.h` install rule (`debian/libsaivs-dev.install`, `debian/control`, `configure.ac`/`SAIINC` and the `Makefile.am` set are untouched by #1984 and unaffected here).

#### Any platform specific information?

**Merge order — please read.**

This is one of two branches carrying #1984. The 202605 branch received it via the auto-backport #2010; a companion revert for that branch is opened separately.

More importantly, this revert is paired with sonic-net/sonic-buildimage#28680, which reverts sonic-buildimage#28365 — the Mellanox build hook that populates `sonic-sairedis/SAI/custom/`.

**sonic-buildimage#28680 should merge first.** `sonic-buildimage` master currently pins `src/sonic-sairedis` at exactly 9bd6103 (this commit). If this revert lands and the submodule pointer later advances past it while sonic-buildimage still syncs the custom headers, `SAI/meta/parse.pl` will keep emitting `#include <saicustom.h>` into the generated `saimetadata.h` while `libsaivs-dev` no longer ships that header — reproducing the sonic-swss build failure described in #28680.

Once #28680 has merged, nothing populates `SAI/custom/` any more, the `if ls SAI/custom/*.h` guard removed here is always false, and this revert is a no-op cleanup.

### Documentation

N/A — revert only.
