### PR TITLE
[202605] Revert "Ship synced custom SAI headers in libsaivs-dev (#2010)"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -72,18 +72,6 @@ endif
 ifneq ($(filter rpc,$(DEB_BUILD_PROFILES)),)
 	sed -i 's|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1 # Add a comment to fix https://github.com/Azure/sonic-buildimage/issues/2694 |' debian/syncd-rpc/usr/bin/syncd_init_common.sh
 endif
-	# SAI may be built with vendor custom headers in SAI/custom/ and the generated
-	# saimetadata.h emitted in that case includes "#include <saicustom.h>". Ship
-	# those custom headers in libsaivs-dev (the VS SAI dev package that is installed
-	# during downstream builds such as sonic-swss) so that include resolves.
-	# libsaivs-dev conflicts with vendor SAI dev packages, so the two never
-	# co-install and there is no file-overwrite clash. Install all SAI/custom/*.h
-	# (same set parse.pl scans via $CUSTOM_DIR) so saimetadata.h's saicustom.h
-	# aggregator chain resolves. Guarded on existence so builds without custom
-	# headers are unaffected.
-	if ls SAI/custom/*.h >/dev/null 2>&1 && [ -d debian/libsaivs-dev/usr/include/sai ]; then \
-		install -m 644 SAI/custom/*.h debian/libsaivs-dev/usr/include/sai/; \
-	fi
 
 override_dh_installinit:
 	dh_installinit --init-script=syncd


### PR DESCRIPTION
### Description of PR

Reverts #2010 ("[action] [PR:1984] Ship synced custom SAI headers in libsaivs-dev"), the 202605 auto-backport of #1984.

This reverts commit a67d06e80462bc748192ea2eb6033add3f4a40d2.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

Revert of #2010, so that 202605 matches the master revert of the same change.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

`git revert` of a67d06e on the 202605 branch. Clean revert, no conflicts — a67d06e is the most recent commit touching `debian/rules` on 202605, so this restores the file to exactly its pre-#2010 content (-12 lines, the exact inverse of the original +12).

#### How did you verify/test it?

- Confirmed the diff is the byte-exact inverse of a67d06e, and that `debian/rules` at this commit is identical to `a67d06e^:debian/rules`.
- Confirmed no other file in the repository references the removed `SAI/custom/*.h` install rule.

#### Any platform specific information?

Companion to the master-branch revert of #1984.

Unlike master, there is **no merge-order constraint on this branch**: the Mellanox build hook that populates `sonic-sairedis/SAI/custom/` (sonic-buildimage#28365) was never backported to 202605 — `platform/mellanox/mlnx-sai-metadata.mk` does not exist on `sonic-buildimage` 202605, and its `platform/mellanox/rules.mk` has zero references to it. Nothing on 202605 populates `SAI/custom/`, so the `if ls SAI/custom/*.h` guard removed here is always false and this revert is a no-op cleanup on that branch.

For reference, `sonic-buildimage` 202605 currently pins `src/sonic-sairedis` at exactly a67d06e (this commit), so that pin will need the usual submodule advance to pick this revert up.

### Documentation

N/A — revert only.
