### PR TITLE
[ci]: Cut sairedis Build over to shared buildenv_setup (CI unification Phase 2A)

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -1,2 +1,7 @@
 **/*
 !*.deb
+# Also publish build-env/ so downstream consumers (sonic-swss) can cascade this
+# repo's dependency declarations via buildenv_setup (reads build-env/ out of the
+# downloaded artifact). Both the dir entry and its contents must be un-ignored.
+!build-env
+!build-env/**

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -1,4 +1,8 @@
 parameters:
+- name: repo
+  type: string
+  default: self
+
 - name: arch
   type: string
   values:
@@ -40,6 +44,13 @@ parameters:
   type: boolean
   default: false
 
+- name: staged_upstreams
+  # List of {artifact: <current-run AZP artifact>, name: <upstream YAML name>}.
+  # Used when another pipeline reuses this template and must build sairedis
+  # against an artifact produced earlier in that same run.
+  type: object
+  default: []
+
 - name: debian_version
   type: string
 
@@ -63,185 +74,70 @@ jobs:
     options:  "--privileged"
 
   steps:
-  - checkout: self
+  - checkout: ${{ parameters.repo }}
     clean: true
     submodules: true
-  - task: DownloadPipelineArtifact@2
-    condition: eq('${{ parameters.arch }}', 'amd64')
-    inputs:
-      source: specific
-      project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib
-      patterns: |
-          target/debs/${{ parameters.debian_version }}/libnl-3*.deb
-          target/debs/${{ parameters.debian_version }}/libnl-genl*.deb
-          target/debs/${{ parameters.debian_version }}/libnl-route*.deb
-          target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
-    displayName: "Download libnl from common_libs"
-  - script: |
-      set -ex
-      sudo dpkg -i $(find ./download -name libnl-*_${{ parameters.arch }}.deb)
-    condition: eq('${{ parameters.arch }}', 'amd64')
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    displayName: "Install sonic libnl"
+    ${{ if ne(parameters.repo, 'self') }}:
+      path: s
+
+  # A consumer reusing this template can stage current-run upstream artifacts
+  # under the names used by build-env/upstream-artifacts.yaml.
+  - ${{ each up in parameters.staged_upstreams }}:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifact: ${{ up.artifact }}
+        path: $(Pipeline.Workspace)/staged/${{ up.name }}
+      displayName: "Stage current-run ${{ up.name }} for the cascade"
+
   - script: |
       set -ex
       sudo apt-get update
-      sudo apt-get install -qq -y \
-        libdbus-glib-1-dev \
-        libpcsclite-dev \
-        docbook-to-man \
-        docbook-utils \
-        aspell-en \
-        libhiredis-dev \
-        swig \
-        libzmq3-dev \
-        autoconf-archive
+      sudo apt-get install -qq -y python3-yaml python3-requests git
 
-      sudo apt-get install -y redis-server
-      sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
-      sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf
-      sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
-      sudo service redis-server start
-      sudo mkdir -m 755 /var/run/sswsyncd
+      clone_swss_common() {
+        ref="$1"
+        for delay in 0 5 15; do
+          [ "$delay" -eq 0 ] || sleep "$delay"
+          rm -rf /tmp/sw-common
+          git clone --depth 1 --branch "$ref" \
+            https://github.com/sonic-net/sonic-swss-common /tmp/sw-common && return 0
+        done
+        return 1
+      }
 
-      sudo apt-get install -y rsyslog
-      sudo rsyslogd
-
-      cat /etc/apt/sources.list
-      dpkg --list | grep libnl
-
-    displayName: "Install dependencies"
-  - script: |
-      set -ex
-      sudo apt-get update
-      sudo apt-get install -qq -y \
-          libnl-3-dev \
-          libnl-genl-3-dev \
-          libnl-route-3-dev \
-          libnl-nf-3-dev \
-          libnl-cli-3-dev
-
-    condition: ne('${{ parameters.arch }}', 'amd64')
-    displayName: "Install libnl for arm dependencies"
-  - task: DownloadPipelineArtifact@2
-    # amd64 artifact name does not has arch suffix
-    condition: and(ne('${{ parameters.debian_version }}', 'trixie'), eq('${{ parameters.arch }}', 'amd64'))
-    inputs:
-      source: specific
-      project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib
-      patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
-    displayName: "Download libyang from amd64 common lib"
-  - task: DownloadPipelineArtifact@2
-    condition: and(ne('${{ parameters.debian_version }}', 'trixie'), ne('${{ parameters.arch }}', 'amd64'))
-    inputs:
-      source: specific
-      project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib.${{ parameters.arch }}
-      patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
-  - task: DownloadPipelineArtifact@2
-    condition: and(eq('${{ parameters.debian_version }}', 'trixie'), eq('${{ parameters.arch }}', 'amd64'))
-    inputs:
-      source: specific
-      project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib
-      patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
-        target/debs/${{ parameters.debian_version }}/libpcre3_*.deb
-    displayName: "Download libyang from amd64 common lib"
-  - task: DownloadPipelineArtifact@2
-    condition: and(eq('${{ parameters.debian_version }}', 'trixie'), ne('${{ parameters.arch }}', 'amd64'))
-    inputs:
-      source: specific
-      project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib.${{ parameters.arch }}
-      patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang3_*.deb
-        target/debs/${{ parameters.debian_version }}/libpcre3_*.deb
-    displayName: "Download libyang from common lib"
-  - script: |
-      set -ex
-      sudo dpkg -i $(find ./download -name *.deb)
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    displayName: "Install libyang from common lib"
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
-      project: build
-      pipeline: sonic-net.sonic-platform-vpp
-      artifact: vpp-${{ parameters.debian_version }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
-      allowPartiallySucceededBuilds: true
-      path: $(Build.ArtifactStagingDirectory)/download
-    displayName: "Download sonic platform-vpp deb packages"
-    condition: eq('${{ parameters.arch }}', 'amd64')
-  - script: |
-      set -ex
-      sudo dpkg -i download/libvppinfra-dev_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/libvppinfra_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/vpp_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/vpp-crypto-engines_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/vpp-dbg_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/vpp-dev_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/vpp-plugin-core_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/vpp-plugin-devtools_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/vpp-plugin-dpdk_*_${{ parameters.arch }}.deb
-      sudo dpkg -i download/python3-vpp-api_*_${{ parameters.arch }}.deb
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    displayName: "Install sonic platform-vpp packages"
-    condition: eq('${{ parameters.arch }}', 'amd64')
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
-      project: build
-      pipeline: Azure.sonic-swss-common
-      artifact: ${{ parameters.swss_common_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      allowPartiallySucceededBuilds: true
-      path: $(Build.ArtifactStagingDirectory)/download
-    displayName: "Download sonic swss common deb packages"
-  - script: |
-      set -ex
-      sudo dpkg -i download/libswsscommon_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i download/libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
-      rm -rf download
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    displayName: "Install sonic swss Common"
-  - script: |
-      set -ex
-      rm ../*.deb || true
-      ./autogen.sh
-      extraflags='--enable-code-coverage'
-      if [ '${{ parameters.asan }}' == True ]; then
-         extraflags='--enable-asan'
+      # Keep the shared tool and upstream artifacts on the same branch. Release
+      # and master builds fail closed; feature branches may fall back to master
+      # when there is no matching sonic-swss-common branch.
+      SETUP_BRANCH="$(BUILD_BRANCH)"
+      if ! clone_swss_common "$SETUP_BRANCH"; then
+        case "$(BUILD_BRANCH)" in
+          master|20[0-9][0-9][0-9][0-9])
+            echo "Failed to clone required sonic-swss-common branch $(BUILD_BRANCH)" >&2
+            exit 1
+            ;;
+          *)
+            echo "No matching swss-common feature branch; falling back to master"
+            clone_swss_common master
+            SETUP_BRANCH=master
+            ;;
+        esac
       fi
-      DEB_BUILD_OPTIONS=nocheck DEB_CONFIGURE_EXTRA_FLAGS=$extraflags dpkg-buildpackage -us -uc -b -Psyncd,vs,nopython2 -j$(nproc)
-      mv ../*.deb .
+
+      REQ_ARGS=$(python3 -c "import json,os; print(' '.join('--required-staged-upstream '+u['name'] for u in json.loads(os.environ.get('STAGED_UPSTREAMS_JSON','[]'))))")
+      PYTHONPATH=/tmp/sw-common/ci python3 -m buildenv_setup \
+        --repo-dir $(Build.SourcesDirectory) \
+        --scope build \
+        --arch ${{ parameters.arch }} \
+        --debian-version ${{ parameters.debian_version }} \
+        --branch "$SETUP_BRANCH" \
+        --upstream-staged-dir $(Pipeline.Workspace)/staged \
+        $REQ_ARGS
+    displayName: "Set up build environment (buildenv_setup)"
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      STAGED_UPSTREAMS_JSON: ${{ convertToJson(parameters.staged_upstreams) }}
+
+  - script: ASAN=${{ parameters.asan }} ./build-env/build.sh
     displayName: "Compile sonic sairedis with coverage enabled"
   - script: |
       set -ex

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -74,8 +74,6 @@ jobs:
   - checkout: ${{ parameters.repo }}
     clean: true
     submodules: true
-    ${{ if ne(parameters.repo, 'self') }}:
-      path: s
 
   # A consumer reusing this template can stage current-run upstream artifacts
   # under the names used by build-env/upstream-artifacts.yaml.
@@ -120,7 +118,10 @@ jobs:
         esac
       fi
 
-      REQ_ARGS=$(python3 -c "import json,os; print(' '.join('--required-staged-upstream '+u['name'] for u in json.loads(os.environ.get('STAGED_UPSTREAMS_JSON','[]'))))")
+      REQ_ARGS=$(echo "$STAGED_UPSTREAMS_JSON" \
+        | jq -r '.[] | .name' \
+        | xargs -I{} echo --required-staged-upstream {} \
+        | tr '\n' ' ')
       PYTHONPATH=/tmp/sw-common/ci python3 -m buildenv_setup \
         --repo-dir $(Build.SourcesDirectory) \
         --scope build \

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -23,9 +23,6 @@ parameters:
   type: number
   default: 60
 
-- name: swss_common_artifact_name
-  type: string
-
 - name: artifact_name
   type: string
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,6 @@ stages:
     parameters:
       arch: amd64
       pool: sonicso1ES-amd64
-      swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       syslog_artifact_name: sonic-sairedis.syslog
       run_unit_test: true
@@ -67,7 +66,6 @@ stages:
     parameters:
       arch: amd64
       pool: sonicso1ES-amd64
-      swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       artifact_name: sonic-sairedis-asan-${{ parameters.debian_version }}
       syslog_artifact_name: sonic-sairedis-asan.syslog
       asan: true
@@ -84,7 +82,6 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicso1ES-armhf
-      swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}.armhf
       artifact_name: sonic-sairedis-${{ parameters.debian_version }}.armhf
       syslog_artifact_name: sonic-sairedis.syslog.armhf
       debian_version: ${{ parameters.debian_version }}
@@ -94,7 +91,6 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicso1ES-arm64
-      swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}.arm64
       artifact_name: sonic-sairedis-${{ parameters.debian_version }}.arm64
       syslog_artifact_name: sonic-sairedis.syslog.arm64
       debian_version: ${{ parameters.debian_version }}
@@ -106,7 +102,6 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
-      swss_common_artifact_name: sonic-swss-common-trixie
       artifact_name: sonic-sairedis-trixie
       syslog_artifact_name: sonic-sairedis-trixie.syslog
       run_unit_test: true
@@ -117,7 +112,6 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicso1ES-armhf
-      swss_common_artifact_name: sonic-swss-common-trixie.armhf
       artifact_name: sonic-sairedis-trixie.armhf
       syslog_artifact_name: sonic-sairedis-trixie.syslog.armhf
       debian_version: trixie
@@ -127,7 +121,6 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicso1ES-arm64
-      swss_common_artifact_name: sonic-swss-common-trixie.arm64
       artifact_name: sonic-sairedis-trixie.arm64
       syslog_artifact_name: sonic-sairedis-trixie.syslog.arm64
       debian_version: trixie

--- a/build-env/Dockerfile
+++ b/build-env/Dockerfile
@@ -1,0 +1,36 @@
+# Local-dev image for building sonic-sairedis.
+#
+# CI does NOT use this file: CI runs inside `container: sonic-slave-*` and invokes
+# buildenv_setup directly (see .azure-pipelines/build-template.yml). This exists
+# so a developer can reproduce the CI build environment locally.
+#
+# sonic-sairedis consumes the shared buildenv_setup tool from
+# sonic-swss-common/ci/. The source tree is mounted at /workspace at runtime, so
+# editing code does not invalidate this heavy dependency-setup layer.
+
+ARG DEBIAN_VERSION=bookworm
+FROM sonicdev-microsoft.azurecr.io:443/sonic-slave-${DEBIAN_VERSION}:latest
+
+ARG DEBIAN_VERSION=bookworm
+ARG SWSS_COMMON_REF=master
+ARG BUILD_BRANCH=master
+
+# Clone sonic-swss-common to obtain the branch-versioned shared tool.
+RUN git clone --depth 1 --branch "${SWSS_COMMON_REF}" \
+      https://github.com/sonic-net/sonic-swss-common /tmp/sw-common
+
+# Copy ONLY the dependency declarations so ordinary source edits stay cached.
+COPY build-env/ /workspace/build-env/
+
+# The canonical Redis hook in the swss-common cascade invokes sudo, so install it
+# explicitly even though this Docker build runs setup as root with --no-sudo.
+RUN apt-get update && apt-get install -y python3-yaml python3-requests sudo \
+ && PYTHONPATH=/tmp/sw-common/ci python3 -m buildenv_setup \
+      --repo-dir /workspace \
+      --scope build \
+      --debian-version "${DEBIAN_VERSION}" \
+      --branch "${BUILD_BRANCH}" \
+      --org-url https://dev.azure.com/mssonic \
+      --no-sudo
+
+WORKDIR /workspace

--- a/build-env/README.md
+++ b/build-env/README.md
@@ -1,0 +1,63 @@
+# build-env/
+
+Declarative build-environment configuration for sonic-sairedis, consumed by the
+shared [`buildenv_setup`](https://github.com/sonic-net/sonic-swss-common/tree/master/ci)
+tool in **sonic-swss-common**. This is the single source of truth for setting up
+the repo's build dependencies.
+
+## Contents
+
+| Path | Purpose | Cascades downstream? |
+|------|---------|----------------------|
+| `packages/base.yaml` | apt packages needed to build/link libsairedis; arm libnl-cli; shared Redis test configuration | **Yes** |
+| `packages/tooling.yaml` | Build-only tooling (docbook/aspell, rsyslog, sswsyncd runtime directory) | No |
+| `upstream-artifacts.yaml` | common-libs (amd64 SONiC libnl + libyang), sonic-swss-common, and VPP DEBs | Yes |
+| `build.sh` | canonical build (`autogen` + `dpkg-buildpackage -Psyncd,vs,nopython2`), used by CI and local dev; `ASAN=true` selects ASAN | — |
+| `Dockerfile`, `compose.yaml` | local-dev image and commands (CI does not use these) | — |
+
+The Redis script body is owned by sonic-swss-common at
+`build-env/configure-redis-for-tests.sh`. Sairedis selects that same script for
+its Build scope; `buildenv_setup` resolves it from the cascaded swss-common
+bundle, so the setup is not duplicated.
+
+## How CI uses it
+
+`.azure-pipelines/build-template.yml`, inside `container: sonic-slave-*`, clones
+sonic-swss-common to get the branch-versioned tool and runs:
+
+```bash
+PYTHONPATH=/tmp/sw-common/ci python3 -m buildenv_setup \
+    --repo-dir $(Build.SourcesDirectory) --scope build \
+    --arch <arch> --debian-version <deb> --branch $(BUILD_BRANCH)
+ASAN=<asan> ./build-env/build.sh
+```
+
+`buildenv_setup` installs apt dependencies, resolves and installs the
+common-libs / libswsscommon / VPP DEBs, walks swss-common's published
+`build-env/` cascade, and runs the Redis / sswsyncd / rsyslog hooks. The VPP
+install uses `VPP_INSTALL_SKIP_SYSCTL=1` for its maintainer scripts.
+
+## Local development
+
+```bash
+cd build-env
+DEBIAN_VERSION=bookworm docker compose run --rm build
+DEBIAN_VERSION=bookworm docker compose run --rm shell
+```
+
+From the shell, run the same post-build unit-test sequence as CI:
+
+```bash
+setcap "cap_sys_time=eip" syncd/.libs/syncd_tests
+setcap "cap_dac_override,cap_ipc_lock,cap_ipc_owner,cap_sys_time=eip" \
+    unittest/syncd/.libs/tests
+make check
+```
+
+The image bakes dependency setup while the source tree is mounted live at
+`/workspace`, so ordinary edits do not require an image rebuild. Set
+`SWSS_COMMON_REF` and `BUILD_BRANCH` when testing matching non-master branches.
+The `build` service reproduces CI's dependency setup and package build. Use the
+`shell` service to run CI's post-build `setcap` + `make check` sequence when
+testing C++ changes. The full VS/DVS suite still needs CI-like
+KVM/privileged/nested-docker infrastructure.

--- a/build-env/build.sh
+++ b/build-env/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Canonical build for sonic-sairedis.
+#
+# Single source of truth for "how to build this repo", used by BOTH CI
+# (.azure-pipelines/build-template.yml) and local dev (build-env/compose.yaml).
+# Must NOT depend on CI-only environment variables (only the optional ASAN flag).
+#
+# The build environment (apt/pip deps + upstream libnl/libyang/vpp/swss-common
+# artifacts) is set up beforehand by `buildenv_setup` (see build-env/README.md);
+# this script only runs the actual package build.
+#
+#   ASAN=true ./build-env/build.sh    # build with AddressSanitizer instead of gcov
+set -ex
+
+# Run from the repo root regardless of where we were invoked.
+cd "$(dirname "$0")/.."
+
+extraflags='--enable-code-coverage'
+case "${ASAN:-false}" in
+  [Tt]rue|1|yes) extraflags='--enable-asan' ;;
+esac
+
+rm -f ../*.deb || true
+./autogen.sh
+DEB_BUILD_OPTIONS=nocheck DEB_CONFIGURE_EXTRA_FLAGS="$extraflags" \
+  dpkg-buildpackage -us -uc -b -Psyncd,vs,nopython2 -j"$(nproc)"
+
+# Collect the built .debs at the repo root (where CI publishes from).
+mv ../*.deb .

--- a/build-env/compose.yaml
+++ b/build-env/compose.yaml
@@ -1,0 +1,33 @@
+# Local-dev convenience for building sonic-sairedis in a CI-like container.
+#
+# Usage:
+#   cd build-env
+#   DEBIAN_VERSION=bookworm docker compose run --rm build     # build the .debs
+#   DEBIAN_VERSION=bookworm docker compose run --rm shell     # interactive shell
+#
+# The repo is mounted live at /workspace, so edits on the host are immediately
+# visible in the container without rebuilding the image (only a change to
+# build-env/ dependency declarations requires an image rebuild). Set ASAN=true to
+# build with AddressSanitizer instead of gcov.
+
+services:
+  build:
+    build:
+      context: ..
+      dockerfile: build-env/Dockerfile
+      args:
+        DEBIAN_VERSION: ${DEBIAN_VERSION:-bookworm}
+        BUILD_BRANCH: ${BUILD_BRANCH:-master}
+        SWSS_COMMON_REF: ${SWSS_COMMON_REF:-master}
+    privileged: true
+    volumes:
+      - ..:/workspace
+    working_dir: /workspace
+    environment:
+      ASAN: ${ASAN:-false}
+    command: ["./build-env/build.sh"]
+
+  shell:
+    extends:
+      service: build
+    command: ["/bin/bash"]

--- a/build-env/packages/base.yaml
+++ b/build-env/packages/base.yaml
@@ -1,0 +1,34 @@
+# sonic-sairedis build dependencies (apt + pip).
+#
+# base.yaml CASCADES: repos downstream of sonic-sairedis (sonic-swss) that build
+# against libsairedis inherit everything declared here.
+#
+# Consumed by `buildenv_setup --scope build`. The buildenv_setup tool itself
+# lives in sonic-swss-common/ci/; sonic-sairedis is a consumer.
+
+packages:
+  # --- core C/C++ build + link dependencies (from build-template.yml) --------
+  - libdbus-glib-1-dev
+  - libpcsclite-dev
+  - libhiredis-dev
+  - swig
+  - libzmq3-dev
+  - autoconf-archive
+
+  # sonic-swss-common's cascaded base.yaml supplies the stock libnl-{3,genl,
+  # route,nf}-dev packages on every architecture. Preserve sairedis's existing
+  # split behavior: amd64 then replaces those with SONiC libnl DEBs from the
+  # direct common-libs upstream; arm builds keep stock apt libnl and additionally
+  # need the CLI headers that swss-common does not declare.
+  - { name: libnl-cli-3-dev, when: { arch: { not: amd64 } } }
+
+post_install:
+  # sonic-swss-common deliberately applies this hook only to its test scope
+  # because its Build stage needs Redis down during an early Rust test. Sairedis
+  # needs Redis configured before `make check`, so select the same canonical
+  # script for build + test here. The script body is NOT duplicated:
+  # post_install.resolve_script finds it in the cascaded swss-common build-env/.
+  - name: configure-redis-for-tests
+    source: configure-redis-for-tests.sh
+    requires: [redis-server]
+    scopes: [build, test]

--- a/build-env/packages/tooling.yaml
+++ b/build-env/packages/tooling.yaml
@@ -1,0 +1,38 @@
+# sonic-sairedis Build-stage-only tooling (does NOT cascade downstream).
+#
+# Packages/config needed by sonic-sairedis's own build + unit tests but not by
+# repos that merely build against libsairedis. Consumed by
+# `buildenv_setup --scope build`.
+
+packages:
+  # man-page / doc generation used during the sairedis build
+  - docbook-to-man
+  - docbook-utils
+  - aspell-en
+  # syslog used by the unit tests
+  - rsyslog
+
+post_install:
+  # Inline hooks must handle both CI (non-root + sudo) and the local-dev
+  # Dockerfile (root + --no-sudo, where sudo may not be installed).
+  - name: mkdir-sswsyncd
+    script: |
+      SUDO=""
+      if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+        SUDO=sudo
+      fi
+      $SUDO mkdir -m 755 -p /var/run/sswsyncd
+    scopes: [build]
+
+  # Start rsyslog so tests that log to syslog work. The post-build
+  # "Update rsyslog.conf" step in build-template.yml swaps in azsyslog.conf and
+  # restarts rsyslogd; that stays in the template because it runs after build.
+  - name: start-rsyslog
+    script: |
+      SUDO=""
+      if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+        SUDO=sudo
+      fi
+      $SUDO rsyslogd
+    requires: [rsyslog]
+    scopes: [build]

--- a/build-env/packages/tooling.yaml
+++ b/build-env/packages/tooling.yaml
@@ -33,6 +33,8 @@ post_install:
       if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
         SUDO=sudo
       fi
-      $SUDO rsyslogd
+      if ! pgrep -x rsyslogd >/dev/null; then
+        $SUDO rsyslogd
+      fi
     requires: [rsyslog]
     scopes: [build]

--- a/build-env/upstream-artifacts.yaml
+++ b/build-env/upstream-artifacts.yaml
@@ -1,0 +1,76 @@
+# Upstream build artifacts that sonic-sairedis needs at build time.
+#
+# Consumed by `buildenv_setup`, which downloads each via the Azure DevOps REST
+# API (or uses a --upstream-staged-dir/<name>/ bundle when staged in the same
+# pipeline run, e.g. sonic-swss-common's own CI building sairedis downstream).
+#
+# Artifact-name convention: amd64 has no arch suffix; non-amd64 appends .{arch}.
+
+upstream:
+  # Keep this entry before sonic-swss-common. The swss-common bundle cascades to
+  # an upstream with the same logical name; the first occurrence wins, so this
+  # superset must provide both sairedis's direct common-lib needs (SONiC libnl
+  # on amd64) and swss-common's transitive libyang3/libyang-dev needs.
+  - name: common-libs
+    project: build
+    pipeline: Azure.sonic-buildimage.common_libs
+    cascade_optional: true
+    result_filter: [succeeded]
+    apt_fix_broken: true
+    artifact_name:
+      - { when: { arch: amd64 },          value: 'common-lib' }
+      - { when: { arch: { not: amd64 } }, value: 'common-lib.{arch}' }
+    debs:
+      # Preserve the current Build template's behavior: SONiC libnl on amd64,
+      # stock apt libnl on arm.
+      - { path: 'target/debs/{debian_version}/libnl-3*.deb',       when: { arch: amd64 } }
+      - { path: 'target/debs/{debian_version}/libnl-genl*.deb',    when: { arch: amd64 } }
+      - { path: 'target/debs/{debian_version}/libnl-route*.deb',   when: { arch: amd64 } }
+      - { path: 'target/debs/{debian_version}/libnl-nf*.deb',      when: { arch: amd64 } }
+      # Superset of the nested swss-common common-libs entry. libpcre3 is not
+      # listed: the current download pattern is a no-op because common-lib does
+      # not publish that DEB, while buildenv_setup intentionally fails on an
+      # unmatched requested artifact.
+      - 'target/debs/{debian_version}/libyang3_*.deb'
+      - 'target/debs/{debian_version}/libyang-dev_3*.deb'
+
+  # sonic-swss-common libraries that sonic-sairedis links against. This is the
+  # core cascading upstream: its published build-env/ contributes base packages,
+  # the shared Redis configuration script, and any future transitive upstreams.
+  - name: sonic-swss-common
+    project: build
+    pipeline: Azure.sonic-swss-common
+    cascade_optional: false
+    result_filter: [succeeded, partiallySucceeded]
+    artifact_name:
+      - { when: { arch: amd64 },          value: 'sonic-swss-common-{debian_version}' }
+      - { when: { arch: { not: amd64 } }, value: 'sonic-swss-common-{debian_version}.{arch}' }
+    debs:
+      - 'libswsscommon_1.0.0_{arch}.deb'
+      - 'libswsscommon-dev_1.0.0_{arch}.deb'
+
+  # sonic platform-vpp DEBs (amd64 only). This upstream intentionally tracks
+  # master, matching the existing pipeline.
+  - name: vpp
+    project: build
+    pipeline: sonic-net.sonic-platform-vpp
+    branch: master
+    when: { arch: amd64 }
+    cascade_optional: true
+    result_filter: [succeeded, partiallySucceeded]
+    apt_fix_broken: true
+    # VPP maintainer scripts call sysctl, which fails in the privileged-but-
+    # restricted CI container. Keep VPP in its own dpkg group and skip sysctl.
+    install_env: { VPP_INSTALL_SKIP_SYSCTL: "1" }
+    artifact_name: 'vpp-{debian_version}'
+    debs:
+      - 'libvppinfra-dev_*_{arch}.deb'
+      - 'libvppinfra_*_{arch}.deb'
+      - 'vpp_*_{arch}.deb'
+      - 'vpp-crypto-engines_*_{arch}.deb'
+      - 'vpp-dbg_*_{arch}.deb'
+      - 'vpp-dev_*_{arch}.deb'
+      - 'vpp-plugin-core_*_{arch}.deb'
+      - 'vpp-plugin-devtools_*_{arch}.deb'
+      - 'vpp-plugin-dpdk_*_{arch}.deb'
+      - 'python3-vpp-api_*_{arch}.deb'


### PR DESCRIPTION
## Summary

Phase 2A of the dataplane CI-unification migration, following the merged
sonic-swss-common tool/canary PR #1222.

This PR makes sonic-sairedis's `build-env/` the single source of truth for its
Build-stage environment and replaces the duplicated apt/artifact/Redis/VPP setup
in `.azure-pipelines/build-template.yml` with the shared `buildenv_setup` tool
hosted by sonic-swss-common.

### What changes

- Add declarative `build-env/` configuration:
  - `packages/base.yaml` — sairedis build/link dependencies that cascade downstream.
  - `packages/tooling.yaml` — Build-only doc/rsyslog/sswsyncd setup.
  - `upstream-artifacts.yaml` — common-libs, sonic-swss-common, and VPP artifacts.
- Add canonical `build-env/build.sh`, used by both CI and local development.
- Add Docker Compose local-development support using the same setup config + build command as CI.
- Cut the complete sairedis Build matrix over (`Build`, `BuildAsan`, `BuildArm`, `BuildTrixie`).
- Publish `build-env/` additively beside the existing top-level DEBs so sonic-swss can cascade it later.
- Make the Build template reusable via `repo` + `staged_upstreams`, including required-staged fail-fast behavior for future same-run downstream builds.

### Behavior preserved / intentionally inherited

- **libnl:** preserve today's split — SONiC-built common-lib DEBs on amd64; stock apt libnl plus CLI headers on arm.
- **VPP:** remains amd64-only/master and installs with `VPP_INSTALL_SKIP_SYSCTL=1`; VPP stays in its own dpkg group.
- **Result filters:** common-libs requires success; swss-common and VPP continue allowing partially-successful builds.
- **Redis:** reuse sonic-swss-common's canonical `configure-redis-for-tests.sh` through the published artifact cascade (including `notify-keyspace-events AKE`, previously PoC-verified against sairedis).
- ASAN vs coverage build flags, post-build rsyslog rewrite, setcap/make-check tests, coverage and syslog publication remain unchanged.

### Scope boundaries

This PR changes the **Build-family stages only**. `BuildSwss`, `BuildDocker*`, and `Test*` remain on their existing local templates and setup paths; those are separate migration slices.

## Validation

- YAML parsing and `build-env/build.sh` shell syntax.
- `docker compose config` validation.
- `buildenv_setup --dry-run` for bookworm + trixie across amd64/armhf/arm64.
- Matrix assertions for conditional libnl packages, upstream artifact selection, inherited swss-common packages/libyang binding, post-install ordering, and Redis-script resolution.
- Synthetic end-to-end staged-cascade test covering:
  - direct common-libs,
  - required same-run sonic-swss-common bundle,
  - nested sonic-buildimage wheels,
  - VPP's isolated install environment,
  - package/post-install cascading.
- Existing compatibility was previously proven by pins-only validation draft #1990 against the pre-merge #1222 artifact (Build + VS Test green).


Design context: sonic-net/SONiC#2419.
