### PR TITLE
[Flexcounter] Poll only initialized PHY/Serdes attributes

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2598,27 +2598,33 @@ public:
             const auto &rid = kv.second->rid;
             const auto &attrIds = kv.second->counter_ids;
 
-            std::vector<sai_attribute_t> attrs(attrIds.size());
+            std::vector<sai_attribute_t> attrs = {};
             PortPhyAttributeData attrData;
 
             SWSS_LOG_DEBUG("Collecting %zu port attributes for VID 0x%" PRIx64 ", RID:0x%" PRIx64,
                            attrIds.size(), vid, rid);
 
-            bool attrDataInitialized = true;
             for (size_t i = 0; i < attrIds.size(); i++)
             {
-                attrs[i].id = attrIds[i];
-                if (!initAttrData(rid, &attrs[i], &attrData))
+                sai_attribute_t attr = {};
+                attr.id = attrIds[i];
+                if (!initAttrData(rid, &attr, &attrData))
                 {
-                    SWSS_LOG_WARN("PORT_PHY_ATTR: Failed to initialize attribute %d for RID:0x%" PRIx64 ", skipping object",
-                                  attrIds[i], rid);
-                    attrDataInitialized = false;
-                    break;
+                    SWSS_LOG_WARN(
+                        "PORT_PHY_ATTR: Failed to initialize attribute"
+                        " %d for RID:0x%" PRIx64 ", "
+                        "skipping this attribute only",
+                        attrIds[i], rid);
+                    continue;
                 }
+                attrs.push_back(attr);
             }
 
-            if (!attrDataInitialized)
+            if (attrs.empty())
             {
+                SWSS_LOG_WARN(
+                    "PORT_PHY_ATTR: No attributes could be initialized"
+                    " for RID:0x%" PRIx64 ", skipping object", rid);
                 continue;
             }
 
@@ -2626,7 +2632,7 @@ public:
             sai_status_t status = Base::m_vendorSai->get(
                     Base::m_objectType,
                     rid,
-                    static_cast<uint32_t>(attrIds.size()),
+                    static_cast<uint32_t>(attrs.size()),
                     attrs.data());
 
             if (status != SAI_STATUS_SUCCESS)
@@ -2639,7 +2645,7 @@ public:
             // Store in PORT_PHY_ATTR table using VID as key
             std::string vid_str = sai_serialize_object_id(vid);
 
-            for (size_t i = 0; i != attrIds.size(); i++)
+            for (size_t i = 0; i != attrs.size(); i++)
             {
                 auto meta = sai_metadata_get_attr_metadata(Base::m_objectType, attrs[i].id);
                 if (!meta)
@@ -2648,10 +2654,10 @@ public:
                     continue;
                 }
 
-                auto it = m_attrAliases.find(attrIds[i]);
+                auto it = m_attrAliases.find(static_cast<sai_port_attr_t>(attrs[i].id));
                 if (it == m_attrAliases.end())
                 {
-                    SWSS_LOG_ERROR("Unsupported PORT_PHY_ATTR: %d", attrIds[i]);
+                    SWSS_LOG_ERROR("Unsupported PORT_PHY_ATTR: %d", attrs[i].id);
                     continue;
                 }
 
@@ -2661,10 +2667,10 @@ public:
                 if (meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST)
                 {
                     // Compare current lane values with previous and update metadata
-                    updateLatchedLaneMetadata(vid, attrIds[i], attrs[i]);
+                    updateLatchedLaneMetadata(vid, static_cast<sai_port_attr_t>(attrs[i].id), attrs[i]);
 
                     // Serialize with timestamp and count per lane
-                    attr_value = buildLatchStatusWithMetadata(vid, attrIds[i], attrs[i]);
+                    attr_value = buildLatchStatusWithMetadata(vid, static_cast<sai_port_attr_t>(attrs[i].id), attrs[i]);
                 }
                 else
                 {
@@ -3135,36 +3141,45 @@ public:
             const auto &rid = kv.second->rid;
             const auto &attrIds = kv.second->counter_ids;
 
-
-            std::vector<sai_attribute_t> attrs(attrIds.size());
+            std::vector<sai_attribute_t> attrs = {};
             PortPhySerdesAttributeData attrData;
 
-            SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Collecting %zu port serdes attributes with VID 0x%" PRIx64 ", RID:0x%" PRIx64,
-                           attrIds.size(), vid, rid);
+            SWSS_LOG_DEBUG(
+                "PORT_PHY_SERDES_ATTR: Collecting %zu port serdes attributes "
+                "with VID 0x%" PRIx64 ", RID:0x%" PRIx64,
+                attrIds.size(), vid, rid);
 
-            // Initialize all attributes - if any fail, skip this object
-            bool attrDataInitialized = true;
+            // Initialize attributes - only collect successfully initialized ones
             for (size_t i = 0; i < attrIds.size(); i++)
             {
-                attrs[i].id = attrIds[i];
-                if (!initAttrData(rid, &attrs[i], &attrData))
+                sai_attribute_t attr = {};
+                attr.id = attrIds[i];
+                if (!initAttrData(rid, &attr, &attrData))
                 {
-                    SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: Failed to initialize attribute %s for RID:0x%" PRIx64 ", skipping object",
-                                  sai_serialize_port_serdes_attr(attrIds[i]).c_str(), rid);
-                    attrDataInitialized = false;
-                    break;
+                    SWSS_LOG_WARN(
+                        "PORT_PHY_SERDES_ATTR: Failed to initialize "
+                        "attribute %s for RID:0x%" PRIx64 ", "
+                        "skipping this attribute only",
+                        sai_serialize_port_serdes_attr(attrIds[i]).c_str(),
+                        rid);
+                    continue;
                 }
+                attrs.push_back(attr);
             }
 
-            if (!attrDataInitialized)
+            if (attrs.empty())
             {
+                SWSS_LOG_WARN(
+                    "PORT_PHY_SERDES_ATTR: No attributes could be "
+                    "initialized for RID:0x%" PRIx64 ", "
+                    "skipping object", rid);
                 continue;
             }
 
             sai_status_t status = Base::m_vendorSai->get(
                     Base::m_objectType,
                     rid,
-                    static_cast<uint32_t>(attrIds.size()),
+                    static_cast<uint32_t>(attrs.size()),
                     attrs.data());
 
             if (status != SAI_STATUS_SUCCESS)
@@ -3184,7 +3199,7 @@ public:
 
             std::string port_vid_str = sai_serialize_object_id(port_it->second.port_vid);
 
-            for (size_t i = 0; i != attrIds.size(); i++)
+            for (size_t i = 0; i != attrs.size(); i++)
             {
                 auto meta = sai_metadata_get_attr_metadata(Base::m_objectType, attrs[i].id);
                 if (!meta)
@@ -3193,10 +3208,10 @@ public:
                     continue;
                 }
 
-                auto it = m_attrAliases.find(attrIds[i]);
+                auto it = m_attrAliases.find(static_cast<sai_port_serdes_attr_t>(attrs[i].id));
                 if (it == m_attrAliases.end())
                 {
-                    SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Unsupported PORT_SERDES_ATTR: %d", attrIds[i]);
+                    SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Unsupported PORT_SERDES_ATTR: %d", attrs[i].id);
                     continue;
                 }
 

--- a/unittest/syncd/TestPortPhyAttr.cpp
+++ b/unittest/syncd/TestPortPhyAttr.cpp
@@ -363,3 +363,152 @@ TEST_F(TestPortPhyAttr, CollectDataSkipsWhenInitAttrDataFails)
 
     flexCounter->removeCounter(failPortOid);
 }
+
+/**
+ * Test that collectData() collects only the successfully initialized attributes
+ * when one attribute fails initAttrData(), leaving the others unaffected.
+ *
+ * Scenario: SAI does not support SAI_PORT_ATTR_RX_SIGNAL_DETECT (returns
+ * NOT_SUPPORTED on lane count query), but FEC_ALIGNMENT_LOCK and RX_SNR
+ * are supported and return valid data.
+ *
+ * Expected behaviour after the fix:
+ *   - phy_rx_signal_detect is NOT written to COUNTERS_DB
+ *   - pcs_fec_lane_alignment_lock IS written to COUNTERS_DB with correct data
+ *   - rx_snr IS written to COUNTERS_DB with correct data
+ *   - sai_get() is called once with only the 2 successful attrs
+ */
+TEST_F(TestPortPhyAttr, CollectDataPartialSuccess)
+{
+    sai_object_id_t partialPortOid = 0x1000000000002;
+    sai_object_id_t partialPortRid = 0x1000000000002;
+
+    sai->mock_get = [](sai_object_type_t object_type,
+                      sai_object_id_t /*object_id*/,
+                      uint32_t attr_count,
+                      sai_attribute_t *attr_list) -> sai_status_t
+    {
+        if (object_type != SAI_OBJECT_TYPE_PORT)
+        {
+            return SAI_STATUS_INVALID_PARAMETER;
+        }
+
+        for (uint32_t i = 0; i < attr_count; i++)
+        {
+            switch (attr_list[i].id)
+            {
+                case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
+                    // Simulate unsupported attribute: lane count query fails
+                    return SAI_STATUS_NOT_SUPPORTED;
+
+                case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
+                    if (attr_list[i].value.portlanelatchstatuslist.list == nullptr)
+                    {
+                        attr_list[i].value.portlanelatchstatuslist.count =
+                            MAX_LANES_PER_PORT;
+                        return SAI_STATUS_BUFFER_OVERFLOW;
+                    }
+                    for (uint32_t lane = 0;
+                         lane < attr_list[i].value.portlanelatchstatuslist.count
+                         && lane < MAX_LANES_PER_PORT; lane++)
+                    {
+                        attr_list[i].value.portlanelatchstatuslist.list[lane]
+                            .lane = lane;
+                        attr_list[i].value.portlanelatchstatuslist.list[lane]
+                            .value.changed = (lane % 2 == 0);
+                        attr_list[i].value.portlanelatchstatuslist.list[lane]
+                            .value.current_status = true;
+                    }
+                    attr_list[i].value.portlanelatchstatuslist.count =
+                        std::min(attr_list[i].value.portlanelatchstatuslist.count,
+                                 static_cast<uint32_t>(MAX_LANES_PER_PORT));
+                    break;
+
+                case SAI_PORT_ATTR_RX_SNR:
+                    if (attr_list[i].value.portsnrlist.list == nullptr)
+                    {
+                        attr_list[i].value.portsnrlist.count = MAX_LANES_PER_PORT;
+                        return SAI_STATUS_BUFFER_OVERFLOW;
+                    }
+                    for (uint32_t lane = 0;
+                         lane < attr_list[i].value.portsnrlist.count
+                         && lane < MAX_LANES_PER_PORT; lane++)
+                    {
+                        attr_list[i].value.portsnrlist.list[lane].lane = lane;
+                        attr_list[i].value.portsnrlist.list[lane].snr =
+                            static_cast<sai_uint16_t>(200 + lane);
+                    }
+                    attr_list[i].value.portsnrlist.count =
+                        std::min(attr_list[i].value.portsnrlist.count,
+                                 static_cast<uint32_t>(MAX_LANES_PER_PORT));
+                    break;
+
+                default:
+                    return SAI_STATUS_NOT_SUPPORTED;
+            }
+        }
+        return SAI_STATUS_SUCCESS;
+    };
+
+    vector<swss::FieldValueTuple> portPhyAttrValues;
+    std::string attrIds =
+        "SAI_PORT_ATTR_RX_SIGNAL_DETECT,"
+        "SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK,"
+        "SAI_PORT_ATTR_RX_SNR";
+    portPhyAttrValues.emplace_back(PORT_PHY_ATTR_ID_LIST, attrIds);
+
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT);
+    flexCounter->addCounter(partialPortOid, partialPortRid, portPhyAttrValues);
+
+    vector<swss::FieldValueTuple> pluginValues;
+    pluginValues.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    pluginValues.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    pluginValues.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    flexCounter->addCounterPlugin(pluginValues);
+
+    usleep(1000 * 1050); // 1.05 seconds - one poll cycle
+
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::RedisPipeline pipeline(&db);
+    swss::Table countersTable(&pipeline, PORT_PHY_ATTR_TABLE, false);
+
+    std::string expectedKey = toOid(partialPortOid);
+
+    // The failing attribute must NOT appear in DB
+    std::string rxSignalDetectValue;
+    bool found = countersTable.hget(
+        expectedKey, "phy_rx_signal_detect", rxSignalDetectValue);
+    EXPECT_FALSE(found)
+        << "phy_rx_signal_detect should NOT be in COUNTERS_DB "
+           "when its initAttrData fails";
+
+    // The successful attributes MUST appear in DB with correct data
+    std::string fecAlignmentValue;
+    found = countersTable.hget(
+        expectedKey, "pcs_fec_lane_alignment_lock", fecAlignmentValue);
+    EXPECT_TRUE(found)
+        << "pcs_fec_lane_alignment_lock MUST be in COUNTERS_DB "
+           "even when another attribute's initAttrData failed";
+
+    std::string rxSnrValue;
+    found = countersTable.hget(expectedKey, "rx_snr", rxSnrValue);
+    EXPECT_TRUE(found)
+        << "rx_snr MUST be in COUNTERS_DB "
+           "even when another attribute's initAttrData failed";
+
+    // Spot-check rx_snr lane values
+    for (uint32_t lane = 0; lane < MAX_LANES_PER_PORT; lane++)
+    {
+        uint32_t raw_snr = 200 + lane;
+        double dB = std::round(
+            static_cast<double>(raw_snr) / 256.0 * 100.0) / 100.0;
+        std::ostringstream expected_entry;
+        expected_entry << "\"" << lane << "\":" << dB;
+        EXPECT_TRUE(
+            rxSnrValue.find(expected_entry.str()) != std::string::npos)
+            << "Lane " << lane << " SNR should be " << dB << " dB"
+            << "\nActual: " << rxSnrValue;
+    }
+
+    flexCounter->removeCounter(partialPortOid);
+}

--- a/unittest/syncd/TestPortPhySerdesAttr.cpp
+++ b/unittest/syncd/TestPortPhySerdesAttr.cpp
@@ -356,3 +356,158 @@ TEST_F(TestPortPhySerdesAttr, CollectDataAndValidateCountersDB)
     flexCounter->removeCounter(testPortSerdesOid);
 }
 
+/**
+ * Test that collectData() collects only the successfully initialized serdes
+ * attributes when one attribute fails initAttrData(), leaving others intact.
+ *
+ * Scenario: SAI returns failure for SAI_PORT_SERDES_ATTR_TX_FIR_COUNT so
+ * m_portSerdesTapsCountMap has no entry for this RID, causing initAttrData
+ * for TX_FIR_TAPS_LIST to return false. RX_VGA is fully supported.
+ *
+ * Expected behaviour after the fix:
+ *   - tx_fir_taps_list is NOT written to COUNTERS_DB
+ *   - rx_vga IS written to COUNTERS_DB with correct data
+ */
+TEST_F(TestPortPhySerdesAttr, CollectDataPartialSuccess)
+{
+    sai_object_id_t partialSerdesOid = 0x57000000000002;
+    sai_object_id_t partialSerdesRid = 0x57000000000002;
+    sai_object_id_t partialPortOid   = 0x1000000000002;
+
+    sai->mock_get = [](sai_object_type_t object_type,
+                      sai_object_id_t /*object_id*/,
+                      uint32_t attr_count,
+                      sai_attribute_t *attr_list) -> sai_status_t
+    {
+        if (object_type == SAI_OBJECT_TYPE_PORT_SERDES)
+        {
+            for (uint32_t i = 0; i < attr_count; i++)
+            {
+                switch (attr_list[i].id)
+                {
+                    case SAI_PORT_SERDES_ATTR_PORT_ID:
+                        attr_list[i].value.oid = 0x1000000000002;
+                        break;
+
+                    case SAI_PORT_SERDES_ATTR_TX_FIR_COUNT:
+                        // Simulate SDK busy / not ready: fail the count query
+                        // so m_portSerdesTapsCountMap is never populated and
+                        // initAttrData for TX_FIR_TAPS_LIST returns false.
+                        return SAI_STATUS_OBJECT_IN_USE;
+
+                    case SAI_PORT_SERDES_ATTR_RX_VGA:
+                        if (attr_list[i].value.u32list.list == nullptr)
+                        {
+                            attr_list[i].value.u32list.count = TEST_LANE_COUNT;
+                            return SAI_STATUS_BUFFER_OVERFLOW;
+                        }
+                        for (uint32_t lane = 0;
+                             lane < attr_list[i].value.u32list.count
+                             && lane < TEST_LANE_COUNT; lane++)
+                        {
+                            attr_list[i].value.u32list.list[lane] = 200 + lane;
+                        }
+                        attr_list[i].value.u32list.count =
+                            std::min(attr_list[i].value.u32list.count,
+                                     TEST_LANE_COUNT);
+                        break;
+
+                    default:
+                        return SAI_STATUS_NOT_SUPPORTED;
+                }
+            }
+            return SAI_STATUS_SUCCESS;
+        }
+        else if (object_type == SAI_OBJECT_TYPE_PORT)
+        {
+            for (uint32_t i = 0; i < attr_count; i++)
+            {
+                if (attr_list[i].id == SAI_PORT_ATTR_HW_LANE_LIST)
+                {
+                    if (attr_list[i].value.u32list.list == nullptr)
+                    {
+                        attr_list[i].value.u32list.count = TEST_LANE_COUNT;
+                        return SAI_STATUS_BUFFER_OVERFLOW;
+                    }
+                    for (uint32_t lane = 0;
+                         lane < attr_list[i].value.u32list.count
+                         && lane < TEST_LANE_COUNT; lane++)
+                    {
+                        attr_list[i].value.u32list.list[lane] = lane;
+                    }
+                    attr_list[i].value.u32list.count =
+                        std::min(attr_list[i].value.u32list.count,
+                                 TEST_LANE_COUNT);
+                    return SAI_STATUS_SUCCESS;
+                }
+            }
+        }
+        return SAI_STATUS_INVALID_PARAMETER;
+    };
+
+    // Register the serdes→port VID mapping in COUNTERS_DB
+    swss::DBConnector db("COUNTERS_DB", 0);
+    swss::Table portSerdesIdToPortIdTable(
+        &db, "COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP");
+    portSerdesIdToPortIdTable.hset(
+        "", toOid(partialSerdesOid), toOid(partialPortOid));
+
+    vector<swss::FieldValueTuple> portSerdesAttrValues;
+    std::string attrIds =
+        "SAI_PORT_SERDES_ATTR_RX_VGA,SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST";
+    portSerdesAttrValues.emplace_back(PORT_PHY_SERDES_ATTR_ID_LIST, attrIds);
+
+    test_syncd::mockVidManagerObjectTypeQuery(SAI_OBJECT_TYPE_PORT_SERDES);
+    flexCounter->addCounter(
+        partialSerdesOid, partialSerdesRid, portSerdesAttrValues);
+
+    vector<swss::FieldValueTuple> pluginValues;
+    pluginValues.emplace_back(POLL_INTERVAL_FIELD, "1000");
+    pluginValues.emplace_back(FLEX_COUNTER_STATUS_FIELD, "enable");
+    pluginValues.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
+    flexCounter->addCounterPlugin(pluginValues);
+
+    usleep(1000 * 1050); // 1.05 seconds - one poll cycle
+
+    swss::RedisPipeline pipeline(&db);
+    swss::Table portPhyAttrTable(&pipeline, PORT_PHY_ATTR_TABLE, false);
+
+    std::string expectedKey = toOid(partialPortOid);
+
+    // TX_FIR_TAPS_LIST failed initAttrData → must NOT appear in DB
+    std::string txFirTapsValue;
+    bool found = portPhyAttrTable.hget(
+        expectedKey, "tx_fir_taps_list", txFirTapsValue);
+    EXPECT_FALSE(found)
+        << "tx_fir_taps_list should NOT be in COUNTERS_DB "
+           "when TX_FIR_COUNT query fails";
+
+    // RX_VGA succeeded → MUST appear in DB with correct lane values
+    std::string rxVgaValue;
+    found = portPhyAttrTable.hget(expectedKey, "rx_vga", rxVgaValue);
+    EXPECT_TRUE(found)
+        << "rx_vga MUST be in COUNTERS_DB "
+           "even when TX_FIR_TAPS_LIST initAttrData failed";
+
+    if (found)
+    {
+        json rxVgaJson;
+        ASSERT_NO_THROW(rxVgaJson = json::parse(rxVgaValue))
+            << "rx_vga is not valid JSON: " << rxVgaValue;
+
+        EXPECT_EQ(rxVgaJson.size(), TEST_LANE_COUNT)
+            << "rx_vga should have " << TEST_LANE_COUNT << " lanes";
+
+        for (uint32_t lane = 0; lane < TEST_LANE_COUNT; lane++)
+        {
+            std::string lane_key = std::to_string(lane);
+            ASSERT_TRUE(rxVgaJson.contains(lane_key))
+                << "Missing lane " << lane << " in rx_vga";
+            EXPECT_EQ(rxVgaJson[lane_key].get<uint32_t>(), 200 + lane)
+                << "Lane " << lane << " VGA mismatch";
+        }
+    }
+
+    flexCounter->removeCounter(partialSerdesOid);
+}
+


### PR DESCRIPTION
… not initialized


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Don't skip complete SAI phy/serdes attribute polling for entire serdes object if there is one or more attributes that is NOT supported or initialized correctly.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?


#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
