### PR TITLE
[vpp] Support SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED in saivpp

### DIFF
--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -2080,6 +2080,23 @@ sai_status_t SwitchVpp::set(
                     m_tunnel_mgr.set_vxlan_port(attr);
                     break;
                 }
+            case SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED:
+                {
+                    // VPP mixes a global "router id" into the IPv4/IPv6 ECMP
+                    // flow hash (ip4_inlines.h / ip6_inlines.h). Map the SAI
+                    // ECMP hash seed onto it so that changing the seed
+                    // re-distributes ECMP/LAG path selection. Fall through to
+                    // set_internal() below so the attribute is also cached.
+                    uint32_t seed = attr->value.u32;
+                    int rc = vpp_ip_flow_hash_router_id_set(seed);
+                    if (rc != 0)
+                    {
+                        SWSS_LOG_ERROR("VPP set ECMP default hash seed=%u failed rc=%d", seed, rc);
+                        return SAI_STATUS_FAILURE;
+                    }
+                    SWSS_LOG_NOTICE("VPP set ECMP default hash seed=%u", seed);
+                    break;
+                }
         }
     }
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1069,6 +1069,13 @@ vl_api_set_ip_flow_hash_v2_reply_t_handler (vl_api_ip_route_add_del_reply_t *msg
 }
 
 static void
+vl_api_set_ip_flow_hash_router_id_reply_t_handler (vl_api_set_ip_flow_hash_router_id_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void
 vl_api_ip_neighbor_add_del_reply_t_handler (vl_api_ip_neighbor_add_del_reply_t *msg)
 {
     int retval = (int)ntohl((uint32_t)msg->retval);
@@ -1634,6 +1641,7 @@ static void vpp_base_vpe_init(void)
     _(IP_MSG_ID(IP_ROUTE_ADD_DEL_REPLY), ip_route_add_del_reply) \
     _(IP_MSG_ID(SW_INTERFACE_IP6_ENABLE_DISABLE_REPLY), sw_interface_ip6_enable_disable_reply) \
     _(IP_MSG_ID(SET_IP_FLOW_HASH_V2_REPLY), set_ip_flow_hash_v2_reply)        \
+    _(IP_MSG_ID(SET_IP_FLOW_HASH_ROUTER_ID_REPLY), set_ip_flow_hash_router_id_reply) \
     _(IP_MSG_ID(IP_ADDRESS_DETAILS), ip_address_details) \
     _(IP_NBR_MSG_ID(IP_NEIGHBOR_ADD_DEL_REPLY), ip_neighbor_add_del_reply) \
     _(L2_MSG_ID(BRIDGE_DOMAIN_ADD_DEL_REPLY), bridge_domain_add_del_reply) \
@@ -3177,6 +3185,37 @@ int vpp_ip_flow_hash_set (uint32_t vrf_id, uint32_t hash_mask, int addr_family)
 
     if (ret) { SAIVPP_ERROR("%s failed(%d) vrf_id %u af %d", __func__, ret, vrf_id, addr_family); }
     else { SAIVPP_INFO("%s vrf_id %u af %d", __func__, vrf_id, addr_family); }
+
+    VPP_UNLOCK();
+
+    return ret;
+}
+
+/*
+ * Set the global ECMP flow-hash "router ID" -- the per-router value VPP mixes
+ * into the IPv4/IPv6 ECMP flow hash (see ip4_inlines.h / ip6_inlines.h:
+ * "a ^= ip_flow_hash_router_id"). This is the natural backend for the SAI
+ * switch attribute SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED: changing it
+ * re-distributes ECMP/LAG path selection without touching any per-flow state.
+ */
+int vpp_ip_flow_hash_router_id_set (uint32_t router_id)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_set_ip_flow_hash_router_id_t *mp;
+    int ret;
+
+    VPP_LOCK();
+
+    __plugin_msg_base = ip_msg_id_base;
+
+    M (SET_IP_FLOW_HASH_ROUTER_ID, mp);
+    mp->router_id = htonl(router_id);
+
+    S (mp);
+    WR (ret);
+
+    if (ret) { SAIVPP_ERROR("%s failed(%d) router_id %u", __func__, ret, router_id); }
+    else { SAIVPP_INFO("%s router_id %u", __func__, router_id); }
 
     VPP_UNLOCK();
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -312,6 +312,7 @@ typedef enum {
     extern int ip_route_add_del(vpp_ip_route_t *prefix, bool is_add);
     extern int ip_route_add_del_get_stats(vpp_ip_route_t *prefix, bool is_add, uint32_t *stats_index);
     extern int vpp_ip_flow_hash_set(uint32_t vrf_id, uint32_t mask, int addr_family);
+    extern int vpp_ip_flow_hash_router_id_set(uint32_t router_id);
 
     extern int vpp_acl_add_replace(vpp_acl_t *in_acl, uint32_t *acl_index, bool is_replace);
     extern int vpp_acl_del(uint32_t acl_index);


### PR DESCRIPTION
### Description of PR

Summary: Implement `SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED` in saivpp by mapping it onto VPP's global ECMP flow-hash router ID (`ip_flow_hash_router_id`), which VPP already mixes into the IPv4/IPv6 ECMP hash. Setting it re-distributes ECMP/LAG path selection — exactly the SAI hash-seed semantic, so no VPP change is needed.

Part of sonic-net/sonic-buildimage#25760.

> [!NOTE]
> Companion PR sonic-net/sonic-mgmt#26756 enables `ecmp/test_ecmp_balance.py` on sonic-vpp and depends on this being in the image, so it merges after this one.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?

`test_udp_packets_ecmp` needs a settable ECMP hash seed. VPP has no vppctl CLI for the router ID — only the binary API behind SAI — so the seed must travel `swssconfig` → APPL_DB → orchagent → `SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED` → saivpp → VPP. saivpp was the missing link.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

3 files, +57:

| File | Change |
|---|---|
| `vppxlate/SaiVppXlate.h` | Declare `vpp_ip_flow_hash_router_id_set(uint32_t)`. |
| `vppxlate/SaiVppXlate.c` | Wrapper around `set_ip_flow_hash_router_id` (modelled on the adjacent `vpp_ip_flow_hash_set()`) + reply handler + message registration. |
| `SwitchVpp.cpp` | Handle the attribute, then fall through to `set_internal()` so it is cached for GET. |

#### How did you verify/test it?

Builds clean under the sairedis strict flags against current master; `libsaivs.so` exports `vpp_ip_flow_hash_router_id_set` and links `libvlib.so.2606`.

Deployed to `vlab-vpp-01` on the converged `vms-kvm-vpp-t1-lag` testbed (`SONiC.master.1151527`). syslog confirms the handler fires (`VPP set ECMP default hash seed=10`), and `ecmp/test_ecmp_balance.py` passes **4/4**.

On a stock image the same run gives `2 passed, 2 failed` — both `test_udp_packets_ecmp` cases failing on *"results are identical with and without ECMP hash offset change"*, i.e. orchagent sets the attribute but the seed never reaches VPP. That is the gap this PR closes.

#### Any platform specific information?

Confined to `vslib/vpp/`; no other SAI backend or platform is affected.

### Documentation

No HLD required — implements an existing standard SAI attribute in an existing backend.
