### PR TITLE
fix(vpp): restore port tap MAC after LAG removal

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -426,6 +426,8 @@ namespace saivs
                     _In_ sai_object_id_t lag_member_oid);
 	    sai_status_t vpp_remove_lag_member(
                     _In_ sai_object_id_t lag_member_oid);
+	    void restorePortTapMac(
+                    _In_ sai_object_id_t port_oid);
 	    sai_status_t vpp_ensure_lag_lcp(
                     _In_ sai_object_id_t lag_oid);
 	    sai_status_t vpp_set_lag_member_egress_disable(

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1505,11 +1505,64 @@ sai_status_t SwitchVpp::removeLagMember(
         CHECK_STATUS_QUIET(vpp_remove_lag_member(lag_member_oid));
     }
 
+    // teamd restores the member tap's permanent MAC when the port leaves the PortChannel while
+    // VPP keeps the switch MAC, so the routed port would drop L3 traffic sent to the tap MAC.
+    if (port_oid != SAI_NULL_OBJECT_ID)
+    {
+        restorePortTapMac(port_oid);
+    }
+
     auto sid = sai_serialize_object_id(lag_member_oid);
 
     CHECK_STATUS(remove_internal(SAI_OBJECT_TYPE_LAG_MEMBER, sid));
 
     return SAI_STATUS_SUCCESS;
+}
+
+void SwitchVpp::restorePortTapMac(
+        _In_ sai_object_id_t port_oid)
+{
+    SWSS_LOG_ENTER();
+
+    // Best effort repair, the caller must still drop the SAI LAG member because the VPP
+    // detach already happened and failing here would leave the object model inconsistent.
+    std::string if_name;
+
+    if (getTapNameFromPortId(port_oid, if_name) == false)
+    {
+        SWSS_LOG_ERROR("no tap found for port %s, switch MAC not restored",
+                sai_serialize_object_id(port_oid).c_str());
+        return;
+    }
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+
+    sai_status_t status = get(SAI_OBJECT_TYPE_SWITCH, m_switch_id, 1, &attr);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("failed to get SAI_SWITCH_ATTR_SRC_MAC_ADDRESS on switch %s: %s, "
+                "switch MAC not restored on %s",
+                sai_serialize_object_id(m_switch_id).c_str(),
+                sai_serialize_status(status).c_str(),
+                if_name.c_str());
+        return;
+    }
+
+    if (vs_set_dev_mac_address(if_name.c_str(), attr.value.mac) < 0)
+    {
+        SWSS_LOG_ERROR("failed to set MAC address %s on tap %s, the routed port will drop "
+                "traffic addressed to its tap MAC",
+                sai_serialize_mac(attr.value.mac).c_str(),
+                if_name.c_str());
+        return;
+    }
+
+    SWSS_LOG_NOTICE("restored switch MAC %s on tap %s after LAG member removal",
+            sai_serialize_mac(attr.value.mac).c_str(),
+            if_name.c_str());
 }
 
 sai_status_t SwitchVpp::vpp_remove_lag_member(

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1511,6 +1511,11 @@ sai_status_t SwitchVpp::removeLagMember(
     {
         restorePortTapMac(port_oid);
     }
+    else
+    {
+        SWSS_LOG_WARN("no port found for LAG member %s, tap MAC not restored",
+                sai_serialize_object_id(lag_member_oid).c_str());
+    }
 
     auto sid = sai_serialize_object_id(lag_member_oid);
 


### PR DESCRIPTION
### Description of PR

Summary:
Restore the Linux hostif tap MAC to the switch source MAC after a physical port leaves a VPP LAG.

Related to #1662

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

`arp/test_neighbor_mac.py::TestNeighborMac::testNeighborMac[0]` is failing on `t1-lag-vpp` after removing `Ethernet0` from `PortChannel102` and using it as a routed interface.

Over the last 14 days, the signature affected 405 of 943 VPP PR plans (42.95%), with 167 plans exhausting all retries. A local run reproduced the exact 120-second PTF-to-DUT ping failure using image `SONiC.master-28819.1183023-66e2de6ac`.

Sample failing Elastictest plan: https://elastictest.org/scheduler/testplan/6a7168d4b63289adaeeee6a4?searchTestCase=arp%2F&testcase=arp%2Ftest_neighbor_mac.py%7C%7C%7C2&type=console

The failing state had a valid RIF, connected/local FIB entries, a learned PTF neighbor, and successful ARP replies. However, Linux teamd had restored the detached tap's permanent MAC (`52:54:00:44:86:c4`) while VPP retained the switch MAC (`22:5d:a7:7e:b7:8e`). PTF therefore learned the tap MAC, but unicast ICMP traffic to that MAC was not accepted by the VPP routed interface.

##### Work item tracking
- Microsoft ADO **(number only)**: 39081324

#### How did you do it?

After either the normal LAG detach path or the already-egress-disabled path, `removeLagMember()` now restores the port tap MAC to `SAI_SWITCH_ATTR_SRC_MAC_ADDRESS` before deleting the internal LAG member object.

The repair is best effort because the VPP detach has already completed. Failures are logged with the affected port or tap, while LAG object removal continues to avoid leaving the SAI object model inconsistent with the dataplane.

#### How did you verify/test it?

- Reproduced the exact failure locally after replaying the fleet predecessor sequence.
- Confirmed that enabling VPP promiscuous mode alone did not help: all 52 probes still failed.
- Changed only the Linux `Ethernet0` MAC to the switch/VPP MAC during a failing loop. Attempts 28-33 failed, attempt 34 passed immediately, `testNeighborMac[1]` passed on its first probe, and the module completed with 2 passed.
- Ran `git diff --check`.
- Ran a C++17 syntax and format harness against the changed helper and call site with `-Wall -Wextra -Wformat=2 -Werror`.
- CI amd64 and ASAN builds and unit tests passed.

A full `t1-lag-vpp` image run with a syncd binary built from this branch remains pending.

#### Any platform specific information?

The change only affects the VPP virtual switch implementation.

### Documentation

N/A
