### PR TITLE
[vpp] Handle VLAN router interface attribute updates on the BVI

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -382,6 +382,12 @@ namespace saivs
 
             sai_status_t vpp_delete_bvi_interface(
                     _In_ sai_object_id_t bvi_obj_id);
+
+            sai_status_t vpp_update_bvi_interface(
+                    _In_ sai_object_id_t rif_obj_id,
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list);
+
             sai_status_t createLag(
                     _In_ sai_object_id_t object_id,
                     _In_ sai_object_id_t switch_id,

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -890,6 +890,106 @@ sai_status_t SwitchVpp::vpp_create_bvi_interface(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchVpp::vpp_update_bvi_interface(
+        _In_ sai_object_id_t rif_obj_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    // A VLAN RIF is realized in VPP as a BVI named "bvi<vlan_id>". The VLAN id
+    // is not part of the update attribute list, so resolve it from the RIF's
+    // stored SAI_ROUTER_INTERFACE_ATTR_VLAN_ID (mirrors vpp_create_bvi_interface).
+    sai_attribute_t attr;
+    attr.id = SAI_ROUTER_INTERFACE_ATTR_VLAN_ID;
+
+    sai_status_t status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_obj_id, 1, &attr);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get vlan id for router interface %s (status %d)",
+                       sai_serialize_object_id(rif_obj_id).c_str(), status);
+        return SAI_STATUS_FAILURE;
+    }
+
+    sai_object_id_t vlan_oid = attr.value.oid;
+
+    if (objectTypeQuery(vlan_oid) != SAI_OBJECT_TYPE_VLAN)
+    {
+        SWSS_LOG_ERROR("SAI_ROUTER_INTERFACE_ATTR_VLAN_ID=%s is not a VLAN object",
+                       sai_serialize_object_id(vlan_oid).c_str());
+        return SAI_STATUS_FAILURE;
+    }
+
+    attr.id = SAI_VLAN_ATTR_VLAN_ID;
+    status = get(SAI_OBJECT_TYPE_VLAN, vlan_oid, 1, &attr);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get SAI_VLAN_ATTR_VLAN_ID for VLAN %s (router interface %s, status %d)",
+                       sai_serialize_object_id(vlan_oid).c_str(),
+                       sai_serialize_object_id(rif_obj_id).c_str(), status);
+        return status;
+    }
+
+    uint32_t vlan_id = attr.value.u16;
+
+    if (vlan_id == 0)
+    {
+        SWSS_LOG_ERROR("Unable to resolve VLAN id for router interface %s",
+                       sai_serialize_object_id(rif_obj_id).c_str());
+        return SAI_STATUS_FAILURE;
+    }
+
+    char hwif_name[32];
+    snprintf(hwif_name, sizeof(hwif_name), "bvi%u", vlan_id);
+
+    auto sid = sai_serialize_object_id(rif_obj_id);
+
+    // Apply the source MAC update
+    auto attr_mac = sai_metadata_get_attr_by_id(SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS, attr_count, attr_list);
+
+    if (attr_mac != NULL)
+    {
+        sai_mac_t mac_addr;
+        memcpy(mac_addr, attr_mac->value.mac, sizeof(sai_mac_t));
+
+        int ret = sw_interface_set_mac(hwif_name, mac_addr);
+
+        if (ret < 0)
+        {
+            SWSS_LOG_ERROR("failed to set MAC %s on BVI %s (ret %d)",
+                           sai_serialize_mac(attr_mac->value.mac).c_str(), hwif_name, ret);
+            return SAI_STATUS_FAILURE;
+        }
+
+        SWSS_LOG_INFO("Set MAC %s on BVI %s",
+                      sai_serialize_mac(attr_mac->value.mac).c_str(), hwif_name);
+        set_internal(SAI_OBJECT_TYPE_ROUTER_INTERFACE, sid, attr_mac);
+    }
+
+    // Apply the MTU update
+    auto attr_mtu = sai_metadata_get_attr_by_id(SAI_ROUTER_INTERFACE_ATTR_MTU, attr_count, attr_list);
+
+    if (attr_mtu != NULL)
+    {
+        int ret = sw_interface_set_mtu(hwif_name, attr_mtu->value.u32);
+
+        if (ret < 0)
+        {
+            SWSS_LOG_ERROR("failed to set MTU %u on BVI %s (ret %d)",
+                           attr_mtu->value.u32, hwif_name, ret);
+            return SAI_STATUS_FAILURE;
+        }
+
+        SWSS_LOG_INFO("Set MTU %u on BVI %s", attr_mtu->value.u32, hwif_name);
+
+        set_internal(SAI_OBJECT_TYPE_ROUTER_INTERFACE, sid, attr_mtu);
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
 sai_status_t SwitchVpp::vpp_delete_bvi_interface(
         _In_ sai_object_id_t bvi_obj_id)
 {

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1856,6 +1856,11 @@ sai_status_t SwitchVpp::vpp_update_router_interface(
     }
     rif_type = attr.value.s32;
 
+    if (rif_type == SAI_ROUTER_INTERFACE_TYPE_VLAN)
+    {
+        return vpp_update_bvi_interface(object_id, attr_count, attr_list);
+    }
+
     attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
     status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, object_id, 1, &attr);
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-buildimage/issues/28856

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

On the VPP virtual switch, any SAI attribute update to a VLAN‑type router interface fails, wedging orchagent.

`SwitchVpp::set()` routes every `SAI_OBJECT_TYPE_ROUTER_INTERFACE` set to `vpp_update_router_interface()`, which reads `SAI_ROUTER_INTERFACE_ATTR_PORT_ID` before checking the RIF type. A VLAN RIF has no `PORT_ID` (it carries `SAI_ROUTER_INTERFACE_ATTR_VLAN_ID`), so the lookup fails and the whole `SET` returns `SAI_STATUS_FAILURE`. The existing "skip if VLAN" guard is placed after that lookup, so it is unreachable for a VLAN RIF.

Observed on a dual‑ToR VPP DUT: right after the `Vlan1000` SVI RIF is created, orchagent issues a `set_router_interface_attribute(SRC_MAC)` on it. syncd logs:

```
syncd:     vpp_update_router_interface: attr SAI_ROUTER_INTERFACE_ATTR_PORT_ID was not passed
orchagent: doTask: Failed to set router interface mac ... for port Vlan1000, rv:-1
orchagent: handleSaiFailure: ... SAI_API_ROUTER_INTERFACE, status: SAI_STATUS_FAILURE
```

`sairedis.rec` shows the exact failing sequence on the VLAN RIF:

```
|c| ROUTER_INTERFACE ... TYPE=SAI_ROUTER_INTERFACE_TYPE_VLAN VLAN_ID=oid:0x... (no PORT_ID)
|s| ROUTER_INTERFACE ... SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS=...
|E| SAI_STATUS_FAILURE
|a| SYNCD_INVOKE_DUMP
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 39152218

#### How did you do it?

Made the update path symmetric with the create/remove paths, which already branch on `SAI_ROUTER_INTERFACE_TYPE_VLAN` first and delegate to `vpp_create_bvi_interface()` / `vpp_delete_bvi_interface()`.
- add update path handler `vpp_update_bvi_interface`

#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
