### PR TITLE
Fix Y2038 time_t usage in syncd and vslib

### DIFF
--- a/syncd/ComparisonLogic.cpp
+++ b/syncd/ComparisonLogic.cpp
@@ -12,6 +12,7 @@
 #include "meta/SaiAttributeList.h"
 
 #include <inttypes.h>
+#include <random>
 
 using namespace syncd;
 using namespace saimeta;
@@ -64,7 +65,8 @@ ComparisonLogic::ComparisonLogic(
     m_current->m_defaultTrapGroupRid     = m_switch->getSwitchDefaultAttrOid(SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP);
     m_temp->m_defaultTrapGroupRid        = m_switch->getSwitchDefaultAttrOid(SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP);
 
-    auto seed = (unsigned int)std::time(0);
+    std::random_device rd;
+    auto seed = rd();
 
     SWSS_LOG_NOTICE("srand seed for switch %s: %u", sai_serialize_object_id(m_switch->getVid()).c_str(), seed);
 

--- a/vslib/FdbInfo.cpp
+++ b/vslib/FdbInfo.cpp
@@ -173,6 +173,8 @@ void FdbInfo::setTimestamp(
 
 uint32_t FdbInfo::currentEpochTimeSec()
 {
+    SWSS_LOG_ENTER();
+
     time_t now = time(nullptr);
 
     if (now > static_cast<time_t>(UINT32_MAX))

--- a/vslib/FdbInfo.cpp
+++ b/vslib/FdbInfo.cpp
@@ -4,6 +4,9 @@
 
 #include "swss/logger.h"
 
+#include <climits>
+#include <ctime>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 #include <nlohmann/json.hpp>
@@ -166,4 +169,14 @@ void FdbInfo::setTimestamp(
     SWSS_LOG_ENTER();
 
     m_timestamp = timestamp;
+}
+
+uint32_t FdbInfo::currentEpochTimeSec()
+{
+    time_t now = time(nullptr);
+
+    if (now > static_cast<time_t>(UINT32_MAX))
+        return UINT32_MAX;
+
+    return static_cast<uint32_t>(now);
 }

--- a/vslib/FdbInfo.h
+++ b/vslib/FdbInfo.h
@@ -54,6 +54,8 @@ namespace saivs
             void setTimestamp(
                     _In_ uint32_t timestamp);
 
+            static uint32_t currentEpochTimeSec();
+
         public: // serialize
 
             std::string serialize() const;

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -2948,7 +2948,7 @@ void SwitchStateBase::processFdbEntriesForAging()
 
     SWSS_LOG_DEBUG("fdb infos to process: %zu", m_fdb_info_set.size());
 
-    uint32_t current = (uint32_t)time(NULL);
+    uint32_t current = FdbInfo::currentEpochTimeSec();
 
     sai_attribute_t attr;
 

--- a/vslib/SwitchStateBaseFdb.cpp
+++ b/vslib/SwitchStateBaseFdb.cpp
@@ -395,7 +395,7 @@ void SwitchStateBase::process_packet_for_fdb_event(
     // we would need hostif info here and maybe interface index, then we can
     // find host info from index
 
-    uint32_t frametime = (uint32_t)time(NULL);
+    uint32_t frametime = FdbInfo::currentEpochTimeSec();
 
     /*
      * We add +2 in case if frame contains 1Q VLAN tag.


### PR DESCRIPTION
Use std::random_device instead of std::time(0) for srand seeding in ComparisonLogic. Add FdbInfo::currentEpochTimeSec() to safely clamp 64-bit epoch time to uint32_t for FDB aging and packet timestamps.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
