### PR TITLE
Meta-Layer FDB diagnostic improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = meta lib vslib proxylib pyext
+SUBDIRS = meta lib vslib proxylib pyext scripts
 
 if SYNCD
 SUBDIRS += syncd saiplayer saidump saidiscovery saisdkdump saiasiccmp tests unittest

--- a/configure.ac
+++ b/configure.ac
@@ -308,4 +308,5 @@ AC_OUTPUT(Makefile
           unittest/saidump/Makefile
           pyext/Makefile
           pyext/py2/Makefile
-          pyext/py3/Makefile)
+          pyext/py3/Makefile
+          scripts/Makefile)

--- a/debian/libsairedis.install
+++ b/debian/libsairedis.install
@@ -1,1 +1,2 @@
 usr/lib/*/libsairedis*.so.*
+usr/bin/sai-meta-fdb.sh

--- a/lib/RedisChannel.cpp
+++ b/lib/RedisChannel.cpp
@@ -8,13 +8,17 @@
 #include "swss/notificationconsumer.h"
 #include "swss/select.h"
 
+#include <exception>
+
 using namespace sairedis;
 
 RedisChannel::RedisChannel(
         _In_ const std::string& dbAsic,
-        _In_ Channel::Callback callback):
+        _In_ Channel::Callback callback,
+        _In_ Channel::Callback debugCallback):
     Channel(callback),
-    m_dbAsic(dbAsic)
+    m_dbAsic(dbAsic),
+    m_debugCallback(debugCallback)
 {
     SWSS_LOG_ENTER();
 
@@ -52,6 +56,19 @@ RedisChannel::RedisChannel(
     // any per-orch NotificationConsumer that also SUBSCRIBE's to the
     // same "NOTIFICATIONS" channel.
     m_notificationConsumer->setStatsLabel("libsairedis:RedisChannel:" + std::string(REDIS_TABLE_NOTIFICATIONS_PER_DB(dbAsic)));
+
+    if (m_debugCallback)
+    {
+        // Optional operator meta FDB debug channel. Kept entirely separate from
+        // the ASIC NOTIFICATIONS consumer so a flood of operator commands can
+        // never displace real notifications, and vice versa.
+        m_dbNtfDebug = std::make_shared<swss::DBConnector>(dbAsic, 0);
+        m_debugConsumer = std::make_shared<swss::NotificationConsumer>(
+                m_dbNtfDebug.get(),
+                SAIREDIS_META_FDB_DEBUG_CHANNEL);
+
+        SWSS_LOG_NOTICE("subscribed meta FDB debug consumer on channel %s", SAIREDIS_META_FDB_DEBUG_CHANNEL);
+    }
 
     m_runNotificationThread = true;
 
@@ -92,6 +109,11 @@ void RedisChannel::notificationThreadFunction()
     s.addSelectable(m_notificationConsumer.get());
     s.addSelectable(&m_notificationThreadShouldEndEvent);
 
+    if (m_debugConsumer)
+    {
+        s.addSelectable(m_debugConsumer.get());
+    }
+
     while (m_runNotificationThread)
     {
         swss::Selectable *sel;
@@ -111,6 +133,35 @@ void RedisChannel::notificationThreadFunction()
             std::string op;
             std::string data;
             std::vector<swss::FieldValueTuple> values;
+
+            if (m_debugConsumer && sel == m_debugConsumer.get())
+            {
+                // Operator meta FDB debug command. Fully isolated and tolerant:
+                // a malformed command must never disturb real notification
+                // processing, so everything is wrapped in try/catch and we
+                // continue the loop regardless of outcome.
+                try
+                {
+                    m_debugConsumer->pop(op, data, values);
+
+                    SWSS_LOG_NOTICE("meta debug command: op = %s, data = %s", op.c_str(), data.c_str());
+
+                    if (m_debugCallback)
+                    {
+                        m_debugCallback(op, data, values);
+                    }
+                }
+                catch (const std::exception& e)
+                {
+                    SWSS_LOG_ERROR("meta debug command failed and was ignored: %s", e.what());
+                }
+                catch (...)
+                {
+                    SWSS_LOG_ERROR("meta debug command failed and was ignored: unknown exception");
+                }
+
+                continue;
+            }
 
             m_notificationConsumer->pop(op, data, values);
 

--- a/lib/RedisChannel.h
+++ b/lib/RedisChannel.h
@@ -26,7 +26,8 @@ namespace sairedis
 
             RedisChannel(
                     _In_ const std::string& dbAsic,
-                    _In_ Channel::Callback callback);
+                    _In_ Channel::Callback callback,
+                    _In_ Channel::Callback debugCallback = nullptr);
 
             virtual ~RedisChannel();
 
@@ -89,5 +90,29 @@ namespace sairedis
              * @brief Notification consumer.
              */
             std::shared_ptr<swss::NotificationConsumer> m_notificationConsumer;
+
+        private: // operator meta FDB debug channel
+
+            /**
+             * @brief Callback invoked for operator meta FDB debug commands.
+             *
+             * Optional. When null the debug consumer below is not created and
+             * this feature is entirely inert.
+             */
+            Channel::Callback m_debugCallback;
+
+            /**
+             * @brief Database connector for the operator debug channel.
+             */
+            std::shared_ptr<swss::DBConnector> m_dbNtfDebug;
+
+            /**
+             * @brief Consumer subscribed to SAIREDIS_META_FDB_DEBUG_CHANNEL.
+             *
+             * Operators PUBLISH a "dump" command to this pub/sub channel to
+             * trigger a meta-layer FDB diagnostic dump. Received on the same
+             * notification thread as m_notificationConsumer.
+             */
+            std::shared_ptr<swss::NotificationConsumer> m_debugConsumer;
     };
 }

--- a/lib/RedisRemoteSaiInterface.cpp
+++ b/lib/RedisRemoteSaiInterface.cpp
@@ -9,6 +9,7 @@
 #include "sairediscommon.h"
 
 #include "meta/NotificationFactory.h"
+#include "meta/NotificationMetaFdbDebug.h"
 #include "meta/sai_serialize.h"
 #include "meta/SaiAttributeList.h"
 #include "meta/PerformanceIntervalTimer.h"
@@ -100,7 +101,8 @@ sai_status_t RedisRemoteSaiInterface::apiInitialize(
     {
         m_communicationChannel = std::make_shared<RedisChannel>(
                 m_contextConfig->m_dbAsic,
-                std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
+                std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3),
+                std::bind(&RedisRemoteSaiInterface::handleMetaDebug, this, _1, _2, _3));
     }
 
     m_responseTimeoutMs = m_communicationChannel->getResponseTimeout();
@@ -407,7 +409,8 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
                     m_communicationChannel = std::make_shared<RedisChannel>(
                             m_contextConfig->m_dbAsic,
-                            std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
+                            std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3),
+                            std::bind(&RedisRemoteSaiInterface::handleMetaDebug, this, _1, _2, _3));
 
                     m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
 
@@ -423,7 +426,8 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
                     m_communicationChannel = std::make_shared<RedisChannel>(
                             m_contextConfig->m_dbAsic,
-                            std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
+                            std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3),
+                            std::bind(&RedisRemoteSaiInterface::handleMetaDebug, this, _1, _2, _3));
 
                     m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
 
@@ -446,7 +450,8 @@ sai_status_t RedisRemoteSaiInterface::setRedisExtensionAttribute(
 
                         m_communicationChannel = std::make_shared<RedisChannel>(
                                 m_contextConfig->m_dbAsic,
-                                std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3));
+                                std::bind(&RedisRemoteSaiInterface::handleNotification, this, _1, _2, _3),
+                                std::bind(&RedisRemoteSaiInterface::handleMetaDebug, this, _1, _2, _3));
 
                         m_communicationChannel->setResponseTimeout(m_responseTimeoutMs);
 
@@ -2340,6 +2345,24 @@ void RedisRemoteSaiInterface::handleNotification(
 
         notification->executeCallback(sn);
     }
+}
+
+void RedisRemoteSaiInterface::handleMetaDebug(
+        _In_ const std::string &op,
+        _In_ const std::string &data,
+        _In_ const std::vector<swss::FieldValueTuple> &values)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("meta debug: op=%s data=%s", op.c_str(), data.c_str());
+
+    // Route the operator command through the existing notification callback so
+    // that Meta::processDebugCommand executes under the sairedis API mutex, the
+    // same as every real notification.
+
+    auto notification = std::make_shared<NotificationMetaFdbDebug>(op, data);
+
+    m_notificationCallback(notification);
 }
 
 sai_object_type_t RedisRemoteSaiInterface::objectTypeQuery(

--- a/lib/RedisRemoteSaiInterface.h
+++ b/lib/RedisRemoteSaiInterface.h
@@ -405,6 +405,19 @@ namespace sairedis
                     _In_ const std::string &serializedNotification,
                     _In_ const std::vector<swss::FieldValueTuple> &values);
 
+            /**
+             * @brief Handle an operator meta FDB debug command.
+             *
+             * Invoked from the RedisChannel notification thread when a command
+             * is published to SAIREDIS_META_FDB_DEBUG_CHANNEL. Wraps the command
+             * in a synthetic NotificationMetaFdbDebug and routes it through the
+             * notification callback so it runs under the sairedis API mutex.
+             */
+            void handleMetaDebug(
+                    _In_ const std::string &op,
+                    _In_ const std::string &data,
+                    _In_ const std::vector<swss::FieldValueTuple> &values);
+
             sai_status_t setRedisExtensionAttribute(
                     _In_ sai_object_type_t objectType,
                     _In_ sai_object_id_t objectId,

--- a/lib/sairediscommon.h
+++ b/lib/sairediscommon.h
@@ -99,6 +99,18 @@
  */
 #define REDIS_TABLE_GETRESPONSE     "GETRESPONSE"
 
+/**
+ * @brief Redis pub/sub channel for operator meta-layer FDB diagnostics.
+ *
+ * libsairedis subscribes a dedicated, tolerant consumer on this channel (see
+ * RedisChannel). Operators PUBLISH a "dump" command to it (e.g. via
+ * sonic-db-cli) to log the meta FDB mirror + desync counters to syslog. The
+ * handler NEVER throws on malformed input, so publishing arbitrary messages to
+ * this channel cannot disturb runtime. Pub/sub is not scoped to a redis
+ * database, so any PUBLISH to this channel name is received.
+ */
+#define SAIREDIS_META_FDB_DEBUG_CHANNEL "SAIREDIS_META_FDB_DEBUG"
+
 // REDIS default database defines
 
 #define REDIS_DEFAULT_DATABASE_ASIC         "ASIC_DB"

--- a/meta/Makefile.am
+++ b/meta/Makefile.am
@@ -42,6 +42,7 @@ libsaimeta_la_SOURCES = \
 				NotificationFlowBulkGetSessionEvent.cpp \
 				NotificationTwampSessionEvent.cpp \
 				NotificationPortHostTxReadyEvent.cpp \
+				NotificationMetaFdbDebug.cpp \
 				NotificationTamTelTypeConfigChange.cpp \
 				NotificationSwitchMacsecPostStatus.cpp \
 				NotificationMacsecPostStatus.cpp \

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -12,6 +12,7 @@
 #include <boost/algorithm/string/join.hpp>
 
 #include <set>
+#include <exception>
 
 // TODO add validation for all oids belong to the same switch
 
@@ -6637,8 +6638,11 @@ void Meta::meta_sai_on_fdb_event_single(
 
             if (m_saiObjectCollection.objectExists(meta_key_fdb))
             {
-                SWSS_LOG_WARN("object key %s already exists, but received LEARNED event",
-                        sai_serialize_object_meta_key(meta_key_fdb).c_str());
+                m_fdbDesyncStats.learnedButExists++;
+                SWSS_LOG_WARN("FDB desync: object key %s already exists, but received LEARNED event (%s) [learnedButExists=%lu]",
+                        sai_serialize_object_meta_key(meta_key_fdb).c_str(),
+                        meta_fdb_event_desc(data).c_str(),
+                        (unsigned long)m_fdbDesyncStats.learnedButExists);
                 break;
             }
 
@@ -6680,8 +6684,11 @@ void Meta::meta_sai_on_fdb_event_single(
 
             if (!m_saiObjectCollection.objectExists(meta_key_fdb))
             {
-                SWSS_LOG_WARN("object key %s doesn't exist but received AGED event",
-                        sai_serialize_object_meta_key(meta_key_fdb).c_str());
+                m_fdbDesyncStats.agedButMissing++;
+                SWSS_LOG_WARN("FDB desync: object key %s doesn't exist but received AGED event (%s) [agedButMissing=%lu]",
+                        sai_serialize_object_meta_key(meta_key_fdb).c_str(),
+                        meta_fdb_event_desc(data).c_str(),
+                        (unsigned long)m_fdbDesyncStats.agedButMissing);
                 break;
             }
 
@@ -6699,8 +6706,11 @@ void Meta::meta_sai_on_fdb_event_single(
 
             if (!m_saiObjectCollection.objectExists(meta_key_fdb))
             {
-                SWSS_LOG_WARN("object key %s doesn't exist but received FLUSHED event",
-                        sai_serialize_object_meta_key(meta_key_fdb).c_str());
+                m_fdbDesyncStats.flushedButMissing++;
+                SWSS_LOG_WARN("FDB desync: object key %s doesn't exist but received FLUSHED event (%s) [flushedButMissing=%lu]",
+                        sai_serialize_object_meta_key(meta_key_fdb).c_str(),
+                        meta_fdb_event_desc(data).c_str(),
+                        (unsigned long)m_fdbDesyncStats.flushedButMissing);
                 break;
             }
 
@@ -6712,8 +6722,11 @@ void Meta::meta_sai_on_fdb_event_single(
 
             if (!m_saiObjectCollection.objectExists(meta_key_fdb))
             {
-                SWSS_LOG_WARN("object key %s doesn't exist but received FDB MOVE event",
-                        sai_serialize_object_meta_key(meta_key_fdb).c_str());
+                m_fdbDesyncStats.moveButMissing++;
+                SWSS_LOG_WARN("FDB desync: object key %s doesn't exist but received FDB MOVE event (%s) [moveButMissing=%lu]",
+                        sai_serialize_object_meta_key(meta_key_fdb).c_str(),
+                        meta_fdb_event_desc(data).c_str(),
+                        (unsigned long)m_fdbDesyncStats.moveButMissing);
                 break;
             }
 
@@ -6742,6 +6755,99 @@ void Meta::meta_sai_on_fdb_event_single(
 
             SWSS_LOG_ERROR("got FDB_ENTRY notification with unknown event_type %d, bug?", data.event_type);
             break;
+    }
+}
+
+std::string Meta::meta_fdb_event_desc(
+        _In_ const sai_fdb_event_notification_data_t& data) const
+{
+    SWSS_LOG_ENTER();
+
+    std::string bridgePort = "n/a";
+    std::string type = "n/a";
+
+    for (uint32_t i = 0; i < data.attr_count; i++)
+    {
+        switch (data.attr[i].id)
+        {
+            case SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID:
+                bridgePort = sai_serialize_object_id(data.attr[i].value.oid);
+                break;
+
+            case SAI_FDB_ENTRY_ATTR_TYPE:
+                type = std::to_string(data.attr[i].value.s32);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    return "event_type=" + std::to_string((int)data.event_type)
+        + " bridge_port=" + bridgePort
+        + " type=" + type
+        + " attr_count=" + std::to_string((unsigned)data.attr_count);
+}
+
+void Meta::dumpFdb() const
+{
+    SWSS_LOG_ENTER();
+
+    // Read-only. Called under the sairedis API mutex.
+
+    SWSS_LOG_NOTICE("meta FDB dump: desync counters: learnedButExists=%lu agedButMissing=%lu flushedButMissing=%lu moveButMissing=%lu",
+            (unsigned long)m_fdbDesyncStats.learnedButExists,
+            (unsigned long)m_fdbDesyncStats.agedButMissing,
+            (unsigned long)m_fdbDesyncStats.flushedButMissing,
+            (unsigned long)m_fdbDesyncStats.moveButMissing);
+
+    size_t fdbCount = 0;
+
+    for (auto& mk: m_saiObjectCollection.getAllKeys())
+    {
+        if (mk.objecttype != SAI_OBJECT_TYPE_FDB_ENTRY)
+        {
+            continue;
+        }
+
+        fdbCount++;
+
+        SWSS_LOG_NOTICE("meta FDB entry: %s",
+                sai_serialize_object_meta_key(mk).c_str());
+    }
+
+    SWSS_LOG_NOTICE("meta FDB dump: %zu FDB entries tracked in meta mirror", fdbCount);
+}
+
+void Meta::processDebugCommand(
+        _In_ const std::string& op,
+        _In_ const std::string& data)
+{
+    SWSS_LOG_ENTER();
+
+    // Tolerant operator command handler. Called under the sairedis API mutex.
+    // MUST NEVER let an exception escape: malformed operator input must not
+    // disturb runtime. All parsing is wrapped in try/catch.
+
+    try
+    {
+        if (op == "dump")
+        {
+            dumpFdb();
+            return;
+        }
+
+        SWSS_LOG_WARN("meta debug: unknown op '%s' ignored", op.c_str());
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_WARN("meta debug command op='%s' data='%s' failed and was ignored: %s",
+                op.c_str(), data.c_str(), e.what());
+    }
+    catch (...)
+    {
+        SWSS_LOG_WARN("meta debug command op='%s' data='%s' failed and was ignored: unknown exception",
+                op.c_str(), data.c_str());
     }
 }
 

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -208,6 +208,36 @@ namespace saimeta
 
             void dump() const;
 
+        public: // meta FDB diagnostics (operator-driven, see doc/specs)
+
+            /**
+             * @brief Dump the meta-layer FDB mirror and desync counters.
+             *
+             * Read-only. Enumerates every FDB_ENTRY currently tracked in
+             * m_saiObjectCollection together with the running desync-event
+             * counters. MUST be called under the sairedis API mutex (same as
+             * every other meta access) because m_oids/m_saiObjectCollection are
+             * shared across all object types.
+             *
+             * This function never throws and never mutates any state.
+             */
+            void dumpFdb() const;
+
+            /**
+             * @brief Tolerant operator command entry point.
+             *
+             * Dispatches the read-only "dump" operator command. NEVER throws on
+             * malformed input: unknown ops are logged and ignored.
+             *
+             * MUST be called under the sairedis API mutex.
+             *
+             * @param op   Operator opcode ("dump").
+             * @param data Opcode payload. Empty for "dump".
+             */
+            void processDebugCommand(
+                    _In_ const std::string& op,
+                    _In_ const std::string& data);
+
         public: // notifications
 
             void meta_sai_on_fdb_event(
@@ -283,6 +313,15 @@ namespace saimeta
 
             void meta_sai_on_fdb_event_single(
                     _In_ const sai_fdb_event_notification_data_t& data);
+
+            /*
+             * Build a short human-readable description of the attributes
+             * carried on an FDB event (bridge port OID + entry type when
+             * present). Diagnostic-only; used to enrich the desync WARN logs.
+             * Never throws.
+             */
+            std::string meta_fdb_event_desc(
+                    _In_ const sai_fdb_event_notification_data_t& data) const;
 
             void meta_sai_on_nat_event_single(
                     _In_ const sai_nat_event_notification_data_t& data);
@@ -670,6 +709,24 @@ namespace saimeta
             SaiObjectCollection m_saiObjectCollection;
 
             AttrKeyMap m_attrKeys;
+
+        private: // meta FDB desync diagnostics
+
+            /*
+             * Running counters for FDB notification/meta-mirror desync events.
+             * Purely diagnostic; incremented at the existing WARN sites in
+             * meta_sai_on_fdb_event_single and dumped by dumpFdb(). Access is
+             * already serialized by the sairedis API mutex.
+             */
+            struct FdbDesyncStats
+            {
+                uint64_t learnedButExists = 0;   // LEARNED event, key already present
+                uint64_t agedButMissing = 0;     // AGED event, key absent
+                uint64_t flushedButMissing = 0;  // FLUSHED event, key absent
+                uint64_t moveButMissing = 0;     // MOVE event, key absent
+            };
+
+            FdbDesyncStats m_fdbDesyncStats;
 
         private: // unittests
 

--- a/meta/NotificationMetaFdbDebug.cpp
+++ b/meta/NotificationMetaFdbDebug.cpp
@@ -1,0 +1,55 @@
+#include "NotificationMetaFdbDebug.h"
+
+#include "swss/logger.h"
+
+using namespace sairedis;
+
+NotificationMetaFdbDebug::NotificationMetaFdbDebug(
+        _In_ const std::string& op,
+        _In_ const std::string& data):
+    Notification(
+            // Not a real switch notification; reuse an existing enum value for
+            // the base class. The type is never dispatched on for this object.
+            SAI_SWITCH_NOTIFICATION_TYPE_FDB_EVENT,
+            op + "|" + data),
+    m_op(op),
+    m_data(data)
+{
+    SWSS_LOG_ENTER();
+
+    // no deserialization: op/data are carried verbatim
+}
+
+sai_object_id_t NotificationMetaFdbDebug::getSwitchId() const
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_NULL_OBJECT_ID;
+}
+
+sai_object_id_t NotificationMetaFdbDebug::getAnyObjectId() const
+{
+    SWSS_LOG_ENTER();
+
+    return SAI_NULL_OBJECT_ID;
+}
+
+void NotificationMetaFdbDebug::processMetadata(
+        _In_ std::shared_ptr<saimeta::Meta> meta) const
+{
+    SWSS_LOG_ENTER();
+
+    // Executed under the sairedis API mutex (see Notification::processMetadata
+    // contract). processDebugCommand is tolerant and never throws.
+
+    meta->processDebugCommand(m_op, m_data);
+}
+
+void NotificationMetaFdbDebug::executeCallback(
+        _In_ const sai_switch_notifications_t& switchNotifications) const
+{
+    SWSS_LOG_ENTER();
+
+    // Intentionally empty: operator debug commands have no SAI-level callback.
+    (void)switchNotifications;
+}

--- a/meta/NotificationMetaFdbDebug.h
+++ b/meta/NotificationMetaFdbDebug.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "Notification.h"
+
+namespace sairedis
+{
+    /**
+     * @brief Synthetic notification carrying an operator FDB debug command.
+     *
+     * This is NOT a SAI switch notification. It is a lightweight vehicle used
+     * to route operator-issued meta-layer FDB diagnostics ("dump") through the
+     * existing, already-locked notification callback chain so that
+     * Meta::processDebugCommand runs under the sairedis API mutex.
+     *
+     * It is constructed directly (never via NotificationFactory), so it can
+     * never trigger the factory's throw-on-unknown-name path. getSwitchId()/
+     * getAnyObjectId() return SAI_NULL_OBJECT_ID (handled gracefully by
+     * saiSwitchIdQuery), and executeCallback() is a deliberate no-op.
+     */
+    class NotificationMetaFdbDebug:
+        public Notification
+    {
+        public:
+
+            NotificationMetaFdbDebug(
+                    _In_ const std::string& op,
+                    _In_ const std::string& data);
+
+            virtual ~NotificationMetaFdbDebug() = default;
+
+        public:
+
+            virtual sai_object_id_t getSwitchId() const override;
+
+            virtual sai_object_id_t getAnyObjectId() const override;
+
+            virtual void processMetadata(
+                    _In_ std::shared_ptr<saimeta::Meta> meta) const override;
+
+            virtual void executeCallback(
+                    _In_ const sai_switch_notifications_t& switchNotifications) const override;
+
+        private:
+
+            std::string m_op;
+
+            std::string m_data;
+    };
+}

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,0 +1,1 @@
+dist_bin_SCRIPTS = sai-meta-fdb.sh

--- a/scripts/sai-meta-fdb.sh
+++ b/scripts/sai-meta-fdb.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# sai-meta-fdb.sh - operator front-end for libsairedis meta-layer FDB diagnostics
+#
+# libsairedis (running inside the orchagent process) subscribes a dedicated,
+# tolerant consumer on the SAIREDIS_META_FDB_DEBUG redis pub/sub channel. This
+# script PUBLISHes operator commands to that channel via sonic-db-cli.
+#
+#   dump   - log the meta-layer FDB mirror + desync counters
+#            (read-only; output goes to syslog at NOTICE level)
+#
+# Results are visible in syslog. Grep for "meta FDB" / "FDB desync" in the
+# swss/orchagent logs.
+#
+# NOTE: pub/sub is not scoped to a redis database, so the DB argument to
+# sonic-db-cli is irrelevant for PUBLISH; ASIC_DB is used for clarity.
+
+set -euo pipefail
+
+CHANNEL="SAIREDIS_META_FDB_DEBUG"
+DB="ASIC_DB"
+
+usage() {
+    echo "Usage:" >&2
+    echo "  $0 dump" >&2
+    exit 1
+}
+
+publish() {
+    # $1 = op, $2 = data
+    local op="$1"
+    local data="$2"
+    # Flat JSON array [op, data] as expected by swss NotificationConsumer::pop
+    local msg
+    msg=$(printf '["%s","%s"]' "$op" "$data")
+    sonic-db-cli "$DB" PUBLISH "$CHANNEL" "$msg"
+    echo "published to $CHANNEL: $msg"
+    echo "check syslog (grep 'meta FDB' / 'FDB desync') for results"
+}
+
+[ $# -ge 1 ] || usage
+
+cmd="$1"; shift || true
+
+case "$cmd" in
+    dump)
+        [ $# -eq 0 ] || usage
+        publish "dump" ""
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
###### Description of PR
Summary:
Adds an operator-triggerable diagnostic path to the libsairedis meta layer so the FDB state that Meta mirrors (m_saiObjectCollection) can be dumped on demand, and enriches the existing FDB-desync WARN logs with running counters and per-event attribute context. This is purely observability — no runtime data-path behavior changes.

#### Fixes # (N/A — diagnostic enhancement)

#####3Type of change
 Bug fix
 New feature
 Refactor / cleanup
 Documentation update
 Test improvement
###### Approach
What is the motivation for this PR?
Under FDB churn (MAC moves between ports driven by hardware learning), the syncd notification queue can overflow and drop fdb_event notifications. When that happens, the meta layer's client-side FDB mirror silently desyncs from the ASIC. Today the only symptom is scattered SWSS_LOG_WARN lines ("object key ... doesn't exist but received AGED event", etc.) with no way to (a) quantify how often each desync class is happening or (b) inspect the current meta mirror contents from a running system.

This PR gives operators a low-risk, read-only way to observe meta-layer FDB state and desync rates in the field, without a debug build or process restart.

###### How did you do it?
Enriched the 4 FDB-desync WARN sites in Meta::meta_sai_on_fdb_event_single (LEARNED-but-exists, AGED/FLUSHED/MOVE-but-missing) with per-class monotonic counters (FdbDesyncStats) and a short attribute description (bridge port OID + entry type) via a new meta_fdb_event_desc() helper.
Added a read-only dump command: Meta::dumpFdb() logs the desync counters and enumerates every FDB_ENTRY currently tracked in the meta mirror to syslog at NOTICE. Meta::processDebugCommand() is a tolerant dispatcher that never throws on malformed input.
Delivery path: operators PUBLISH a dump command to a dedicated redis pub/sub channel (SAIREDIS_META_FDB_DEBUG). RedisChannel subscribes an optional, isolated second consumer on that channel (created only when a debug callback is wired), handled on the existing notification thread inside a try/catch so a malformed command can never disturb real notification processing. The command is wrapped in a synthetic NotificationMetaFdbDebug and routed through the normal notification callback so processDebugCommand executes under the sairedis API mutex, exactly like every real notification.
Operator front-end: sai-meta-fdb.sh dump publishes the command via sonic-db-cli and points the operator at the relevant syslog greps.
The feature is inert by default: if no debug callback is passed to RedisChannel, the second consumer is never created.

####### How did you verify/test it?

drive MAC-move churn, run sai-meta-fdb.sh dump, and confirm the meta mirror listing + desync counters appear in the swss/orchagent syslog (grep 'meta FDB' / 'FDB desync').


########### Any platform specific information?
None — platform-independent (libsairedis / meta layer). Observed originally on BCM56770/CMICx (DS3000-class) boxes but the diagnostic is generic.

########## Documentation
No wiki update yet. Operator usage is self-documented in the sai-meta-fdb.sh header and --help/usage output.