### PR TITLE
[vpp] Drive sonic_ext ip2me ACL-bypass from drop-ACL port binds

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -863,6 +863,23 @@ namespace saivs
             std::map<sai_object_id_t, std::list<sai_object_id_t>> m_acl_tbl_grp_mbr_map;
             std::map<sai_object_id_t, std::list<sai_object_id_t>> m_acl_tbl_grp_ports_map;
             std::map<sai_object_id_t, vpp_ace_cntr_info_t> m_ace_cntr_info_map;
+
+            // ip2me (receive-DPO check before ACL) tracking.
+            //
+            // A table is an "ip2me drop table" if it carries at least one
+            // DROP/deny rule and could therefore discard ip2me (for-us)
+            // traffic; the set is kept current by AclTblConfig.
+            // m_ip2me_port_tables records, per VPP interface, the set of
+            // ingress ACL tables currently bound to it (drop or not), so a
+            // table whose drop-ness flips after it is bound can still be
+            // re-evaluated. The sonic_ext ip2me feature is enabled on an
+            // interface while any of its bound tables is a drop table, and
+            // disabled otherwise; m_ip2me_enabled_ports records the last
+            // programmed state to keep the enable/disable calls idempotent.
+            std::set<sai_object_id_t> m_ip2me_drop_tables;
+            std::map<std::string, std::set<sai_object_id_t>> m_ip2me_port_tables;
+            std::set<std::string> m_ip2me_enabled_ports;
+
             std::map<std::string, uint32_t> m_routeStatsIndexMap;
             std::map<sai_object_id_t, std::map<sai_stat_id_t, uint64_t>> m_routeCounterStatsBaseMap;
             std::map<sai_object_id_t, std::map<sai_stat_id_t, uint64_t>> m_routeCounterStatsCarryMap;
@@ -1118,6 +1135,25 @@ namespace saivs
                     _In_ sai_object_id_t tbl_grp_oid,
                     _In_ sai_object_id_t tbl_oid,
                     _In_ bool is_bind);
+
+            /*
+             * ip2me (receive-DPO check before ACL) helpers -- see
+             * SwitchVppAcl.cpp. They keep the sonic_ext ip2me feature enabled
+             * on exactly the VPP interfaces that have an ingress drop ACL
+             * bound, so ip2me (for-us) traffic can bypass it.
+             */
+            void ip2meUpdateDropTable(
+                    _In_ sai_object_id_t tbl_oid,
+                    _In_ bool has_deny);
+
+            void ip2meUpdatePortBinding(
+                    _In_ const std::string &hwif_name,
+                    _In_ sai_object_id_t tbl_oid,
+                    _In_ bool is_input,
+                    _In_ bool is_bind);
+
+            void ip2meRefreshPort(
+                    _In_ const std::string &hwif_name);
 
             sai_status_t getAclEntryStats(
                     _In_ sai_object_id_t ace_cntr_oid,

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -864,20 +864,33 @@ namespace saivs
             std::map<sai_object_id_t, std::list<sai_object_id_t>> m_acl_tbl_grp_ports_map;
             std::map<sai_object_id_t, vpp_ace_cntr_info_t> m_ace_cntr_info_map;
 
+            // Generic per-port ACL table bookkeeping.
+            //
+            // m_port_acl_tables records, per VPP interface (hwif name), the set
+            // of ACL tables currently bound to it in each direction. It is not
+            // specific to any feature: it provides a forward (port -> tables)
+            // and, via getPortsWithAclTable(), a reverse (table -> ports)
+            // lookup for anything that needs to map ports to ACL tables (the
+            // ip2me hook today, egress features tomorrow).
+            struct PortAclTables
+            {
+                std::set<sai_object_id_t> ingress;
+                std::set<sai_object_id_t> egress;
+            };
+            std::map<std::string, PortAclTables> m_port_acl_tables;
+
             // ip2me (receive-DPO check before ACL) tracking.
             //
             // A table is an "ip2me drop table" if it carries at least one
             // DROP/deny rule and could therefore discard ip2me (for-us)
-            // traffic; the set is kept current by AclTblConfig.
-            // m_ip2me_port_tables records, per VPP interface, the set of
-            // ingress ACL tables currently bound to it (drop or not), so a
-            // table whose drop-ness flips after it is bound can still be
-            // re-evaluated. The sonic_ext ip2me feature is enabled on an
-            // interface while any of its bound tables is a drop table, and
-            // disabled otherwise; m_ip2me_enabled_ports records the last
-            // programmed state to keep the enable/disable calls idempotent.
+            // traffic; the set is kept current by AclTblConfig. A table whose
+            // drop-ness flips after it is bound is re-evaluated against the
+            // ingress bindings in m_port_acl_tables. The sonic_ext ip2me
+            // feature is enabled on an interface while any of its bound ingress
+            // tables is a drop table, and disabled otherwise;
+            // m_ip2me_enabled_ports records the last programmed state to keep
+            // the enable/disable calls idempotent.
             std::set<sai_object_id_t> m_ip2me_drop_tables;
-            std::map<std::string, std::set<sai_object_id_t>> m_ip2me_port_tables;
             std::set<std::string> m_ip2me_enabled_ports;
 
             std::map<std::string, uint32_t> m_routeStatsIndexMap;
@@ -1137,6 +1150,21 @@ namespace saivs
                     _In_ bool is_bind);
 
             /*
+             * Generic port <-> ACL-table binding bookkeeping (both
+             * directions), backing m_port_acl_tables. Not specific to ip2me --
+             * see SwitchVppAcl.cpp.
+             */
+            void updatePortAclTableBinding(
+                    _In_ const std::string &hwif_name,
+                    _In_ sai_object_id_t tbl_oid,
+                    _In_ bool is_input,
+                    _In_ bool is_bind);
+
+            std::vector<std::string> getPortsWithAclTable(
+                    _In_ sai_object_id_t tbl_oid,
+                    _In_ bool is_input);
+
+            /*
              * ip2me (receive-DPO check before ACL) helpers -- see
              * SwitchVppAcl.cpp. They keep the sonic_ext ip2me feature enabled
              * on exactly the VPP interfaces that have an ingress drop ACL
@@ -1145,12 +1173,6 @@ namespace saivs
             void ip2meUpdateDropTable(
                     _In_ sai_object_id_t tbl_oid,
                     _In_ bool has_deny);
-
-            void ip2meUpdatePortBinding(
-                    _In_ const std::string &hwif_name,
-                    _In_ sai_object_id_t tbl_oid,
-                    _In_ bool is_input,
-                    _In_ bool is_bind);
 
             void ip2meRefreshPort(
                     _In_ const std::string &hwif_name);

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -1198,6 +1198,21 @@ sai_status_t SwitchVpp::AclTblConfig(
     SWSS_LOG_INFO("Generated %ld regular ACL rules and %ld tunterm ACL rules",
                     acl_rules.size(), tunterm_acl_rules.size());
 
+    // ip2me: record whether this table now carries a DROP/deny rule so the
+    // feature can be (dis)enabled on the interfaces it is bound to. A table
+    // with a deny rule can discard ip2me (for-us) traffic on the l2-input
+    // arc before it is punted, which is exactly what the ip2me node guards.
+    {
+        bool has_deny = false;
+        for (const auto &rule : acl_rules) {
+            if (rule.action == VPP_ACL_ACTION_API_DENY) {
+                has_deny = true;
+                break;
+            }
+        }
+        ip2meUpdateDropTable(tbl_oid, has_deny);
+    }
+
     // Create and populate regular ACL if we have rules
     if (!acl_rules.empty()) {
         auto tbl_sid = sai_serialize_object_id(tbl_oid);
@@ -1441,6 +1456,11 @@ sai_status_t SwitchVpp::AclTblRemove(
         }
         m_acl_tbl_rules_map.erase(it);
     }
+
+    // ip2me: the table is going away -- clear its drop-table state and
+    // re-evaluate any interfaces that still reference it (defensive; the
+    // per-port unbind normally runs before the table is deleted).
+    ip2meUpdateDropTable(tbl_oid, false);
 
     status = tunterm_acl_delete(tbl_oid, true);
 
@@ -1824,6 +1844,118 @@ sai_status_t SwitchVpp::addRemovePortTblGrp(
     return SAI_STATUS_SUCCESS;
 }
 
+/*
+ * ip2me (receive-DPO check before ACL) -- sonic_ext plugin hook.
+ *
+ * Keep the sonic_ext ip2me feature enabled on exactly the VPP interfaces
+ * that have an ingress ACL containing a DROP/deny rule bound, so ip2me
+ * (destined-to-this-switch) traffic can bypass that drop ACL and still be
+ * punted (mirrors hardware CoPP-before-ACL). The feature is a no-op on
+ * every other interface and consumes zero ACL rules.
+ *
+ * State is split so the enable decision is robust to event ordering:
+ *   - m_ip2me_drop_tables   : tables that currently carry a deny rule
+ *                             (updated by AclTblConfig on every rule change).
+ *   - m_ip2me_port_tables   : per interface, the ingress tables bound to it
+ *                             (drop or not), so a table whose drop-ness flips
+ *                             after it was bound can be re-evaluated.
+ *   - m_ip2me_enabled_ports : interfaces where the feature is programmed on,
+ *                             so the vpp enable/disable stays idempotent.
+ */
+void SwitchVpp::ip2meRefreshPort(
+        _In_ const std::string &hwif_name)
+{
+    SWSS_LOG_ENTER();
+
+    // Desired state: enabled iff any ingress table bound to this interface
+    // is currently a drop table.
+    bool want_enable = false;
+    auto pit = m_ip2me_port_tables.find(hwif_name);
+    if (pit != m_ip2me_port_tables.end()) {
+        for (auto tbl_oid : pit->second) {
+            if (m_ip2me_drop_tables.count(tbl_oid)) {
+                want_enable = true;
+                break;
+            }
+        }
+    }
+
+    bool is_enabled = (m_ip2me_enabled_ports.count(hwif_name) != 0);
+    if (want_enable == is_enabled) {
+        return; // already in the desired state
+    }
+
+    int ret = vpp_sonic_ext_ip2me_enable_disable(hwif_name.c_str(), want_enable);
+    if (ret != 0) {
+        SWSS_LOG_ERROR("ip2me %s failed (%d) for interface %s",
+                       want_enable ? "enable" : "disable", ret, hwif_name.c_str());
+        return; // leave tracked state unchanged so a later refresh retries
+    }
+
+    if (want_enable) {
+        m_ip2me_enabled_ports.insert(hwif_name);
+    } else {
+        m_ip2me_enabled_ports.erase(hwif_name);
+    }
+    SWSS_LOG_NOTICE("ip2me skip ACL %s on interface %s",
+                    want_enable ? "enabled" : "disabled", hwif_name.c_str());
+}
+
+void SwitchVpp::ip2meUpdateDropTable(
+        _In_ sai_object_id_t tbl_oid,
+        _In_ bool has_deny)
+{
+    SWSS_LOG_ENTER();
+
+    bool was_drop = (m_ip2me_drop_tables.count(tbl_oid) != 0);
+    if (has_deny == was_drop) {
+        return; // drop-ness unchanged
+    }
+
+    if (has_deny) {
+        m_ip2me_drop_tables.insert(tbl_oid);
+    } else {
+        m_ip2me_drop_tables.erase(tbl_oid);
+    }
+
+    // Drop-ness flipped: re-evaluate every interface that currently has this
+    // table bound (the bind may have happened before the rules were added,
+    // or the last deny rule was just removed).
+    for (auto &kv : m_ip2me_port_tables) {
+        if (kv.second.count(tbl_oid)) {
+            ip2meRefreshPort(kv.first);
+        }
+    }
+}
+
+void SwitchVpp::ip2meUpdatePortBinding(
+        _In_ const std::string &hwif_name,
+        _In_ sai_object_id_t tbl_oid,
+        _In_ bool is_input,
+        _In_ bool is_bind)
+{
+    SWSS_LOG_ENTER();
+
+    // ip2me runs on the l2-input arc, so only ingress binds are relevant.
+    if (!is_input) {
+        return;
+    }
+
+    if (is_bind) {
+        m_ip2me_port_tables[hwif_name].insert(tbl_oid);
+    } else {
+        auto pit = m_ip2me_port_tables.find(hwif_name);
+        if (pit != m_ip2me_port_tables.end()) {
+            pit->second.erase(tbl_oid);
+            if (pit->second.empty()) {
+                m_ip2me_port_tables.erase(pit);
+            }
+        }
+    }
+
+    ip2meRefreshPort(hwif_name);
+}
+
 sai_status_t SwitchVpp::aclBindUnbindPort(
         _In_ sai_object_id_t port_oid,
         _In_ sai_object_id_t tbl_grp_oid,
@@ -1884,6 +2016,10 @@ sai_status_t SwitchVpp::aclBindUnbindPort(
             return SAI_STATUS_FAILURE;
         }
         auto acl_swindex = vpp_idx_it->second;
+
+        // Track this (interface, table) ingress binding for the ip2me
+        // feature and enable/disable it as needed.
+        ip2meUpdatePortBinding(hwif_name, tbl_oid, is_input, is_bind);
 
         // Get member priority
         attr.id = SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY;
@@ -2040,6 +2176,9 @@ sai_status_t SwitchVpp::aclBindUnbindPorts(
         }
         SWSS_LOG_NOTICE("ACL table %s %s port %s", sai_serialize_object_id(tbl_oid).c_str(),
                         is_bind ? "bound to": "unbound from", hwif_name.c_str());
+
+        // Keep ip2me in sync for this (interface, table) ingress binding.
+        ip2meUpdatePortBinding(hwif_name, tbl_oid, is_input, is_bind);
     }
     return SAI_STATUS_SUCCESS;
 }

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -20,6 +20,7 @@
 
 #include <list>
 #include <vector>
+#include <tuple>
 #include <algorithm>
 
 using namespace saivs;
@@ -1198,21 +1199,6 @@ sai_status_t SwitchVpp::AclTblConfig(
     SWSS_LOG_INFO("Generated %ld regular ACL rules and %ld tunterm ACL rules",
                     acl_rules.size(), tunterm_acl_rules.size());
 
-    // ip2me: record whether this table now carries a DROP/deny rule so the
-    // feature can be (dis)enabled on the interfaces it is bound to. A table
-    // with a deny rule can discard ip2me (for-us) traffic on the l2-input
-    // arc before it is punted, which is exactly what the ip2me node guards.
-    {
-        bool has_deny = false;
-        for (const auto &rule : acl_rules) {
-            if (rule.action == VPP_ACL_ACTION_API_DENY) {
-                has_deny = true;
-                break;
-            }
-        }
-        ip2meUpdateDropTable(tbl_oid, has_deny);
-    }
-
     // Create and populate regular ACL if we have rules
     if (!acl_rules.empty()) {
         auto tbl_sid = sai_serialize_object_id(tbl_oid);
@@ -1271,6 +1257,23 @@ sai_status_t SwitchVpp::AclTblConfig(
     } else if (status != SAI_STATUS_SUCCESS) {
         SWSS_LOG_ERROR("ACL plugin operation failed, skipping tunterm "
                        "configuration. status %d", status);
+    }
+
+    // ip2me: only once the ACL has actually been (re)programmed in VPP do we
+    // record whether this table now carries a DROP/deny rule, so the in-memory
+    // drop-table state can never diverge from what VPP is enforcing if the
+    // programming above failed. A table with a deny rule can discard ip2me
+    // (for-us) traffic on the l2-input arc before it is punted, which is
+    // exactly what the ip2me node guards.
+    if (status == SAI_STATUS_SUCCESS) {
+        bool has_deny = false;
+        for (const auto &rule : acl_rules) {
+            if (rule.action == VPP_ACL_ACTION_API_DENY) {
+                has_deny = true;
+                break;
+            }
+        }
+        ip2meUpdateDropTable(tbl_oid, has_deny);
     }
 
     cleanup_acl_tbl_config(aces, ordered_aces, acl, tunterm_acl);
@@ -1993,8 +1996,8 @@ sai_status_t SwitchVpp::aclBindUnbindPort(
         return SAI_STATUS_FAILURE;
     }
 
-    // Build a vector of (priority, acl_swindex) for sorting
-    std::vector<std::pair<uint32_t, uint32_t>> sorted_members;
+    // Build a vector of (priority, acl_swindex, tbl_oid) for sorting
+    std::vector<std::tuple<uint32_t, uint32_t, sai_object_id_t>> sorted_members;
 
     for (auto member_oid: member_list) {
         sai_attribute_t attr;
@@ -2017,10 +2020,6 @@ sai_status_t SwitchVpp::aclBindUnbindPort(
         }
         auto acl_swindex = vpp_idx_it->second;
 
-        // Track this (interface, table) ingress binding for the ip2me
-        // feature and enable/disable it as needed.
-        ip2meUpdatePortBinding(hwif_name, tbl_oid, is_input, is_bind);
-
         // Get member priority
         attr.id = SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY;
         uint32_t priority = 0;
@@ -2028,18 +2027,21 @@ sai_status_t SwitchVpp::aclBindUnbindPort(
             priority = attr.value.u32;
         }
 
-        sorted_members.push_back({priority, acl_swindex});
+        sorted_members.push_back({priority, acl_swindex, tbl_oid});
     }
 
     // Sort by priority in descending order (higher priority first)
     std::sort(sorted_members.begin(), sorted_members.end(),
-              [](const std::pair<uint32_t, uint32_t>& a, const std::pair<uint32_t, uint32_t>& b) {
-                  return a.first > b.first;
+              [](const std::tuple<uint32_t, uint32_t, sai_object_id_t>& a,
+                 const std::tuple<uint32_t, uint32_t, sai_object_id_t>& b) {
+                  return std::get<0>(a) > std::get<0>(b);
               });
 
     // Bind/unbind each ACL in sorted order
     for (const auto& member : sorted_members) {
-        uint32_t acl_swindex = member.second;
+        uint32_t priority = std::get<0>(member);
+        uint32_t acl_swindex = std::get<1>(member);
+        sai_object_id_t tbl_oid = std::get<2>(member);
         int ret;
 
         if (is_bind)
@@ -2053,7 +2055,12 @@ sai_status_t SwitchVpp::aclBindUnbindPort(
             return SAI_STATUS_FAILURE;
         }
         SWSS_LOG_NOTICE("ACL swindex %u %s to port %s (priority %u)", acl_swindex,
-                        is_bind ? "bound" : "unbound", hwif_name.c_str(), member.first);
+                        is_bind ? "bound" : "unbound", hwif_name.c_str(), priority);
+
+        // ip2me: only now that the (un)bind actually succeeded in VPP do we
+        // track this (interface, table) ingress binding and enable/disable
+        // the feature, so the tracked state matches what VPP is enforcing.
+        ip2meUpdatePortBinding(hwif_name, tbl_oid, is_input, is_bind);
     }
 
     // Handle the shared default ACL

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -1848,6 +1848,54 @@ sai_status_t SwitchVpp::addRemovePortTblGrp(
 }
 
 /*
+ * Generic port <-> ACL-table binding bookkeeping.
+ *
+ * updatePortAclTableBinding() maintains m_port_acl_tables: for each VPP
+ * interface (hwif name) the set of ACL tables bound to it, tracked per
+ * direction (ingress/egress). getPortsWithAclTable() is the reverse lookup
+ * (table -> interfaces) for a direction. Neither is specific to a feature;
+ * they are the shared port<->table map the ip2me hook (and future egress
+ * features) build on.
+ */
+void SwitchVpp::updatePortAclTableBinding(
+        _In_ const std::string &hwif_name,
+        _In_ sai_object_id_t tbl_oid,
+        _In_ bool is_input,
+        _In_ bool is_bind)
+{
+    SWSS_LOG_ENTER();
+
+    if (is_bind) {
+        auto &tables = m_port_acl_tables[hwif_name];
+        (is_input ? tables.ingress : tables.egress).insert(tbl_oid);
+    } else {
+        auto pit = m_port_acl_tables.find(hwif_name);
+        if (pit != m_port_acl_tables.end()) {
+            (is_input ? pit->second.ingress : pit->second.egress).erase(tbl_oid);
+            if (pit->second.ingress.empty() && pit->second.egress.empty()) {
+                m_port_acl_tables.erase(pit);
+            }
+        }
+    }
+}
+
+std::vector<std::string> SwitchVpp::getPortsWithAclTable(
+        _In_ sai_object_id_t tbl_oid,
+        _In_ bool is_input)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<std::string> ports;
+    for (auto &kv : m_port_acl_tables) {
+        const auto &tables = is_input ? kv.second.ingress : kv.second.egress;
+        if (tables.count(tbl_oid)) {
+            ports.push_back(kv.first);
+        }
+    }
+    return ports;
+}
+
+/*
  * ip2me (receive-DPO check before ACL) -- sonic_ext plugin hook.
  *
  * Keep the sonic_ext ip2me feature enabled on exactly the VPP interfaces
@@ -1857,11 +1905,12 @@ sai_status_t SwitchVpp::addRemovePortTblGrp(
  * every other interface and consumes zero ACL rules.
  *
  * State is split so the enable decision is robust to event ordering:
+ *   - m_port_acl_tables     : per interface, the ACL tables bound to it in
+ *                             each direction (generic; ip2me reads the ingress
+ *                             set), so a table whose drop-ness flips after it
+ *                             was bound can be re-evaluated.
  *   - m_ip2me_drop_tables   : tables that currently carry a deny rule
  *                             (updated by AclTblConfig on every rule change).
- *   - m_ip2me_port_tables   : per interface, the ingress tables bound to it
- *                             (drop or not), so a table whose drop-ness flips
- *                             after it was bound can be re-evaluated.
  *   - m_ip2me_enabled_ports : interfaces where the feature is programmed on,
  *                             so the vpp enable/disable stays idempotent.
  */
@@ -1873,9 +1922,9 @@ void SwitchVpp::ip2meRefreshPort(
     // Desired state: enabled iff any ingress table bound to this interface
     // is currently a drop table.
     bool want_enable = false;
-    auto pit = m_ip2me_port_tables.find(hwif_name);
-    if (pit != m_ip2me_port_tables.end()) {
-        for (auto tbl_oid : pit->second) {
+    auto pit = m_port_acl_tables.find(hwif_name);
+    if (pit != m_port_acl_tables.end()) {
+        for (auto tbl_oid : pit->second.ingress) {
             if (m_ip2me_drop_tables.count(tbl_oid)) {
                 want_enable = true;
                 break;
@@ -1922,41 +1971,11 @@ void SwitchVpp::ip2meUpdateDropTable(
     }
 
     // Drop-ness flipped: re-evaluate every interface that currently has this
-    // table bound (the bind may have happened before the rules were added,
-    // or the last deny rule was just removed).
-    for (auto &kv : m_ip2me_port_tables) {
-        if (kv.second.count(tbl_oid)) {
-            ip2meRefreshPort(kv.first);
-        }
+    // table bound on ingress (the bind may have happened before the rules were
+    // added, or the last deny rule was just removed).
+    for (const auto &hwif_name : getPortsWithAclTable(tbl_oid, /*is_input*/ true)) {
+        ip2meRefreshPort(hwif_name);
     }
-}
-
-void SwitchVpp::ip2meUpdatePortBinding(
-        _In_ const std::string &hwif_name,
-        _In_ sai_object_id_t tbl_oid,
-        _In_ bool is_input,
-        _In_ bool is_bind)
-{
-    SWSS_LOG_ENTER();
-
-    // ip2me runs on the l2-input arc, so only ingress binds are relevant.
-    if (!is_input) {
-        return;
-    }
-
-    if (is_bind) {
-        m_ip2me_port_tables[hwif_name].insert(tbl_oid);
-    } else {
-        auto pit = m_ip2me_port_tables.find(hwif_name);
-        if (pit != m_ip2me_port_tables.end()) {
-            pit->second.erase(tbl_oid);
-            if (pit->second.empty()) {
-                m_ip2me_port_tables.erase(pit);
-            }
-        }
-    }
-
-    ip2meRefreshPort(hwif_name);
 }
 
 sai_status_t SwitchVpp::aclBindUnbindPort(
@@ -2057,10 +2076,11 @@ sai_status_t SwitchVpp::aclBindUnbindPort(
         SWSS_LOG_NOTICE("ACL swindex %u %s to port %s (priority %u)", acl_swindex,
                         is_bind ? "bound" : "unbound", hwif_name.c_str(), priority);
 
-        // ip2me: only now that the (un)bind actually succeeded in VPP do we
-        // track this (interface, table) ingress binding and enable/disable
-        // the feature, so the tracked state matches what VPP is enforcing.
-        ip2meUpdatePortBinding(hwif_name, tbl_oid, is_input, is_bind);
+        // Only now that the (un)bind actually succeeded in VPP do we record
+        // this (interface, table, direction) binding and refresh the ip2me
+        // feature, so the tracked state matches what VPP is enforcing.
+        updatePortAclTableBinding(hwif_name, tbl_oid, is_input, is_bind);
+        ip2meRefreshPort(hwif_name);
     }
 
     // Handle the shared default ACL
@@ -2184,8 +2204,10 @@ sai_status_t SwitchVpp::aclBindUnbindPorts(
         SWSS_LOG_NOTICE("ACL table %s %s port %s", sai_serialize_object_id(tbl_oid).c_str(),
                         is_bind ? "bound to": "unbound from", hwif_name.c_str());
 
-        // Keep ip2me in sync for this (interface, table) ingress binding.
-        ip2meUpdatePortBinding(hwif_name, tbl_oid, is_input, is_bind);
+        // Record this (interface, table, direction) binding and keep the ip2me
+        // feature in sync for it.
+        updatePortAclTableBinding(hwif_name, tbl_oid, is_input, is_bind);
+        ip2meRefreshPort(hwif_name);
     }
     return SAI_STATUS_SUCCESS;
 }

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -56,6 +56,9 @@
 #include <vpp_plugins/tunterm_acl/tunterm_acl.api_enum.h>
 #include <vpp_plugins/tunterm_acl/tunterm_acl.api_types.h>
 
+#include <vpp_plugins/sonic_ext/sonic_ext.api_enum.h>
+#include <vpp_plugins/sonic_ext/sonic_ext.api_types.h>
+
 #include <vlibmemory/vlib.api_types.h>
 #include <vlibmemory/memclnt.api_enum.h>
 
@@ -331,6 +334,24 @@
 
 #define vl_api_version(n, v) static u32 sflow_api_version = v;
 #include <vpp_plugins/sflow/sflow.api.h>
+#undef vl_api_version
+
+/* sonic_ext API inclusion */
+
+#define vl_typedefs
+#include <vpp_plugins/sonic_ext/sonic_ext.api.h>
+#undef vl_typedefs
+
+#define vl_endianfun
+#include <vpp_plugins/sonic_ext/sonic_ext.api.h>
+#undef vl_endianfun
+
+#define vl_calcsizefun
+#include <vpp_plugins/sonic_ext/sonic_ext.api.h>
+#undef vl_calcsizefun
+
+#define vl_api_version(n, v) static u32 sonic_ext_api_version = v;
+#include <vpp_plugins/sonic_ext/sonic_ext.api.h>
 #undef vl_api_version
 
 /* BOND API inclusion */
@@ -1466,6 +1487,13 @@ vl_api_sflow_sampling_rate_set_reply_t_handler(vl_api_sflow_sampling_rate_set_re
 }
 
 static void
+vl_api_sonic_ext_ip2me_enable_disable_reply_t_handler(vl_api_sonic_ext_ip2me_enable_disable_reply_t *msg)
+{
+    int retval = (int)ntohl((uint32_t)msg->retval);
+    set_reply_status(retval);
+}
+
+static void
 vl_api_bfd_udp_set_tos_reply_t_handler (vl_api_bfd_udp_set_tos_reply_t *msg)
 {
     int retval = (int)ntohl((uint32_t)msg->retval);
@@ -1908,6 +1936,7 @@ static void vpp_base_vpe_init(void)
 static u16 ip_msg_id_base, ip_nbr_msg_id_base, lcp_msg_id_base;
 static u16 acl_msg_id_base;
 static u16 sflow_msg_id_base;
+static u16 sonic_ext_msg_id_base;
 
 static void vpp_ext_vpe_init(void)
 {
@@ -2014,6 +2043,9 @@ vl_api_mpls_route_add_del_reply_t_handler (vl_api_mpls_route_add_del_reply_t *ms
 #define MPLS_MSG_ID(id) \
     (VL_API_##id + mpls_msg_id_base)
 
+#define SONIC_EXT_MSG_ID(id) \
+    (VL_API_##id + sonic_ext_msg_id_base)
+
 #define foreach_vpe_plugin_api_reply_msg                                \
     _(LCP_MSG_ID(LCP_ITF_PAIR_ADD_DEL_REPLY), lcp_itf_pair_add_del_reply) \
     _(LCP_MSG_ID(LCP_ETHERTYPE_ENABLE_REPLY), lcp_ethertype_enable_reply) \
@@ -2032,6 +2064,7 @@ vl_api_mpls_route_add_del_reply_t_handler (vl_api_mpls_route_add_del_reply_t *ms
     _(SR_MSG_ID(SR_SET_ENCAP_SOURCE_REPLY), sr_set_encap_source_reply) \
     _(SFLOW_MSG_ID(SFLOW_ENABLE_DISABLE_REPLY), sflow_enable_disable_reply) \
     _(SFLOW_MSG_ID(SFLOW_SAMPLING_RATE_SET_REPLY), sflow_sampling_rate_set_reply) \
+    _(SONIC_EXT_MSG_ID(SONIC_EXT_IP2ME_ENABLE_DISABLE_REPLY), sonic_ext_ip2me_enable_disable_reply) \
     _(IPIP_MSG_ID(IPIP_ADD_TUNNEL_REPLY), ipip_add_tunnel_reply) \
     _(IPIP_MSG_ID(IPIP_DEL_TUNNEL_REPLY), ipip_del_tunnel_reply) \
     _(MPLS_MSG_ID(SW_INTERFACE_SET_MPLS_ENABLE_REPLY), sw_interface_set_mpls_enable_reply) \
@@ -2128,6 +2161,10 @@ static void get_base_msg_id()
     msg_base_lookup_name = format (0, "sflow_%08x%c", sflow_api_version, 0);
     sflow_msg_id_base = vl_client_get_first_plugin_msg_id ((char *) msg_base_lookup_name);
     assert(sflow_msg_id_base != (u16) ~0);
+
+    msg_base_lookup_name = format (0, "sonic_ext_%08x%c", sonic_ext_api_version, 0);
+    sonic_ext_msg_id_base = vl_client_get_first_plugin_msg_id ((char *) msg_base_lookup_name);
+    assert(sonic_ext_msg_id_base != (u16) ~0);
 }
 
 #define API_SOCKET_FILE "/run/vpp/api.sock"
@@ -3721,6 +3758,47 @@ int vpp_sflow_sampling_rate_set(uint32_t sampling_n)
         SAIVPP_ERROR("%s failed(%d) sampling_N %u", __func__, ret, sampling_n);
     } else {
         SAIVPP_INFO("%s sampling_N %u", __func__, sampling_n);
+    }
+
+    VPP_UNLOCK();
+    return ret;
+}
+
+int vpp_sonic_ext_ip2me_enable_disable(const char *hwif_name, bool enable)
+{
+    vat_main_t *vam = &vat_main;
+    vl_api_sonic_ext_ip2me_enable_disable_t *mp;
+    int ret;
+
+    VPP_LOCK();
+
+    __plugin_msg_base = sonic_ext_msg_id_base;
+    M(SONIC_EXT_IP2ME_ENABLE_DISABLE, mp);
+
+    if (hwif_name) {
+        u32 idx;
+        idx = get_swif_idx(vam, hwif_name);
+        if (idx != (u32) -1) {
+            mp->sw_if_index = htonl(idx);
+        } else {
+            SAIVPP_ERROR("Unable to get the sw_index for %s\n", hwif_name);
+            VPP_UNLOCK();
+            return -EINVAL;
+        }
+    } else {
+        VPP_UNLOCK();
+        return -EINVAL;
+    }
+
+    mp->enable = enable;
+
+    S(mp);
+    WR(ret);
+
+    if (ret) {
+        SAIVPP_ERROR("%s failed(%d) %s enable %d", __func__, ret, hwif_name, enable);
+    } else {
+        SAIVPP_INFO("%s %s enable %d", __func__, hwif_name, enable);
     }
 
     VPP_UNLOCK();

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -3786,6 +3786,8 @@ int vpp_sonic_ext_ip2me_enable_disable(const char *hwif_name, bool enable)
             return -EINVAL;
         }
     } else {
+        SAIVPP_ERROR("%s: hwif_name is NULL, cannot %s ip2me", __func__,
+                     enable ? "enable" : "disable");
         VPP_UNLOCK();
         return -EINVAL;
     }

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -453,6 +453,8 @@ typedef enum {
 
     extern int vpp_sflow_enable_disable(const char *hwif_name, bool enable);
     extern int vpp_sflow_sampling_rate_set(uint32_t sampling_n);
+
+    extern int vpp_sonic_ext_ip2me_enable_disable(const char *hwif_name, bool enable);
     extern int vpp_ipip_tunnel_add(vpp_ipip_tunnel_t *tunnel, uint32_t *sw_if_index);
     extern int vpp_ipip_tunnel_del(uint32_t sw_if_index);
     extern int sw_interface_set_unnumbered(uint32_t unnumbered_sw_if_index,


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-buildimage/issues/28884

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
SONiC VPP now drops ICMP replies to local RIF addresses (VLAN, Loopback, PortChannel, etc) if a drop ACL rule is installed. The correct behavior should be CoPP before ACL (any for-us traffic should be trapped to kernel before dataplane ACL rules).

This PR is to fix this issue.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 39223945

#### How did you do it?

sonic-platforms-vpp PR: https://github.com/sonic-net/sonic-platform-vpp/pull/272 add sonic-ext-ip2me-ip4/ip6 nodes on the l2-input-ip4/ip6 feature arcs, running before acl-plugin-in-ip*-l2. Each frame gets a FIB receive-lookup on the inner dst IP; a DPO_RECEIVE (ip2me) result steers it to l2-input-feat-arc-end, bypassing the ACL so for-us traffic still reaches the BVI/ip*-local for punt while transit traffic hits the ACL as usual. This restores hardware-style CoPP-before-ACL ordering 

This PR enables this on exactly the interfaces where such a drop ACL is bound.

#### How did you verify/test it?
Build and setup an active-standby dualtor testbed, verify ICMP heartbeats can be received on standby mux ports.

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
