### PR TITLE
[Syncd/FlexCounter]Fix PORT_PHY_SERDES_ATTR counter wedge after port …

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2831,22 +2831,38 @@ public:
         SWSS_LOG_ENTER();
     }
 
-    bool getPortRidFromPortSerdesRid(sai_object_id_t port_serdes_rid, sai_object_id_t &port_rid)
+    /*
+     * Resolve port_vid -> port_rid by reading ASIC_DB's VIDTORID hash directly.
+     *
+     * VIDTORID on ASIC_DB is maintained by syncd itself at object create time
+     * and is authoritative for any port whose VID we already know.
+     */
+    bool getPortRidFromPortVid(sai_object_id_t port_vid, sai_object_id_t &port_rid)
     {
         SWSS_LOG_ENTER();
 
-        sai_attribute_t attr;
-        attr.id = SAI_PORT_SERDES_ATTR_PORT_ID;
-        sai_status_t status = Base::m_vendorSai->get(Base::m_objectType, port_serdes_rid, 1, &attr);
-
-        if (status == SAI_STATUS_SUCCESS)
+        try
         {
-            port_rid = attr.value.oid;
-            return true;
+            swss::DBConnector db("ASIC_DB", 0, m_isTcpConn);
+
+            std::string vid_str = sai_serialize_object_id(port_vid);
+            std::string rid_str;
+
+            if (db.hget("VIDTORID", vid_str, rid_str))
+            {
+                sai_deserialize_object_id(rid_str, port_rid);
+                return true;
+            }
+
+            SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: port_vid:0x%" PRIx64
+                          " not found in ASIC_DB VIDTORID", port_vid);
+        }
+        catch (const std::exception &e)
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Exception while querying "
+                           "ASIC_DB VIDTORID: %s", e.what());
         }
 
-        SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to get port RID for port serdes RID:0x%" PRIx64 ", status:%d",
-                      port_serdes_rid, status);
         return false;
     }
 
@@ -2879,25 +2895,36 @@ public:
         return false;
     }
 
-    void updatePortSerdesIdToPortIdMap(sai_object_id_t port_serdes_rid, sai_object_id_t port_serdes_vid)
+    /*
+     * Populate m_portSerdesIdToPortIdMap for a newly created/registered port_serdes.
+     *
+     * The lookup goes:
+     *   port_serdes_vid --(COUNTERS_DB COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP,
+     *                      written by orchagent as part of the same enrollment)--> port_vid
+     *   port_vid        --(ASIC_DB VIDTORID, written by syncd at PORT create time)-> port_rid
+     *
+     */
+    void updatePortSerdesIdToPortIdMap(sai_object_id_t port_serdes_rid,
+                                       sai_object_id_t port_serdes_vid)
     {
         SWSS_LOG_ENTER();
 
         sai_object_id_t port_rid = SAI_NULL_OBJECT_ID;
         sai_object_id_t port_vid = SAI_NULL_OBJECT_ID;
 
-        if (getPortRidFromPortSerdesRid(port_serdes_rid, port_rid) &&
-            getPortVidFromPortSerdesVid(port_serdes_vid, port_vid))
+        if (!getPortVidFromPortSerdesVid(port_serdes_vid, port_vid) ||
+            !getPortRidFromPortVid(port_vid, port_rid))
         {
-            m_portSerdesIdToPortIdMap[port_serdes_rid] = PortIdInfo(port_rid, port_vid);
-            SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Mapped port_serdes_rid:0x%" PRIx64 " -> port_rid:0x%" PRIx64 ", port_vid:0x%" PRIx64,
-                          port_serdes_rid, port_rid, port_vid);
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to resolve port for "
+                           "port_serdes_vid:0x%" PRIx64, port_serdes_vid);
+            return;
         }
-        else
-        {
-            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Failed to map port_serdes_rid:0x%" PRIx64 " - could not retrieve port RID or VID", port_serdes_rid);
-            m_portSerdesIdToPortIdMap.erase(port_serdes_rid);
-        }
+
+        SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Mapped port_serdes_rid:0x%" PRIx64
+                       " -> port_rid:0x%" PRIx64 ", port_vid:0x%" PRIx64,
+                       port_serdes_rid, port_rid, port_vid);
+
+        m_portSerdesIdToPortIdMap[port_serdes_rid] = PortIdInfo(port_rid, port_vid);
     }
 
     void updatePortSerdesIdToLaneCountMap(sai_object_id_t port_serdes_rid)

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -2846,11 +2846,12 @@ public:
             swss::DBConnector db("ASIC_DB", 0, m_isTcpConn);
 
             std::string vid_str = sai_serialize_object_id(port_vid);
-            std::string rid_str;
 
-            if (db.hget("VIDTORID", vid_str, rid_str))
+            auto rid_str = db.hget("VIDTORID", vid_str);
+
+            if (rid_str)
             {
-                sai_deserialize_object_id(rid_str, port_rid);
+                sai_deserialize_object_id(*rid_str, port_rid);
                 return true;
             }
 


### PR DESCRIPTION
…serdes replaced


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fixes a race between orchagent and syncd that permanently disables PORT_PHY_SERDES_ATTR flex-counter telemetry after any port_serdes replacement (happens during SI settings on that serdes object). 


***Root cause***
PortPhySerdesAttrContext::addObject in syncd/FlexCounter.cpp builds its per-object lookup maps by issuing a synchronous vendor-SAI query on the freshly created port_serdes RID:

```
Base::m_vendorSai->get(SAI_OBJECT_TYPE_PORT_SERDES, port_serdes_rid,
                      1, &attr /* SAI_PORT_SERDES_ATTR_PORT_ID */);
```

The vendor SDK issue(Bug#1)

`brcm_sai_get_port_serdes_attribute_cmn` shouldn't touch the SDK lane path to serve SAI_PORT_SERDES_ATTR_PORT_ID. That attribute is create-only and cached; returning it should be a memory lookup.The vendor SAI's implementation of "give me the PORT_ID of this port_serdes" internally re-reads the port's hardware lane list, which is transiently unavailable while SAI_PORT_ATTR_ADMIN_STATE=true is still settling on the port. The flex-counter SET arrives at syncd from FLEX_COUNTER_DB during exactly that window, and the query returns -17.

| Time | Actor | Event |
|---|---|---|
| 07:49:16.534354 | orch → syncd (ASIC) | **create** new PORT_SERDES `0x…1ace` (with `PORT_ID = 0x…7a`) |
| 07:49:16.544030 | orch (log) | "Created port serdes object 0x…1ace for port 0x…7a" |
| 07:49:16.546348 | orch (log) | "Successfully set ASIC serdes tunings for port Ethernet500" |
| **07:49:16.546406** | **orch → syncd (ASIC)** | **`SAI_PORT_ATTR_ADMIN_STATE=true`** |
| 07:49:16.548179 | orch → syncd (FLEX_COUNTER_DB) | flex-counter SET for `0x…1ace, 0x…1acd, …` (all 8 lanes) |
| 07:49:16.560697 | vendor SAI (inside syncd) | `brcm_sai_get_port_serdes_attribute_cmn:20501 Port 426 hardware lane count get failed with error -17` |

Thanks to Justin Wong(Arista) to help fetch these detailed logs.

Summary:
Fixes # (issue)

- Removed getPortRidFromPortSerdesRid — the vendor SAI query that was failing with -17 during ADMIN_STATE=true bring-up.

- Added getPortRidFromPortVid — reads ASIC_DB's VIDTORID hash directly with a plain swss::DBConnector("ASIC_DB", 0, m_isTcpConn) + hget("VIDTORID", vid_str, rid_str).

- Rewrote updatePortSerdesIdToPortIdMap to chain getPortVidFromPortSerdesVid (COUNTERS_DB) with the new getPortRidFromPortVid (ASIC_DB). No vendor SAI in the loop.

- Removed the erase() on failure — absence now unambiguously means "not populated yet".

Ordering of events in syncd:-
Orchagent enrolls flex counters only after `create_port_serdes()` returns success. That's true within orchagent, but in syncd the two writes travel on two different Redis channels with independent draining:

1. ASIC channel (c create) — synchronous with vendor SAI. This is where the create completes. 
2. FLEX_COUNTER_DB channel (p counter polling) — asynchronous producer table, drained by syncd's main loop separately.

Under the sairedis mutex those two consumers are serialized, so admin-up and the flex-counter SET can end up interleaved on the syncd side regardless of the order orchagent published them. So even a strictly-ordered orchagent doesn't close the vendor's transient window; only removing the vendor SAI dependency (this PR) or fixing the vendor SAI (Bug #1).


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
Fixes #1946 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

Removes the dependency on the transitional vendor-SAI query and derives the port_serdes → port mapping entirely from data syncd already owns:

Both lookups are backed by state that is authoritative at the moment addObject runs:

`COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP` is written by orchagent as part of the same port_serdes enrollment, before the `FLEX_COUNTER_DB` SET.
The port VID→RID translation is stable for the switch's lifetime (populated at PORT create time during bring-up).
The port_serdes VID→RID translation is already used successfully by the enclosing Syncd::processFlexCounterEvent; if it weren't populated, that code would already have taken the "was not found" branch.

Neither lookup touches the vendor SAI, so neither can hit the brcm_sai_get_port_serdes_attribute_cmn -17 window.

#### How did you verify/test it?

Unit / integration

- Existing FlexCounter unit tests continue to pass.

- New unit test: create PortPhySerdesAttrContext, register a mock VirtualOidTranslator with a known port_vid → port_rid mapping and a mock Redis map with port_serdes_vid → port_vid; call addObject and assert m_portSerdesIdToPortIdMap is populated correctly without any call to SaiInterface::get(SAI_OBJECT_TYPE_PORT_SERDES, ...).

On hardware (Seen consistently on TH5 switch)

1. Bring up a port with PORT_PHY_SERDES_ATTR polling enabled.

2. Trigger a serdes replacement (e.g. config interface shutdown / startup or a serdes tuning change) that reproduces the sequence in the "Observed symptom" section.

3. Confirm:
- Syslog no longer contains the getPortRidFromPortSerdesRid: ... status:-17, updatePortSerdesIdToPortIdMap: ... could not retrieve port RID or VID, or subsequent initAttrData: ... has no lane count information messages.
- COUNTERS_DB PORT_PHY_ATTR_TABLE continues to be updated for the affected port after the SI settings is applied

4. Repeat multiple config reload to ensure no errors seens previously.

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
