### PR TITLE
[vpp] SAIVPP harness compatibility: VPP 26.06 startup plugins, backend-restart reaping, harness log routing

### DIFF
--- a/.azure-pipelines/docker-sai-test-vpp/README.md
+++ b/.azure-pipelines/docker-sai-test-vpp/README.md
@@ -57,7 +57,7 @@ The table below lists OCP `sai_test` classes that **pass** on the current VPP SA
 
 ## b) Building the framework
 
-The image bundles pre-built `.deb` packages from `debs/` (git-ignored locally). You only need to regenerate `.deb`s when the corresponding source changes. All examples below use the local image tag **`docker-sai-test-vpp:local`** (the `build_harness.sh` default).
+The image bundles pre-built `.deb` packages from `debs/` (git-ignored locally). You only need to regenerate `.deb`s when the corresponding source changes. All examples below use **`docker-sai-test-vpp:latest`**, the tag `build_harness.sh` applies by default. Because `latest` is Docker's implicit tag you can also drop it and write just `docker-sai-test-vpp`; CI images are tagged with the pipeline definition and build number instead, so they never collide with a locally built one.
 
 ### Use cases
 
@@ -103,7 +103,7 @@ All of these are staged in [`debs/`](debs/) (local-only). The Dockerfile install
 
 ### Build script (use case 1)
 
-`build_harness.sh` automates staging from `sonic-buildimage` and building the image as **`docker-sai-test-vpp:local`**. It validates that all required runtime `.deb`s are present in `debs/` before `docker build`. If sonic-sairedis packages are missing, it runs the trixie `make` targets automatically (disable with `--no-auto-build`). VPP, `libswsscommon`, and `libyang`/`libyang3` are not auto-built — the script fails with hints if they are absent.
+`build_harness.sh` automates staging from `sonic-buildimage` and building the image as **`docker-sai-test-vpp:latest`**. It validates that all required runtime `.deb`s are present in `debs/` before `docker build`. If sonic-sairedis packages are missing, it runs the trixie `make` targets automatically (disable with `--no-auto-build`). VPP, `libswsscommon`, and `libyang`/`libyang3` are not auto-built — the script fails with hints if they are absent.
 
 ```bash
 cd <sonic-buildimage>/src/sonic-sairedis/.azure-pipelines/docker-sai-test-vpp
@@ -160,7 +160,7 @@ cd <sonic-buildimage>/src/sonic-sairedis
 
 docker build --no-cache \
   -f .azure-pipelines/docker-sai-test-vpp/Dockerfile \
-  -t docker-sai-test-vpp:local .
+  -t docker-sai-test-vpp:latest .
 ```
 
 If you are behind a proxy, pass it through (both lower- and upper-case):
@@ -171,7 +171,7 @@ docker build --no-cache \
   --build-arg HTTP_PROXY=$http_proxy   --build-arg HTTPS_PROXY=$https_proxy \
   --build-arg no_proxy=$no_proxy       --build-arg NO_PROXY=$no_proxy \
   -f .azure-pipelines/docker-sai-test-vpp/Dockerfile \
-  -t docker-sai-test-vpp:local .
+  -t docker-sai-test-vpp:latest .
 ```
 
 > Rebuild scope: editing only `run_test.sh` / `sai_test/**` / harness templates needs an **image rebuild** only (fast). Editing `vslib/` C++ needs a **`.deb` rebuild** (above) first, then the image.
@@ -197,14 +197,14 @@ The OCP `sai_test` suite is baked into the image at `/sai_test` (copied from `SA
 
 ```bash
 docker run --rm --privileged -e PORT_COUNT=32 \
-  docker-sai-test-vpp:local sai_route_test.RouteRifTest
+  docker-sai-test-vpp:latest sai_route_test.RouteRifTest
 ```
 
 ### Run several tests (one container, grouped or isolated per env)
 
 ```bash
 docker run --rm --privileged -e PORT_COUNT=32 \
-  docker-sai-test-vpp:local \
+  docker-sai-test-vpp:latest \
   sai_route_test.RouteRifTest sai_ecmp_test.EcmpHashFieldSportTestV4
 ```
 
@@ -215,14 +215,14 @@ With default `ISOLATE_EACH_TEST=1`, each selector still gets its own fresh backe
 ```bash
 # whole modules (default isolation: ~45-50 min for all four)
 docker run --rm --privileged -e PORT_COUNT=32 \
-  docker-sai-test-vpp:local sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test
+  docker-sai-test-vpp:latest sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test
 
 # faster grouped mode (~9x; fewer passes without upstream workarounds)
 docker run --rm --privileged -e PORT_COUNT=32 -e ISOLATE_EACH_TEST=0 \
-  docker-sai-test-vpp:local sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test
+  docker-sai-test-vpp:latest sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test
 
 # every discovered test class (no args)
-docker run --rm --privileged -e PORT_COUNT=32 docker-sai-test-vpp:local
+docker run --rm --privileged -e PORT_COUNT=32 docker-sai-test-vpp:latest
 ```
 
 ### Collecting results (JUnit XML) and updating the supported-test list
@@ -237,7 +237,7 @@ mkdir -p results/xml
 rm -f results/xml/TEST-*.xml
 nohup docker run --rm --privileged -e PORT_COUNT=32 \
   -v "$PWD/results/xml:/test-results" \
-  docker-sai-test-vpp:local \
+  docker-sai-test-vpp:latest \
   sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test \
   > results/run.log 2>&1 &
 tail -f results/run.log
@@ -251,7 +251,7 @@ While a matrix run is in progress (from the `docker-sai-test-vpp/` directory):
 |---|---|
 | **Log** | `results/run.log` (or whatever path you passed to `nohup` / `tee`) |
 | **Progress** | `grep -oE '\[[0-9]+/87\]' results/run.log \| tail -1` |
-| **Container** | `docker ps --filter ancestor=docker-sai-test-vpp:local` |
+| **Container** | `docker ps --filter ancestor=docker-sai-test-vpp:latest` |
 
 The `87` in the progress grep matches the four-module isolation plan (`sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test`). For other selectors, use `grep -oE '\[[0-9]+/[0-9]+\]'` instead.
 
@@ -282,7 +282,7 @@ Debug hold mode, environment variables, in-container log paths, and common pitfa
 ```bash
 docker rm -f officesai-debug 2>/dev/null
 docker run -d --name officesai-debug --privileged -e PORT_COUNT=32 \
-  docker-sai-test-vpp:local --debug sai_route_test.RouteRifTest
+  docker-sai-test-vpp:latest --debug sai_route_test.RouteRifTest
 
 # while the test runs, inspect VPP state:
 docker exec officesai-debug vppctl show interface

--- a/.azure-pipelines/docker-sai-test-vpp/README.md
+++ b/.azure-pipelines/docker-sai-test-vpp/README.md
@@ -30,21 +30,21 @@ The framework exercises SAI operations (create/set/get/remove of ports, RIFs, ro
 - **VPP** is the dataplane; `OEthernetX` are the VPP-facing kernel veth ends and `OEthX_peer` are the PTF-facing ends. `OEthernetX` represents an out-facing (wire) interface; the inside `EthernetX` (linux_cp TAP) faces the SONiC control plane.
 - **saiserver** is a thin Thrift→SAI shim (port 9092) linked against `libsaivs.so`.
 - **PTF** runs the OCP `sai_test` Python suite and does packet I/O on the `OEthX_peer` ends.
-- **`run_test.sh`** is the container entrypoint and orchestrator: Redis → veth topology → VPP → saiserver → PTF. PortChannel netdevs and LAG/SVI connected IPs are set up in sai_test `setUp()` via sai_test's `SIMULATE_SONIC` helper (`config/simulate_sonic.py`), not in `run_test.sh`.
+- **`run_test.sh`** is the container entrypoint and orchestrator: Redis → veth topology → VPP → saiserver → PTF. It writes the SONiC-to-VPP interface map to `/usr/share/sonic/hwsku/sonic_vpp_ifmap.ini`. PortChannel netdevs and LAG/SVI connected IPs are set up in sai_test `setUp()` via sai_test's `SIMULATE_SONIC` helper (`config/simulate_sonic.py`), not in `run_test.sh`.
 
-### Key design point — config-signature grouping
+### Key design point — per-test isolation (default) and config-signature grouping
 
-The VPP SAI backend can build the switch + host-interfaces **once per saiserver process**. The OCP framework is built to configure a common T0 setup once and have subsequent tests reuse it (`common_configured=true`). But different test classes ask `T0TestBase.setUp` for *different* common configs (e.g. ECMP tests need next-hop groups). So `run_test.sh`:
+The VPP SAI backend can build the switch + host-interfaces **once per saiserver process**. The OCP framework is built to configure a common T0 setup once and have subsequent tests reuse it (`common_configured=true`). But different test classes ask `T0TestBase.setUp` for *different* common configs (e.g. ECMP tests need next-hop groups), and rebuilding the full T0 config twice in one saiserver process can crash the backend.
 
-1. parses each requested test class's `setUp` (resolving config kwargs through the class **inheritance chain**) to compute its common-config "signature";
-2. groups tests by signature;
-3. for each group: **restarts the backend** (fresh saiserver), the first test builds + persists that group's config, the rest reuse it.
+**Default (`ISOLATE_EACH_TEST=1`):** every requested test class runs in its **own** config group. Before each test, `run_test.sh` tears down and restarts Redis + VPP + saiserver, waits for the old VPP process to be fully reaped, then starts a fresh backend. Each test rebuilds its own common config (`common_configured=false`). This eliminates cross-test state contamination (ECMP `-6`/`-7` reuse artifacts, ordering-dependent flakes) at the cost of ~45–50 minutes for the full 4-module matrix (87 tests × ~30s recycle+rebuild each).
 
-This lets one container run any mix of tests correctly in a single invocation.
+**Grouped mode (`ISOLATE_EACH_TEST=0`):** `run_test.sh` parses each test class's `setUp` (resolving config kwargs through the class **inheritance chain**) to compute a common-config "signature", groups tests by signature, and for each group restarts the backend once: the first test in the group builds + persists that group's config, the rest reuse it (`common_configured=true`). This is ~9× faster but passes fewer tests when upstream workarounds are not present.
+
+Set `COMMON_CONFIGURED_REUSE=0` only for legacy single-invocation debugging (one ptf process, no grouping).
 
 ### Supported tests
 
-The table below lists OCP `sai_test` classes that **pass** on the current VPP SAI backend (last validated **2026-07-14** against `sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test` on `sai_vpp_ut_phase3`). It is the published substitute for a full compatibility matrix: only passing tests are listed. After a local matrix run, update this section when the pass set changes (see **Collecting results** below).
+The table below lists OCP `sai_test` classes that **pass** on the current VPP SAI backend (last validated **2026-07-14** against `sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test` on `sai_vpp_ut_phase3`, `ISOLATE_EACH_TEST=1`). It is the published substitute for a full compatibility matrix: only passing tests are listed. After a local matrix run, update this section when the pass set changes (see **Collecting results** below).
 
 | Module | Passing test classes |
 |---|---|
@@ -53,11 +53,11 @@ The table below lists OCP `sai_test` classes that **pass** on the current VPP SA
 | `sai_rif_test` | `IngressDisableTestV4`, `IngressDisableTestV6` |
 | `sai_route_test` | `DefaultRouteV4Test`, `DefaultRouteV6Test`, `DropRouteTest`, `DropRoutev6Test`, `LagMultipleRouteTest`, `LagMultipleRoutev6Test`, `RemoveRouteV4Test`, `RouteDiffPrefixAddThenDeleteLongerV4Test`, `RouteDiffPrefixAddThenDeleteLongerV6Test`, `RouteDiffPrefixAddThenDeleteShorterV4Test`, `RouteDiffPrefixAddThenDeleteShorterV6Test`, `RouteRifTest`, `RouteRifv6Test`, `RouteSameSipDipv4Test`, `RouteSameSipDipv6Test`, `RouteUpdateTest`, `RouteUpdatev6Test`, `StaicSviMacFloodingTest`, `StaicSviMacFloodingV6Test` |
 
-**37** classes passing (of 89 executed in the last full matrix run).
+**37** classes passing. The harness plans **87** test targets across the four modules above; `gen_compatibility_matrix.py` may report a higher row count when a test produces both ERROR and FAIL JUnit entries.
 
 ## b) Building the framework
 
-The image bundles pre-built `.deb` packages from `debs/` (git-ignored locally). You only need to regenerate `.deb`s when the corresponding source changes.
+The image bundles pre-built `.deb` packages from `debs/` (git-ignored locally). You only need to regenerate `.deb`s when the corresponding source changes. All examples below use the local image tag **`docker-sai-test-vpp:local`** (the `build_harness.sh` default).
 
 ### Use cases
 
@@ -99,11 +99,11 @@ The framework is designed to support three distinct deployment and testing scena
 | `saiserver_*` / `saiserverv2_*` | `sonic-sairedis` SAI Thrift server |
 | `python-saithrift_*` / `python-saithriftv2_*` | `sonic-sairedis` SAI Thrift Python client |
 
-All of these are staged in [`debs/`](debs/) (local-only). The Dockerfile installs every runtime `.deb` it finds there (skipping `-dbg`/`-dev`/`-dbgsym`).
+All of these are staged in [`debs/`](debs/) (local-only). The Dockerfile installs every runtime `.deb` it finds there (skipping `-dbg`/`-dev`/`-dbgsym`). When both legacy and v2 saithrift packages are present, **`saiserverv2_*` and `python-saithriftv2_*` are preferred**.
 
 ### Build script (use case 1)
 
-`build_harness.sh` automates staging from `sonic-buildimage` and building the image. It validates that all required runtime `.deb`s are present in `debs/` before `docker build`. If sonic-sairedis packages are missing, it runs the trixie `make` targets automatically (disable with `--no-auto-build`). VPP, `libswsscommon`, and `libyang`/`libyang3` are not auto-built — the script fails with hints if they are absent.
+`build_harness.sh` automates staging from `sonic-buildimage` and building the image as **`docker-sai-test-vpp:local`**. It validates that all required runtime `.deb`s are present in `debs/` before `docker build`. If sonic-sairedis packages are missing, it runs the trixie `make` targets automatically (disable with `--no-auto-build`). VPP, `libswsscommon`, and `libyang`/`libyang3` are not auto-built — the script fails with hints if they are absent.
 
 ```bash
 cd <sonic-buildimage>/src/sonic-sairedis/.azure-pipelines/docker-sai-test-vpp
@@ -129,14 +129,25 @@ make target/debs/trixie/libsairedis_1.0.0_amd64.deb
 # Build saiserver + saithrift client (if those changed)
 BLDENV=trixie make -f Makefile.work target/debs/trixie/libsaithrift-dev_0.9.4_amd64.deb
 
-# Stage the fresh packages into the harness build context
+# Stage the fresh packages into the harness build context (prefer v2 names on trixie)
 cp target/debs/trixie/libsaivs_*.deb     target/debs/trixie/libsaivs-dev_*.deb \
    target/debs/trixie/libsairedis_*.deb  target/debs/trixie/libsairedis-dev_*.deb \
-   target/debs/trixie/saiserver_*.deb    target/debs/trixie/python-saithrift_*.deb \
+   target/debs/trixie/libsaimetadata_*.deb \
+   target/debs/trixie/saiserverv2_*.deb  target/debs/trixie/python-saithriftv2_*.deb \
    src/sonic-sairedis/.azure-pipelines/docker-sai-test-vpp/debs/
 ```
 
 Then run `./build_harness.sh` (or `./build_harness.sh --no-stage-debs` if `debs/` is already up to date).
+
+#### Trixie `libsaithrift-dev` build failure (workaround)
+
+On trixie, `make -f Makefile.work target/debs/trixie/libsaithrift-dev_0.9.4_amd64.deb` may fail (legacy `libthrift-0.11.0` / python2 debhelper dependency). `libsairedis` / `libsaivs` debs still build. If saithrift packaging fails:
+
+1. Build `libsairedis` as above (produces fresh `libsaivs` / `libsaimetadata`).
+2. Build `saiserver` manually inside `sonic-slave-trixie` from the sairedis tree, or copy a known-good `saiserverv2_*.deb` into `debs/`.
+3. Rebuild the harness image with `./build_harness.sh --no-stage-debs`.
+
+The image must contain a `saiserverv2` binary built against the same `libsaivs` as the staged debs — a stale saiserver deb will produce confusing Thrift/runtime failures.
 
 > Behind a corporate proxy, prefix `make` with your Docker build credentials, e.g. `DOCKER_CONFIG=<dir>`. VPP `.deb`s come from the `sonic-platform-vpp` pipeline; drop new ones into `debs/` or pass `--vpp-deb-dir`. `build_harness.sh` forwards proxy env vars to `docker build`.
 
@@ -149,7 +160,7 @@ cd <sonic-buildimage>/src/sonic-sairedis
 
 docker build --no-cache \
   -f .azure-pipelines/docker-sai-test-vpp/Dockerfile \
-  -t docker-sai-test-vpp:phase1 .
+  -t docker-sai-test-vpp:local .
 ```
 
 If you are behind a proxy, pass it through (both lower- and upper-case):
@@ -160,10 +171,19 @@ docker build --no-cache \
   --build-arg HTTP_PROXY=$http_proxy   --build-arg HTTPS_PROXY=$https_proxy \
   --build-arg no_proxy=$no_proxy       --build-arg NO_PROXY=$no_proxy \
   -f .azure-pipelines/docker-sai-test-vpp/Dockerfile \
-  -t docker-sai-test-vpp:phase1 .
+  -t docker-sai-test-vpp:local .
 ```
 
-> Rebuild scope: editing only `run_test.sh` / `sai_test/**` needs an **image rebuild** only (fast). Editing `vslib/` C++ needs a **`.deb` rebuild** (above) first, then the image.
+> Rebuild scope: editing only `run_test.sh` / `sai_test/**` / harness templates needs an **image rebuild** only (fast). Editing `vslib/` C++ needs a **`.deb` rebuild** (above) first, then the image.
+
+### VPP startup plugins (`vpp_startup.conf.template`)
+
+The harness-generated VPP config enables plugins required by current VPP + libsaivs, including:
+
+- **`tap_plugin.so`** — needed for VPP 26.06 linux-cp host-interface creation.
+- **`sflow_plugin.so`** — saiserver startup asserts if the sflow message-id base is missing when this plugin is disabled.
+
+Other enabled plugins (`af_packet`, `linux_cp`, `linux_nl`, `acl`, `vxlan`, …) match the VPP SAI dataplane bench. Do not trim these without validating saiserver startup and host-interface creation.
 
 ## c) Running tests
 
@@ -171,46 +191,63 @@ The container entrypoint is `run_test.sh`. Test selectors are PTF targets: `modu
 
 ### Where the tests come from
 
-The OCP `sai_test` suite is baked into the image at `/sai_test` (copied from `SAI/test/sai_test/` in the repo). PTF and the SAI Thrift client come from `SAI/test/ptf` and the `python-saithrift` package. `run_test.sh` discovers test classes under `/sai_test` automatically.
+The OCP `sai_test` suite is baked into the image at `/sai_test` (copied from `SAI/test/sai_test/` in the repo). PTF and the SAI Thrift client come from `SAI/test/ptf` and the `python-saithrift` / `python-saithriftv2` package. `run_test.sh` discovers test classes under `/sai_test` automatically.
 
 ### Run a single test
 
 ```bash
 docker run --rm --privileged -e PORT_COUNT=32 \
-  docker-sai-test-vpp:phase1 sai_route_test.RouteRifTest
+  docker-sai-test-vpp:local sai_route_test.RouteRifTest
 ```
 
-### Run several tests (auto-grouped by config, one container)
+### Run several tests (one container, grouped or isolated per env)
 
 ```bash
 docker run --rm --privileged -e PORT_COUNT=32 \
-  docker-sai-test-vpp:phase1 \
+  docker-sai-test-vpp:local \
   sai_route_test.RouteRifTest sai_ecmp_test.EcmpHashFieldSportTestV4
 ```
+
+With default `ISOLATE_EACH_TEST=1`, each selector still gets its own fresh backend even when multiple classes are listed.
 
 ### Run whole modules, or everything
 
 ```bash
-# whole modules
+# whole modules (default isolation: ~45-50 min for all four)
 docker run --rm --privileged -e PORT_COUNT=32 \
-  docker-sai-test-vpp:phase1 sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test
+  docker-sai-test-vpp:local sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test
+
+# faster grouped mode (~9x; fewer passes without upstream workarounds)
+docker run --rm --privileged -e PORT_COUNT=32 -e ISOLATE_EACH_TEST=0 \
+  docker-sai-test-vpp:local sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test
 
 # every discovered test class (no args)
-docker run --rm --privileged -e PORT_COUNT=32 docker-sai-test-vpp:phase1
+docker run --rm --privileged -e PORT_COUNT=32 docker-sai-test-vpp:local
 ```
 
 ### Collecting results (JUnit XML) and updating the supported-test list
 
-PTF writes one JUnit-XML file per test into `/test-results`. By convention these land in the local-only `results/` tree (git-ignored; not published to the remote). Run from the `docker-sai-test-vpp/` directory and bind-mount `results/xml` out:
+PTF writes one JUnit-XML file per test into `/test-results`. By convention these land in the local-only `results/` tree (git-ignored; not published to the remote). Run from the `docker-sai-test-vpp/` directory and bind-mount `results/xml` out.
+
+For a full 4-module matrix, prefer **`nohup`** (or an equivalent detached logger) so a dropped SSH/IDE session does not kill the container mid-run. Tail the log file for progress — long runs produce megabytes of output and some IDE terminals stop updating while the run continues.
 
 ```bash
 cd <sonic-buildimage>/src/sonic-sairedis/.azure-pipelines/docker-sai-test-vpp
 mkdir -p results/xml
-docker run --rm --privileged -e PORT_COUNT=32 \
+rm -f results/xml/TEST-*.xml
+nohup docker run --rm --privileged -e PORT_COUNT=32 \
   -v "$PWD/results/xml:/test-results" \
-  docker-sai-test-vpp:phase1 \
+  docker-sai-test-vpp:local \
   sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test \
-  2>&1 | tee results/run.log
+  > results/run.log 2>&1 &
+tail -f results/run.log
+```
+
+Monitor progress without the full firehose:
+
+```bash
+grep -oE '\[[0-9]+/[0-9]+\]' results/run.log | tail -1
+grep -E '^(OK|FAIL|ERROR) |\[run_test\] ===' results/run.log | tail -20
 ```
 
 Then build a local compatibility matrix with the bundled generator (defaults to the `results/` tree). The generator parses JUnit XML with `defusedxml` (hardened against XXE), so install it once if needed:
@@ -233,7 +270,7 @@ Debug hold mode, environment variables, in-container log paths, and common pitfa
 ```bash
 docker rm -f officesai-debug 2>/dev/null
 docker run -d --name officesai-debug --privileged -e PORT_COUNT=32 \
-  docker-sai-test-vpp:phase1 --debug sai_route_test.RouteRifTest
+  docker-sai-test-vpp:local --debug sai_route_test.RouteRifTest
 
 # while the test runs, inspect VPP state:
 docker exec officesai-debug vppctl show interface
@@ -249,8 +286,17 @@ In `--debug` the container leaves the dataplane running after the test so you ca
 | Variable | Default | Meaning |
 |---|---|---|
 | `PORT_COUNT` | 32 | number of `OEthernetX`/`OEthX_peer` veth pairs |
-| `COMMON_CONFIGURED_REUSE` | 1 | 1 = config-signature grouping + reuse; 0 = legacy single ptf invocation |
+| `ISOLATE_EACH_TEST` | 1 | 1 = fresh backend + own config per test; 0 = config-signature grouping with reuse |
+| `COMMON_CONFIGURED_REUSE` | 1 | 1 = plan multi-target runs with grouping/isolation; 0 = legacy single ptf invocation |
+| `SAI_PORT_UP_SHARED_WAIT` | 1 | 1 = poll all ports together in `port_configer.py` (seconds, not ~64s serial) |
+| `SAI_PORT_UP_RETRIES` | 2 | shared-wait retry count (with `SAI_PORT_UP_SHARED_WAIT=1`) |
+| `SAI_PORT_UP_POLL_INTERVAL` | 1 | seconds between shared-wait polls |
 | `KEEP_VETHS_UP_SECONDS` | 120 | how long the per-group watchdog keeps VPP host-interfaces/veths up |
+| `KEEP_VETHS_UP_INTERVAL` | 3 | seconds between watchdog `vppctl set interface state` batches |
+| `LAG_COUNT` | 4 | PortChannel netdevs torn down at container exit |
+| `MTU` | 9100 | veth MTU |
+| `STARTUP_TIMEOUT` | 60 | seconds to wait for VPP / saiserver readiness |
+| `THRIFT_PORT` | 9092 | saiserver Thrift listen port |
 | `LAG_RIF_IPS` | 1 | enable LAG RIF connected-IP assignment in sai_test setUp (`SIMULATE_SONIC`) |
 | `SVI_RIF_IPS` | 1 | enable SVI RIF connected-IP assignment in sai_test setUp |
 | `SIMULATE_SONIC` | 1 | set by `run_test.sh`; enables sai_test's SONiC control-plane simulation (PortChannel netdevs + LAG/SVI RIF IPs) |
@@ -258,9 +304,11 @@ In `--debug` the container leaves the dataplane running after the test so you ca
 
 These are read by `run_test.sh` at container start (defaults shown).
 
+The VPP SAI profile resolves port lane sets through `port_config.ini`. The product default is `/usr/share/sonic/hwsku/port_config.ini`; this UT profile overrides it with `/etc/sai/port_config.ini`, which is installed from the harness fixture.
+
 ### Logs inside the container
 
-- `/var/log/saiserver.log` — saiserver stdout/stderr **plus** `libsaivs` `SWSS_LOG_*` lines. After the SAI change that removed `swss::Logger` setup from `saiserver.cpp`, the harness routes `SWSS_LOG_*` to stdout via an `LD_PRELOAD` shim (`swss_log_stdout_preload.cpp` → `/usr/local/lib/libswss_log_stdout.so`) so SAI backend traces still land in this file. `sai_log_set()` API-level notices from saiserver itself are also configured there.
+- `/var/log/saiserver.log` — saiserver stdout/stderr **plus** `libsaivs` `SWSS_LOG_*` lines. After the SAI change that removed `swss::Logger` setup from `saiserver.cpp`, the harness routes `SWSS_LOG_*` to **stderr** via an `LD_PRELOAD` shim (`swss_log_stdout_preload.cpp` → `/usr/local/lib/libswss_log_stdout.so`; the `.so` name is historical). `run_test.sh` redirects saiserver `2>&1` into this file so backend traces still land here. Routing to stderr (not stdout) keeps `SWSS_LOG_ENTER` lines out of `swss::exec()` captured stdout (e.g. the `find_new_bond_id` shell pipeline used during LAG create).
 - `/var/log/vpp.log`, `/var/log/vpp-startup.log` — VPP CLI history / stdout (crash backtraces).
 - `/var/log/vpp-api-trace.txt` — decoded VPP binary-API trace (dumped at teardown).
 - `/test-results/TEST-*.xml` — per-test JUnit results (bind-mount to the local `results/xml/` directory on the host).
@@ -268,5 +316,8 @@ These are read by `run_test.sh` at container start (defaults shown).
 ### Gotchas
 
 - The container must be `--privileged` (raw AF_PACKET sockets on veths/TAPs).
-- The VPP SAI backend can build the switch once per saiserver process; the per-group backend restart in `run_test.sh` handles this automatically — do not expect to re-run a full config build inside a single long-lived saiserver.
+- The VPP SAI backend can build the switch once per saiserver process; `run_test.sh` restarts the backend per test (default) or per config-signature group — do not expect to re-run a full config build inside a single long-lived saiserver.
+- **`stop_backend()` waits for child exit:** `terminate_process()` calls `wait` on VPP/saiserver/redis PIDs after they die so the next `start_vpp()` cannot overlap with a dying instance (avoids transient `Killed vpp` during per-test recycle).
+- **`Set port...` / `Turn up ports...` looks hung:** each test's T0 common-config build spends ~10–20s on port admin-up and veth bring-up with little console output; this is normal, not a deadlock.
+- **Long matrix runs:** use `nohup` + `tail -f results/run.log`; do not rely on IDE agent terminals for live progress on 87-test isolation runs.
 - A benign `buffer: numa[1] falling back to non-hugepage backed buffer pool` line at teardown is a host hugepage-availability warning, not a test failure.

--- a/.azure-pipelines/docker-sai-test-vpp/README.md
+++ b/.azure-pipelines/docker-sai-test-vpp/README.md
@@ -44,16 +44,16 @@ This lets one container run any mix of tests correctly in a single invocation.
 
 ### Supported tests
 
-The table below lists OCP `sai_test` classes that **pass** on the current VPP SAI backend (last strict validation **2026-07-21** against `sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test`). It is the published substitute for a full compatibility matrix: only passing tests are listed. After a local matrix run, update this section when the pass set changes (see **Collecting results** below).
+The table below lists OCP `sai_test` classes that **pass** on the current VPP SAI backend (last validated **2026-07-14** against `sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test` on `sai_vpp_ut_phase3`). It is the published substitute for a full compatibility matrix: only passing tests are listed. After a local matrix run, update this section when the pass set changes (see **Collecting results** below).
 
 | Module | Passing test classes |
 |---|---|
-| `sai_ecmp_test` | `EcmpLagDisableTestV4`, `EcmpLagDisableTestV6`, `EcmpReuseLagRouteV4`, `EcmpReuseLagRouteV6`, `RemoveAllNextHopMemeberTestV4`, `RemoveNexthopGroupTestV4` |
-| `sai_neighbor_test` | `AddHostRouteTestV6`, `NhopDiffPrefixRemoveLonger`, `NhopDiffPrefixRemoveLongerV6`, `NhopDiffPrefixRemoveShorter`, `NhopDiffPrefixRemoveShorterV6` |
-| `sai_rif_test` | — |
-| `sai_route_test` | `LagMultipleRoutev6Test`, `RemoveRouteV4Test`, `RouteDiffPrefixAddThenDeleteLongerV4Test`, `RouteDiffPrefixAddThenDeleteLongerV6Test`, `RouteDiffPrefixAddThenDeleteShorterV4Test`, `RouteDiffPrefixAddThenDeleteShorterV6Test`, `RouteSameSipDipv6Test`, `StaicSviMacFloodingTest` |
+| `sai_ecmp_test` | `EcmpLagDisableTestV4`, `EcmpLagDisableTestV6`, `EcmpReuseLagRouteV4`, `EcmpReuseLagRouteV6`, `ReAddLagEcmpTestV4`, `RemoveAllNextHopMemeberTestV4`, `RemoveLagEcmpTestV4`, `RemoveLagEcmpTestV6`, `RemoveNexthopGroupTestV4` |
+| `sai_neighbor_test` | `AddHostRouteTest`, `AddHostRouteTestV6`, `NhopDiffPrefixRemoveLonger`, `NhopDiffPrefixRemoveLongerV6`, `NhopDiffPrefixRemoveShorter`, `NhopDiffPrefixRemoveShorterV6`, `NoHostRouteTestV6` |
+| `sai_rif_test` | `IngressDisableTestV4`, `IngressDisableTestV6` |
+| `sai_route_test` | `DefaultRouteV4Test`, `DefaultRouteV6Test`, `DropRouteTest`, `DropRoutev6Test`, `LagMultipleRouteTest`, `LagMultipleRoutev6Test`, `RemoveRouteV4Test`, `RouteDiffPrefixAddThenDeleteLongerV4Test`, `RouteDiffPrefixAddThenDeleteLongerV6Test`, `RouteDiffPrefixAddThenDeleteShorterV4Test`, `RouteDiffPrefixAddThenDeleteShorterV6Test`, `RouteRifTest`, `RouteRifv6Test`, `RouteSameSipDipv4Test`, `RouteSameSipDipv6Test`, `RouteUpdateTest`, `RouteUpdatev6Test`, `StaicSviMacFloodingTest`, `StaicSviMacFloodingV6Test` |
 
-**19** classes passing (of 91 JUnit rows in the last strict full matrix run).
+**37** classes passing (of 89 executed in the last full matrix run).
 
 ## b) Building the framework
 
@@ -206,7 +206,6 @@ PTF writes one JUnit-XML file per test into `/test-results`. By convention these
 ```bash
 cd <sonic-buildimage>/src/sonic-sairedis/.azure-pipelines/docker-sai-test-vpp
 mkdir -p results/xml
-rm -f results/xml/TEST-*.xml
 docker run --rm --privileged -e PORT_COUNT=32 \
   -v "$PWD/results/xml:/test-results" \
   docker-sai-test-vpp:phase1 \
@@ -251,14 +250,13 @@ In `--debug` the container leaves the dataplane running after the test so you ca
 |---|---|---|
 | `PORT_COUNT` | 32 | number of `OEthernetX`/`OEthX_peer` veth pairs |
 | `COMMON_CONFIGURED_REUSE` | 1 | 1 = config-signature grouping + reuse; 0 = legacy single ptf invocation |
+| `KEEP_VETHS_UP_SECONDS` | 120 | how long the per-group watchdog keeps VPP host-interfaces/veths up |
 | `LAG_RIF_IPS` | 1 | enable LAG RIF connected-IP assignment in sai_test setUp (`SIMULATE_SONIC`) |
 | `SVI_RIF_IPS` | 1 | enable SVI RIF connected-IP assignment in sai_test setUp |
 | `SIMULATE_SONIC` | 1 | set by `run_test.sh`; enables sai_test's SONiC control-plane simulation (PortChannel netdevs + LAG/SVI RIF IPs) |
 | `TEST_FILTER` | — | alternative way to pass a single selector via env |
 
 These are read by `run_test.sh` at container start (defaults shown).
-
-The VPP SAI profile resolves port lane sets through `port_config.ini`. The product default is `/usr/share/sonic/hwsku/port_config.ini`; this UT profile overrides it with `/etc/sai/port_config.ini`, which is installed from the harness fixture.
 
 ### Logs inside the container
 

--- a/.azure-pipelines/docker-sai-test-vpp/README.md
+++ b/.azure-pipelines/docker-sai-test-vpp/README.md
@@ -243,6 +243,18 @@ nohup docker run --rm --privileged -e PORT_COUNT=32 \
 tail -f results/run.log
 ```
 
+### Monitor
+
+While a matrix run is in progress (from the `docker-sai-test-vpp/` directory):
+
+| | |
+|---|---|
+| **Log** | `results/run.log` (or whatever path you passed to `nohup` / `tee`) |
+| **Progress** | `grep -oE '\[[0-9]+/87\]' results/run.log \| tail -1` |
+| **Container** | `docker ps --filter ancestor=docker-sai-test-vpp:local` |
+
+The `87` in the progress grep matches the four-module isolation plan (`sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test`). For other selectors, use `grep -oE '\[[0-9]+/[0-9]+\]'` instead.
+
 Monitor progress without the full firehose:
 
 ```bash

--- a/.azure-pipelines/docker-sai-test-vpp/build_harness.sh
+++ b/.azure-pipelines/docker-sai-test-vpp/build_harness.sh
@@ -8,7 +8,7 @@ BUILDIMAGE_ROOT="${SONIC_BUILDIMAGE:-$(cd "${SAIREDIS_ROOT}/../.." && pwd)}"
 DEB_STAGING="${SCRIPT_DIR}/debs"
 DOCKERFILE="${SAIREDIS_ROOT}/.azure-pipelines/docker-sai-test-vpp/Dockerfile"
 BLDENV="${BLDENV:-trixie}"
-IMAGE_TAG="${IMAGE_TAG:-docker-sai-test-vpp:phase1}"
+IMAGE_TAG="${IMAGE_TAG:-docker-sai-test-vpp:local}"
 STAGE_DEBS="${STAGE_DEBS:-1}"
 BUILD_SAIREDIS_DEBS="${BUILD_SAIREDIS_DEBS:-0}"
 AUTO_BUILD_SAIREDIS_DEBS="${AUTO_BUILD_SAIREDIS_DEBS:-1}"
@@ -35,7 +35,7 @@ Options:
   --no-auto-build       Do not invoke make when sonic-sairedis .debs are
                         missing (validate only; fail with hints)
   --bldenv <name>       Debian suite for target/debs (default: trixie)
-  --image-tag <tag>     Docker image tag (default: docker-sai-test-vpp:phase1)
+  --image-tag <tag>     Docker image tag (default: docker-sai-test-vpp:local)
   --vpp-deb-dir <path>  Directory of VPP .debs (default: search buildimage
                         target/debs/<bldenv> and VPP_DEB_DIR env)
   -h, --help            Show this help

--- a/.azure-pipelines/docker-sai-test-vpp/build_harness.sh
+++ b/.azure-pipelines/docker-sai-test-vpp/build_harness.sh
@@ -8,7 +8,7 @@ BUILDIMAGE_ROOT="${SONIC_BUILDIMAGE:-$(cd "${SAIREDIS_ROOT}/../.." && pwd)}"
 DEB_STAGING="${SCRIPT_DIR}/debs"
 DOCKERFILE="${SAIREDIS_ROOT}/.azure-pipelines/docker-sai-test-vpp/Dockerfile"
 BLDENV="${BLDENV:-trixie}"
-IMAGE_TAG="${IMAGE_TAG:-docker-sai-test-vpp:local}"
+IMAGE_TAG="${IMAGE_TAG:-docker-sai-test-vpp:latest}"
 STAGE_DEBS="${STAGE_DEBS:-1}"
 BUILD_SAIREDIS_DEBS="${BUILD_SAIREDIS_DEBS:-0}"
 AUTO_BUILD_SAIREDIS_DEBS="${AUTO_BUILD_SAIREDIS_DEBS:-1}"
@@ -35,7 +35,7 @@ Options:
   --no-auto-build       Do not invoke make when sonic-sairedis .debs are
                         missing (validate only; fail with hints)
   --bldenv <name>       Debian suite for target/debs (default: trixie)
-  --image-tag <tag>     Docker image tag (default: docker-sai-test-vpp:local)
+  --image-tag <tag>     Docker image tag (default: docker-sai-test-vpp:latest)
   --vpp-deb-dir <path>  Directory of VPP .debs (default: search buildimage
                         target/debs/<bldenv> and VPP_DEB_DIR env)
   -h, --help            Show this help

--- a/.azure-pipelines/docker-sai-test-vpp/gen_compatibility_matrix.py
+++ b/.azure-pipelines/docker-sai-test-vpp/gen_compatibility_matrix.py
@@ -23,7 +23,7 @@ Example workflow:
     mkdir -p results/xml
     docker run --rm --privileged -e PORT_COUNT=32 \
         -v "$PWD/results/xml:/test-results" \
-        docker-sai-test-vpp:phase1 \
+        docker-sai-test-vpp:local \
         sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test \
         2>&1 | tee results/run.log
     python3 gen_compatibility_matrix.py        # writes results/compatibility-matrix.md

--- a/.azure-pipelines/docker-sai-test-vpp/gen_compatibility_matrix.py
+++ b/.azure-pipelines/docker-sai-test-vpp/gen_compatibility_matrix.py
@@ -23,7 +23,7 @@ Example workflow:
     mkdir -p results/xml
     docker run --rm --privileged -e PORT_COUNT=32 \
         -v "$PWD/results/xml:/test-results" \
-        docker-sai-test-vpp:local \
+        docker-sai-test-vpp:latest \
         sai_route_test sai_rif_test sai_neighbor_test sai_ecmp_test \
         2>&1 | tee results/run.log
     python3 gen_compatibility_matrix.py        # writes results/compatibility-matrix.md

--- a/.azure-pipelines/docker-sai-test-vpp/run_test.sh
+++ b/.azure-pipelines/docker-sai-test-vpp/run_test.sh
@@ -621,13 +621,19 @@ terminate_process()
     local process_name="$1"
     local process_pid="$2"
 
-    if [[ -z "$process_pid" ]] || ! kill -0 "$process_pid" >/dev/null 2>&1; then
+    if [[ -z "$process_pid" ]]; then
+        return 0
+    fi
+
+    if ! kill -0 "$process_pid" >/dev/null 2>&1; then
+        wait "$process_pid" 2>/dev/null || true
         return 0
     fi
 
     kill "$process_pid" >/dev/null 2>&1 || true
     for ((attempt = 1; attempt <= 5; attempt++)); do
         if ! kill -0 "$process_pid" >/dev/null 2>&1; then
+            wait "$process_pid" 2>/dev/null || true
             return 0
         fi
         sleep 1
@@ -635,6 +641,7 @@ terminate_process()
 
     log "Force stopping $process_name"
     kill -9 "$process_pid" >/dev/null 2>&1 || true
+    wait "$process_pid" 2>/dev/null || true
 }
 
 # In --debug mode, hold the script (PID 1) open after the tests finish so the

--- a/.azure-pipelines/docker-sai-test-vpp/swss_log_stdout_preload.cpp
+++ b/.azure-pipelines/docker-sai-test-vpp/swss_log_stdout_preload.cpp
@@ -10,8 +10,8 @@ static void route_swss_log_to_stdout()
 {
     SWSS_LOG_ENTER();
     swss::Logger::setMinPrio(swss::Logger::SWSS_DEBUG);
-    // STDERR keeps SWSS_LOG_ENTER/EXIT out of swss::exec() captured stdout (e.g.
-    // find_new_bond_id's ip|awk pipeline). run_test.sh redirects 2>&1 to SAISERVER_LOG.
+    // Standard error keeps function entry and exit logs out of captured standard
+    // output. The harness redirects both streams to the SAI server log.
     swss::Logger::swssOutputNotify("saiserver", "STDERR");
 }
 

--- a/.azure-pipelines/docker-sai-test-vpp/swss_log_stdout_preload.cpp
+++ b/.azure-pipelines/docker-sai-test-vpp/swss_log_stdout_preload.cpp
@@ -10,7 +10,9 @@ static void route_swss_log_to_stdout()
 {
     SWSS_LOG_ENTER();
     swss::Logger::setMinPrio(swss::Logger::SWSS_DEBUG);
-    swss::Logger::swssOutputNotify("saiserver", "STDOUT");
+    // STDERR keeps SWSS_LOG_ENTER/EXIT out of swss::exec() captured stdout (e.g.
+    // find_new_bond_id's ip|awk pipeline). run_test.sh redirects 2>&1 to SAISERVER_LOG.
+    swss::Logger::swssOutputNotify("saiserver", "STDERR");
 }
 
 } // namespace

--- a/.azure-pipelines/docker-sai-test-vpp/vpp_startup.conf.template
+++ b/.azure-pipelines/docker-sai-test-vpp/vpp_startup.conf.template
@@ -45,6 +45,7 @@ plugins {
   plugin vxlan_plugin.so { enable }
   plugin tunterm_acl_plugin.so { enable }
   plugin ip_validate_plugin.so { enable }
+  plugin sflow_plugin.so { enable }
 }
 
 linux-cp {

--- a/.azure-pipelines/docker-sai-test-vpp/vpp_startup.conf.template
+++ b/.azure-pipelines/docker-sai-test-vpp/vpp_startup.conf.template
@@ -38,6 +38,7 @@ ip6 {
 plugins {
   plugin default { disable }
   plugin af_packet_plugin.so { enable }
+  plugin tap_plugin.so { enable }
   plugin linux_cp_plugin.so { enable }
   plugin linux_nl_plugin.so { enable }
   plugin acl_plugin.so { enable }


### PR DESCRIPTION
### Description of PR

Summary:
Follow-up to the merged SAIVPP unit-test framework ([#1950](https://github.com/sonic-net/sonic-sairedis/pull/1950), [#1951](https://github.com/sonic-net/sonic-sairedis/pull/1951), [#1952](https://github.com/sonic-net/sonic-sairedis/pull/1952)). Restores the compatibility that the harness lost as `master` and VPP moved forward: two VPP 26.06 startup plugins the harness needs, a backend-restart race in `run_test.sh`, harness log routing, and the corresponding documentation refresh. Small and mostly mechanical; reviewers can start at `.azure-pipelines/docker-sai-test-vpp/vpp_startup.conf.template`.

Fixes # (N/A — no upstream issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation update
- [x] Test improvement

### Approach

#### What is the motivation for this PR?
The Phase 3 development branch was rebuilt on a newer `master` and a newer VPP than Phase 1/2 targeted. That surfaced two independent breakages: VPP 26.06 moved the TAP driver into its own plugin and `saiserver` began asserting on a missing sflow message-id base, so the harness could not create `linux_cp` host interfaces; and the per-test backend recycle could overlap a dying VPP instance. Neither is a VPP dataplane behavior change — they are the cost of catching up to current upstream.

#### How did you do it?
- `.azure-pipelines/docker-sai-test-vpp/vpp_startup.conf.template`: enable `tap_plugin.so` (VPP 26.06 relocated the TAP driver `linux_cp` needs; without it `lcp_itf_pair_add_del` returns `FEATURE_DISABLED` and host-interface bring-up fails) and `sflow_plugin.so` (saiserver startup asserts if the sflow message-id base is absent).
- `.azure-pipelines/docker-sai-test-vpp/run_test.sh`: `terminate_process()` now `wait`s on each VPP/saiserver/Redis PID after it dies, so the next `start_vpp()` cannot overlap a dying instance during the per-test recycle.
- `.azure-pipelines/docker-sai-test-vpp/swss_log_stdout_preload.cpp`: route `SWSS_LOG_*` to **stderr** instead of stdout. `run_test.sh` redirects both streams into `saiserver.log`, and keeping `SWSS_LOG_ENTER` lines off stdout stops them from polluting `swss::exec()` captured output (e.g. the `find_new_bond_id` shell pipeline used during LAG create).
- `.azure-pipelines/docker-sai-test-vpp/README.md`, `build_harness.sh`, `gen_compatibility_matrix.py`: refresh the harness documentation for the current state, retire the stale `phase1` image tag in favour of Docker's default `docker-sai-test-vpp:latest` (per review feedback), document the per-test isolation default and the newly required VPP plugins, and add a Monitor section for detached long matrix runs.

Four commits that were originally in this PR moved into the SAI submodule-bump PR. Three are metadata initializers (`syncd/SwitchNotifications.h`, `unittest/meta/TestSaiSerialize.cpp`, `unittest/syncd/TestAttrVersionChecker.cpp`), because the members they initialize do not exist in the SAI revision `master` currently pins. The fourth is the `pyext/py3/Makefile.am` `-Wno-error=disabled-optimization` flag: the newer SAI headers are what enlarge the SWIG-generated `pysairedis` wrapper past GCC's `max-gcse-memory` limit on armhf, so that flag belongs with the bump rather than here.

#### How did you verify/test it?
`bash -n` on the harness scripts, `tests/checkwhitespace.sh`, `tests/swsslogentercheck.sh`, and `git diff --check` all pass. The compatibility fixes were originally found and validated on the Phase 3 integration branch, where the harness could not build the image or complete a backend recycle without them. No new pass counts are claimed here: this PR restores the ability to build and run, and the gated matrix numbers live in the CI PR.

#### Any platform specific information?
VPP unit-test harness only. No `vslib/vpp/` dataplane behavior changes, so production VPP forwarding is untouched. The two newly enabled VPP plugins apply to the harness-generated `startup.conf` only, not to any product configuration.

### Documentation
Updates the harness `README.md`: per-test isolation vs grouped mode, the required VPP startup plugins and why they cannot be trimmed, the `docker-sai-test-vpp:latest` tag convention, and detached-run/monitoring guidance.

### Dependencies and merge order
Based on current upstream `master`; no required merge order. File-disjoint from the backend PR below. This PR and the CI PR both touch `docker-sai-test-vpp/README.md`, `run_test.sh`, and `build_harness.sh`, so whichever merges second needs a rebase — that is a textual overlap, not a functional dependency. Development context for this work is in the Phase 3 integration draft [#1992](https://github.com/sonic-net/sonic-sairedis/pull/1992), which stays open as history and should not be merged.
