### PR TITLE
[vpp] VPP SAI backend fixes: detect bond-create failure, program route DROP actions

### DIFF
--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1202,10 +1202,11 @@ sai_status_t SwitchVpp::vpp_create_lag(
     mode = VPP_BOND_API_MODE_XOR;
     lb = VPP_BOND_API_LB_ALGO_L34_INNER;
 
-    create_bond_interface(bond_id, mode, lb, &swif_idx);
-    if (swif_idx == static_cast<uint32_t>(~0))
+    int ret = create_bond_interface(bond_id, mode, lb, &swif_idx);
+    if (ret != 0 || swif_idx == static_cast<uint32_t>(~0) || swif_idx == 0)
     {
-        SWSS_LOG_ERROR("failed to create bond interface in VPP for %s", sai_serialize_object_id(lag_id).c_str());
+        SWSS_LOG_ERROR("failed to create bond interface in VPP for %s (ret=%d, swif_idx=%u)",
+                sai_serialize_object_id(lag_id).c_str(), ret, swif_idx);
         return SAI_STATUS_FAILURE;
     }
 

--- a/vslib/vpp/SwitchVppRoute.cpp
+++ b/vslib/vpp/SwitchVppRoute.cpp
@@ -162,7 +162,35 @@ sai_status_t SwitchVpp::IpRouteAddRemove(
         packet_action = attr.value.s32;
     }
 
-    // We should program drop routes
+    sai_route_entry_t route_entry;
+    sai_deserialize_route_entry(serializedObjectId, route_entry);
+
+    if (packet_action == SAI_PACKET_ACTION_DROP) {
+        std::shared_ptr<IpVrfInfo> vrf = vpp_get_ip_vrf(route_entry.vr_id);
+        uint32_t vrf_id = vrf == nullptr ? 0 : vrf->m_vrf_id;
+        vpp_ip_route_t *ip_route = (vpp_ip_route_t *)
+            calloc(1, sizeof(vpp_ip_route_t) + sizeof(vpp_ip_nexthop_t));
+        if (!ip_route) {
+            return SAI_STATUS_FAILURE;
+        }
+
+        create_route_prefix_entry(&route_entry, ip_route);
+        ip_route->vrf_id = vrf_id;
+        ip_route->nexthop_cnt = 1;
+        ip_route->nexthop[0].addr.sa_family = ip_route->prefix_addr.sa_family;
+        ip_route->nexthop[0].sw_if_index = (uint32_t)~0;
+        ip_route->nexthop[0].weight = 1;
+        ip_route->nexthop[0].type = VPP_NEXTHOP_DROP;
+
+        ret = ip_route_add_del_get_stats(ip_route, is_add, is_add ? stats_index : NULL);
+        free(ip_route);
+
+        SWSS_LOG_NOTICE("%s drop route in VS %s status %d table %u",
+                        is_add ? "Add" : "Remove",
+                        serializedObjectId.c_str(), ret, vrf_id);
+        return ret == 0 ? SAI_STATUS_SUCCESS : SAI_STATUS_FAILURE;
+    }
+
     if (packet_action != SAI_PACKET_ACTION_FORWARD) {
         SWSS_LOG_NOTICE("Ignoring ip route %s: action is not forward: %d",
                         serializedObjectId.c_str(), packet_action);
@@ -178,12 +206,9 @@ sai_status_t SwitchVpp::IpRouteAddRemove(
     }
     next_hop_oid = attr.value.oid;
 
-    sai_route_entry_t route_entry;
     const char *hwif_name = NULL;
     vpp_nexthop_type_e nexthop_type = VPP_NEXTHOP_NORMAL;
     bool config_ip_route = false;
-
-    sai_deserialize_route_entry(serializedObjectId, route_entry);
 
     nexthop_grp_config_t *nxthop_group = NULL;
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -2969,6 +2969,8 @@ int ip_route_add_del_get_stats (vpp_ip_route_t *prefix, bool is_add, uint32_t *s
             fib_path->type = htonl(FIB_API_PATH_TYPE_NORMAL);
         } else if (nexthop->type == VPP_NEXTHOP_LOCAL) {
             fib_path->type = htonl(FIB_API_PATH_TYPE_LOCAL);
+        } else if (nexthop->type == VPP_NEXTHOP_DROP) {
+            fib_path->type = htonl(FIB_API_PATH_TYPE_DROP);
         }
         fib_path->table_id = 0;
         fib_path->rpf_id = htonl((uint32_t)~0);

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -24,7 +24,8 @@ extern "C" {
 
     typedef enum {
 	VPP_NEXTHOP_NORMAL = 1,
-	VPP_NEXTHOP_LOCAL = 2
+    VPP_NEXTHOP_LOCAL = 2,
+    VPP_NEXTHOP_DROP = 3
     } vpp_nexthop_type_e;
 
     typedef struct vpp_ip_addr_ {


### PR DESCRIPTION
### Description of PR

Summary:
Two VPP SAI backend (`vslib/vpp/`) correctness fixes found while bringing the OCP `sai_test` suite forward on the SAIVPP unit-test framework ([#1950](https://github.com/sonic-net/sonic-sairedis/pull/1950)), and not included in the earlier backend PR ([#1952](https://github.com/sonic-net/sonic-sairedis/pull/1952)). Pure backend — no harness, CI, or docs. Reviewers can start in `vslib/vpp/SwitchVppRoute.cpp`.

Fixes # (N/A — no upstream issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?
Two gaps. First, `vpp_create_lag()` ignored the return code of `create_bond_interface()` and only rejected `sw_if_index == ~0`. When VPP rejects `bond_create` the reply carries a non-zero `retval` with `sw_if_index` 0 (`local0`), so the guard passed, the LAG was recorded against `local0`, and the real failure only surfaced later as a confusing lag-member create error. Second, a SAI route with `SAI_PACKET_ACTION_DROP` was silently ignored: the code took the "action is not forward" path and never programmed anything, so traffic to a supposedly dropped prefix kept following whatever less-specific route existed.

#### How did you do it?
- `vslib/vpp/SwitchVppFdb.cpp`: capture the `create_bond_interface()` return code and treat a non-zero return, `~0`, or `0` as failure, logging both `ret` and `swif_idx` so the VPP-side rejection is visible at the point of failure.
- `vslib/vpp/SwitchVppRoute.cpp`: handle `SAI_PACKET_ACTION_DROP` before the forward-only early return. Resolve the VRF, build a single-path `vpp_ip_route_t` with `VPP_NEXTHOP_DROP` and `sw_if_index = ~0`, and program it through the existing `ip_route_add_del_get_stats()` path so add and remove are symmetric. The `sai_deserialize_route_entry()` call moved above the packet-action branch because both paths now need the parsed entry.
- `vslib/vpp/vppxlate/SaiVppXlate.{c,h}`: add `VPP_NEXTHOP_DROP` to `vpp_nexthop_type_e` and map it to `FIB_API_PATH_TYPE_DROP` when building the FIB path.

#### How did you verify/test it?
`tests/checkwhitespace.sh`, `tests/swsslogentercheck.sh`, and `git diff --check` pass. Both fixes were exercised on the Phase 3 integration branch, where the bond-create guard converted a late, misleading lag-member error into an immediate and accurate LAG create failure, and the DROP path made `sai_route_test.DropRouteTest` / `DropRoutev6Test` program a real VPP drop route instead of being ignored. Those two selectors run in the full matrix but are deliberately **not** in the gated stable baseline yet (see the CI PR), so no gated pass-count change is claimed here.

#### Any platform specific information?
VPP platform only (`vslib/vpp/`). The bond-create change is a strictly stronger error check on an existing failure path. The DROP change adds programming where the backend previously did nothing, so a VRF that relied on a DROP route being a no-op will now actually drop.

### Documentation
No new docs in this PR (kept backend-only). Development context and validation notes are in `sonic-buildimage/devdocs/merge-p3.md`.

### Dependencies and merge order
Based on current upstream `master`; no required merge order. File-disjoint from both other Phase 3 PRs, verified by merging this branch and the compatibility branch onto `master` in both orders with no conflicts. Development context is in the Phase 3 integration draft [#1992](https://github.com/sonic-net/sonic-sairedis/pull/1992), which stays open as history.