### PR TITLE
[submodule] Update SAI to latest upstream master and align generated-metadata initializers

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -2036,6 +2036,7 @@ void Meta::meta_generic_validation_post_remove(
                 break;
 
             case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
+            case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             case SAI_ATTR_VALUE_TYPE_TAPS_LIST:
                 // no special action required
@@ -3827,6 +3828,10 @@ sai_status_t Meta::meta_generic_validation_create(
                 VALIDATION_LIST(md, value.portlanelatchstatuslist);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
+                VALIDATION_LIST(md, value.port_ilt_lane_training_status_list);
+                break;
+
             case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
                 VALIDATION_LIST(md, value.portsnrlist);
                 break;
@@ -4480,6 +4485,10 @@ sai_status_t Meta::meta_generic_validation_set(
             VALIDATION_LIST(md, value.portlanelatchstatuslist);
             break;
 
+        case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
+            VALIDATION_LIST(md, value.port_ilt_lane_training_status_list);
+            break;
+
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             VALIDATION_LIST(md, value.portsnrlist);
             break;
@@ -4890,6 +4899,10 @@ sai_status_t Meta::meta_generic_validation_get(
                 VALIDATION_LIST(md, value.portlanelatchstatuslist);
                 break;
 
+            case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
+                VALIDATION_LIST(md, value.port_ilt_lane_training_status_list);
+                break;
+
             case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
                 VALIDATION_LIST(md, value.portsnrlist);
                 break;
@@ -5206,6 +5219,10 @@ void Meta::meta_generic_validation_post_get(
 
             case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
                 VALIDATION_LIST_GET(md, value.portlanelatchstatuslist);
+                break;
+
+            case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
+                VALIDATION_LIST_GET(md, value.port_ilt_lane_training_status_list);
                 break;
 
             case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -350,6 +350,10 @@ sai_status_t transfer_attribute(
             RETURN_ON_ERROR(transfer_list(src_attr.value.portlanelatchstatuslist, dst_attr.value.portlanelatchstatuslist, countOnly));
             break;
 
+        case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
+            RETURN_ON_ERROR(transfer_list(src_attr.value.port_ilt_lane_training_status_list, dst_attr.value.port_ilt_lane_training_status_list, countOnly));
+            break;
+
         case SAI_ATTR_VALUE_TYPE_LATCH_STATUS:
             transfer_primitive(src_attr.value.latchstatus, dst_attr.value.latchstatus);
             break;
@@ -1886,6 +1890,32 @@ std::string sai_serialize_port_snr_list(
     return j.dump();
 }
 
+std::string sai_serialize_port_ilt_lane_training_status_list(
+        _In_ const sai_port_ilt_lane_training_status_list_t& status_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    json j = json::object();
+
+    if (status_list.list == NULL || countOnly)
+    {
+        return j.dump();
+    }
+
+    // Create dictionary format keyed by lane, with each training status by name
+    for (uint32_t i = 0; i < status_list.count; ++i)
+    {
+        std::string lane_key = std::to_string(status_list.list[i].lane);
+
+        j[lane_key] = sai_serialize_enum(
+                static_cast<int32_t>(status_list.list[i].training_status),
+                &sai_metadata_enum_sai_port_ilt_lane_training_status_t);
+    }
+
+    return j.dump();
+}
+
 std::string sai_serialize_taps_list(
         _In_ const sai_taps_list_t& port_serdes_taps_list,
         _In_ bool countOnly)
@@ -2462,6 +2492,9 @@ std::string sai_serialize_attr_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             return sai_serialize_port_lane_latch_status_list(attr.value.portlanelatchstatuslist, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
+            return sai_serialize_port_ilt_lane_training_status_list(attr.value.port_ilt_lane_training_status_list, countOnly);
 
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             return sai_serialize_port_snr_list(attr.value.portsnrlist, countOnly);
@@ -4864,6 +4897,80 @@ void sai_deserialize_port_snr_list(
     }
 }
 
+void sai_deserialize_port_ilt_lane_training_status_list(
+        _In_ const std::string& s,
+        _Out_ sai_port_ilt_lane_training_status_list_t& status_list,
+        _In_ bool countOnly)
+{
+    SWSS_LOG_ENTER();
+
+    // Entries are collected here first so that a malformed lane key or training
+    // status, both of which throw, cannot leak a partially populated list.
+
+    sai_ilt_lane_training_status_t *list = NULL;
+
+    try
+    {
+        json j = json::parse(s);
+
+        if (j.empty() || !j.is_object())
+        {
+            status_list.count = 0;
+            status_list.list = NULL;
+            return;
+        }
+
+        status_list.count = static_cast<uint32_t>(j.size());
+
+        if (countOnly)
+        {
+            return;
+        }
+
+        list = sai_alloc_n_of_ptr_type(status_list.count, list);
+
+        uint32_t idx = 0;
+        for (auto it = j.begin(); it != j.end(); ++it, ++idx)
+        {
+            // Populate defaults first so a rejected entry never leaves this
+            // element uninitialized for the caller.
+            list[idx].lane = static_cast<uint32_t>(std::stoul(it.key()));
+            list[idx].training_status = SAI_PORT_ILT_LANE_TRAINING_STATUS_RESERVED;
+
+            if (!it.value().is_string())
+            {
+                SWSS_LOG_ERROR("Invalid training status value type for lane %s", it.key().c_str());
+                continue;
+            }
+
+            int32_t training_status = 0;
+
+            sai_deserialize_enum(
+                    it.value().get<std::string>(),
+                    &sai_metadata_enum_sai_port_ilt_lane_training_status_t,
+                    training_status);
+
+            list[idx].training_status = static_cast<sai_port_ilt_lane_training_status_t>(training_status);
+        }
+
+        status_list.list = list;
+    }
+    catch (const json::parse_error& e)
+    {
+        SWSS_LOG_ERROR("JSON parse error in sai_deserialize_port_ilt_lane_training_status_list: %s", e.what());
+        delete[] list;
+        status_list.count = 0;
+        status_list.list = NULL;
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Error in sai_deserialize_port_ilt_lane_training_status_list: %s", e.what());
+        delete[] list;
+        status_list.count = 0;
+        status_list.list = NULL;
+    }
+}
+
 void sai_deserialize_taps_list(
         _In_ const std::string& s,
         _Out_ sai_taps_list_t& port_serdes_taps_list,
@@ -5107,6 +5214,9 @@ void sai_deserialize_attr_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             return sai_deserialize_port_lane_latch_status_list(s, attr.value.portlanelatchstatuslist, countOnly);
+
+        case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
+            return sai_deserialize_port_ilt_lane_training_status_list(s, attr.value.port_ilt_lane_training_status_list, countOnly);
 
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             return sai_deserialize_port_snr_list(s, attr.value.portsnrlist, countOnly);
@@ -6571,6 +6681,10 @@ void sai_deserialize_free_attribute_value(
 
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             sai_free_list(attr.value.portlanelatchstatuslist);
+            break;
+
+        case SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST:
+            sai_free_list(attr.value.port_ilt_lane_training_status_list);
             break;
 
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -330,6 +330,10 @@ std::string sai_serialize_port_snr_list(
         _In_ const sai_port_snr_list_t& snr_list,
         _In_ bool countOnly);
 
+std::string sai_serialize_port_ilt_lane_training_status_list(
+        _In_ const sai_port_ilt_lane_training_status_list_t& status_list,
+        _In_ bool countOnly);
+
 std::string sai_serialize_taps_list(
         _In_ const sai_taps_list_t& port_serdes_taps_list,
         _In_ bool countOnly);
@@ -796,6 +800,11 @@ void sai_deserialize_stats_st_capability_list(
 void sai_deserialize_port_snr_list(
         _In_ const std::string& s,
         _Out_ sai_port_snr_list_t& snr_list,
+        _In_ bool countOnly);
+
+void sai_deserialize_port_ilt_lane_training_status_list(
+        _In_ const std::string& s,
+        _Out_ sai_port_ilt_lane_training_status_list_t& status_list,
         _In_ bool countOnly);
 
 void sai_deserialize_taps_list(

--- a/pyext/py3/Makefile.am
+++ b/pyext/py3/Makefile.am
@@ -10,7 +10,8 @@ BUILT_SOURCES = pysairedis_wrap.cpp
 
 _pysairedis_la_SOURCES = pysairedis_wrap.cpp $(SOURCES)
 _pysairedis_la_CXXFLAGS = $(PYTHON3_CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) \
-						  -Wno-cast-align -Wno-cast-qual -Wno-shadow -Wno-redundant-decls
+						  -Wno-cast-align -Wno-cast-qual -Wno-shadow -Wno-redundant-decls \
+						  -Wno-error=disabled-optimization
 
 _pysairedis_la_LDFLAGS = -module \
 		-lhiredis -lswsscommon -lpthread \

--- a/syncd/SwitchNotifications.h
+++ b/syncd/SwitchNotifications.h
@@ -169,9 +169,11 @@ namespace syncd
                             .on_ipsec_post_status = &Slot<context>::onIpsecPostStatus,
                             .on_switch_macsec_post_status = &Slot<context>::onSwitchMacsecPostStatus,
                             .on_switch_ipsec_post_status = &Slot<context>::onSwitchIpsecPostStatus,
+                            .on_next_hop_group_hw_protection_switchover = nullptr,
                             .on_ha_set_event = &Slot<context>::onHaSetEvent,
                             .on_ha_scope_event = &Slot<context>::onHaScopeEvent,
                             .on_flow_bulk_get_session_event = &Slot<context>::onFlowBulkGetSessionEvent,
+                            .on_ocs_port_state_change = nullptr,
                             }) { }
 
                 virtual ~Slot() {}

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -1299,8 +1299,8 @@ TEST(SaiSerialize, serialize_qos_map)
     attr.id = SAI_QOS_MAP_ATTR_MAP_TO_VALUE_LIST;
 
     sai_qos_map_t qm = {
-        .key   = { .tc = 1, .dscp = 2, .dot1p = 3, .prio = 4, .pg = 5, .queue_index = 6, .color = SAI_PACKET_COLOR_RED, .mpls_exp = 0, .fc = 2 },
-        .value = { .tc = 11, .dscp = 22, .dot1p = 33, .prio = 44, .pg = 55, .queue_index = 66, .color = SAI_PACKET_COLOR_GREEN, .mpls_exp = 0, .fc = 2 } };
+        .key   = { .tc = 1, .dscp = 2, .dot1p = 3, .prio = 4, .pg = 5, .queue_index = 6, .color = SAI_PACKET_COLOR_RED, .mpls_exp = 0, .fc = 2, .dei = 0, .vc = 0 },
+        .value = { .tc = 11, .dscp = 22, .dot1p = 33, .prio = 44, .pg = 55, .queue_index = 66, .color = SAI_PACKET_COLOR_GREEN, .mpls_exp = 0, .fc = 2, .dei = 0, .vc = 0 } };
 
     attr.value.qosmap.count = 1;
     attr.value.qosmap.list = &qm;

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -226,6 +226,130 @@ TEST(SaiSerialize, sai_deserialize_port_snr_list)
     EXPECT_EQ(snr_list.list, nullptr);
 }
 
+TEST(SaiSerialize, sai_serialize_port_ilt_lane_training_status_list)
+{
+    sai_ilt_lane_training_status_t list[2];
+
+    list[0].lane = 0;
+    list[0].training_status = SAI_PORT_ILT_LANE_TRAINING_STATUS_OK;
+
+    list[1].lane = 1;
+    list[1].training_status = SAI_PORT_ILT_LANE_TRAINING_STATUS_FAIL;
+
+    sai_port_ilt_lane_training_status_list_t status_list;
+
+    status_list.count = 2;
+    status_list.list = list;
+
+    auto s = sai_serialize_port_ilt_lane_training_status_list(status_list, false);
+
+    std::string expected =
+        R"({"0":"SAI_PORT_ILT_LANE_TRAINING_STATUS_OK","1":"SAI_PORT_ILT_LANE_TRAINING_STATUS_FAIL"})";
+
+    EXPECT_EQ(s, expected);
+
+    // A count only request and a null list both serialize to an empty object
+
+    EXPECT_EQ(sai_serialize_port_ilt_lane_training_status_list(status_list, true), "{}");
+
+    status_list.list = nullptr;
+
+    EXPECT_EQ(sai_serialize_port_ilt_lane_training_status_list(status_list, false), "{}");
+}
+
+TEST(SaiSerialize, sai_deserialize_port_ilt_lane_training_status_list)
+{
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+
+    auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT,
+                                                SAI_PORT_ATTR_ILT_LANE_TRAINING_STATUS_LIST);
+    attr.id = SAI_PORT_ATTR_ILT_LANE_TRAINING_STATUS_LIST;
+
+    std::string json_str =
+        R"({"0":"SAI_PORT_ILT_LANE_TRAINING_STATUS_OK","3":"SAI_PORT_ILT_LANE_TRAINING_STATUS_IN_PROGRESS"})";
+
+    sai_deserialize_attr_value(json_str, *meta, attr, false);
+
+    EXPECT_EQ(attr.value.port_ilt_lane_training_status_list.count, 2);
+    ASSERT_NE(attr.value.port_ilt_lane_training_status_list.list, nullptr);
+
+    EXPECT_EQ(attr.value.port_ilt_lane_training_status_list.list[0].lane, 0);
+    EXPECT_EQ(attr.value.port_ilt_lane_training_status_list.list[0].training_status,
+            SAI_PORT_ILT_LANE_TRAINING_STATUS_OK);
+
+    EXPECT_EQ(attr.value.port_ilt_lane_training_status_list.list[1].lane, 3);
+    EXPECT_EQ(attr.value.port_ilt_lane_training_status_list.list[1].training_status,
+            SAI_PORT_ILT_LANE_TRAINING_STATUS_IN_PROGRESS);
+
+    sai_deserialize_free_attribute_value(meta->attrvaluetype, attr);
+
+    std::string empty_json_str = R"({})";
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_PORT_ATTR_ILT_LANE_TRAINING_STATUS_LIST;
+
+    sai_deserialize_attr_value(empty_json_str, *meta, attr, false);
+    EXPECT_EQ(attr.value.port_ilt_lane_training_status_list.count, 0);
+    EXPECT_EQ(attr.value.port_ilt_lane_training_status_list.list, nullptr);
+}
+
+TEST(SaiSerialize, sai_deserialize_port_ilt_lane_training_status_list_count_only)
+{
+    std::string json_str =
+        R"({"0":"SAI_PORT_ILT_LANE_TRAINING_STATUS_OK","3":"SAI_PORT_ILT_LANE_TRAINING_STATUS_TRAINED"})";
+
+    sai_port_ilt_lane_training_status_list_t status_list;
+    memset(&status_list, 0, sizeof(status_list));
+
+    sai_deserialize_port_ilt_lane_training_status_list(json_str, status_list, true);
+
+    EXPECT_EQ(status_list.count, 2);
+    EXPECT_EQ(status_list.list, nullptr);
+}
+
+TEST(SaiSerialize, sai_deserialize_port_ilt_lane_training_status_list_malformed)
+{
+    sai_port_ilt_lane_training_status_list_t status_list;
+
+    // A non string status is skipped, but the lane it belongs to is still
+    // reported so the caller never reads an uninitialized entry
+
+    memset(&status_list, 0, sizeof(status_list));
+
+    sai_deserialize_port_ilt_lane_training_status_list(
+            R"({"0":7,"1":"SAI_PORT_ILT_LANE_TRAINING_STATUS_FAIL"})", status_list, false);
+
+    EXPECT_EQ(status_list.count, 2);
+    ASSERT_NE(status_list.list, nullptr);
+
+    EXPECT_EQ(status_list.list[0].lane, 0);
+    EXPECT_EQ(status_list.list[0].training_status, SAI_PORT_ILT_LANE_TRAINING_STATUS_RESERVED);
+
+    EXPECT_EQ(status_list.list[1].lane, 1);
+    EXPECT_EQ(status_list.list[1].training_status, SAI_PORT_ILT_LANE_TRAINING_STATUS_FAIL);
+
+    delete[] status_list.list;
+
+    // Input that is not an object, that fails to parse, or that carries a non
+    // numeric lane key yields an empty list instead of throwing
+
+    memset(&status_list, 0, sizeof(status_list));
+    sai_deserialize_port_ilt_lane_training_status_list(R"(["a"])", status_list, false);
+    EXPECT_EQ(status_list.count, 0);
+    EXPECT_EQ(status_list.list, nullptr);
+
+    memset(&status_list, 0, sizeof(status_list));
+    sai_deserialize_port_ilt_lane_training_status_list("{not json", status_list, false);
+    EXPECT_EQ(status_list.count, 0);
+    EXPECT_EQ(status_list.list, nullptr);
+
+    memset(&status_list, 0, sizeof(status_list));
+    sai_deserialize_port_ilt_lane_training_status_list(
+            R"({"lane0":"SAI_PORT_ILT_LANE_TRAINING_STATUS_OK"})", status_list, false);
+    EXPECT_EQ(status_list.count, 0);
+    EXPECT_EQ(status_list.list, nullptr);
+}
+
 TEST(SaiSerialize, sai_serialize_attr_value)
 {
     sai_attribute_t attr;

--- a/unittest/syncd/TestAttrVersionChecker.cpp
+++ b/unittest/syncd/TestAttrVersionChecker.cpp
@@ -93,6 +93,7 @@ TEST(AttrVersionChecker, reset)
         .iscustom                      = false,\
         .apiversion                    = (v),\
         .nextrelease                   = (n),\
+        .valueprecision                = 0,\
     };\
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Moves the `SAI` submodule from `c67f1152` (tag `v1.18.1`) to upstream `opencomputeproject/SAI` master `6dd7381`, and makes the repository build and pass its tests against the newer headers. Three commits: the pointer move plus the four generated-metadata initializers it requires (these must be atomic, since neither half builds alone), serialization support for the new `SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST` value type, and one build flag for the SWIG-generated Python wrapper that the larger headers make necessary on armhf. Reviewers can start at `syncd/SwitchNotifications.h`, and please read the version-string note under "Any platform specific information?" before approving.

Fixes # (N/A — no upstream issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [x] Test improvement

### Approach

#### What is the motivation for this PR?
The SAIVPP unit-test framework needs two `sai_test` changes that are already merged upstream — the opt-in `SIMULATE_SONIC` control-plane emulation ([opencomputeproject/SAI#2316](https://github.com/opencomputeproject/SAI/pull/2316)) and the simulated IPv6 control-traffic isolation ([opencomputeproject/SAI#2321](https://github.com/opencomputeproject/SAI/pull/2321)) — and neither is reachable at the currently pinned revision. Bumping the pointer also pulls in newer generated metadata, which requires three initializer updates in this repository; without them the build fails, so they belong in the same commit.

There is also a build-blocking reason beyond the test content. The VPP SAI CI PR adds a Trixie `saithriftv2` package build, and on the pinned `c67f1152` that build fails outright: `gensairpc.pl` throws in `assign_attr_types` while generating `sai.thrift`. The fix is upstream SAI `82a8d7e` ("Fix gensairpc.pl crash on Doxygen 1.9.8+", [opencomputeproject/SAI#2282](https://github.com/opencomputeproject/SAI/pull/2282)), reachable from master but not from the current pin. So this bump is a prerequisite for that PR's CI to pass at all, not only for its runtime matrix.

#### How did you do it?
- `SAI`: `c67f1152` (tag `v1.18.1`) → `6dd7381` (upstream master).
- `syncd/SwitchNotifications.h`: add the `on_next_hop_group_hw_protection_switchover` initializer. `sai_switch_notifications_t` is generated from the `SAI_SWITCH_ATTR_*_NOTIFY` attributes; the newer SAI adds `SAI_SWITCH_ATTR_NEXT_HOP_GROUP_HW_PROTECTION_SWITCHOVER_NOTIFY` (`inc/sainexthopgroup.h`, `inc/saiswitch.h`), taking the count from 21 to 22, so the slot-table aggregate initialization needs the new member. It is set to `nullptr` because syncd does not yet handle this notification.
- `unittest/meta/TestSaiSerialize.cpp`: initialize the `dei` and `vc` members added to `sai_qos_map_params_t` in `inc/saitypes.h`.
- `unittest/syncd/TestAttrVersionChecker.cpp`: initialize the `valueprecision` member added to `meta/saimetadatatypes.h`.
- `syncd/SwitchNotifications.h`, second slot: add `on_ocs_port_state_change`. The newer SAI also adds `SAI_SWITCH_ATTR_OCS_PORT_STATE_CHANGE_NOTIFY` in `experimental/saiswitchextensions.h` for the optical-circuit-switch API, and it lands last in the generated notification struct. Also `nullptr`, for the same reason.
- Second commit, `meta/SaiSerialize.cpp`, `meta/sai_serialize.h`, `meta/Meta.cpp`, and `unittest/meta/TestSaiSerialize.cpp`: implement `SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST`, added upstream by [opencomputeproject/SAI#2303](https://github.com/opencomputeproject/SAI/pull/2303). It mirrors the existing `PORT_LANE_LATCH_STATUS_LIST` and `PORT_SNR_LIST` handling: transfer, serialize, deserialize, the free path, the five validation sites in `Meta.cpp`, and round-trip unit tests. The list serializes as a JSON object keyed by lane, with each status rendered by enum name. The deserializer differs from its `PORT_LANE_LATCH_STATUS_LIST` sibling in one respect: it builds the entry array in a local pointer and publishes it to the caller only on success. Both a malformed lane key and an unrecognized status name throw (`sai_deserialize_enum` falls back to `sai_deserialize_number`), and freeing on that path keeps the malformed-input tests clean under ASAN.
- Third commit, `pyext/py3/Makefile.am`: add `-Wno-error=disabled-optimization` for the SWIG-generated `pysairedis` wrapper. The newer headers enlarge the generated `pysairedis_wrap.cpp` enough that GCC skips its const/copy-propagation and PRE passes on `max-gcse-memory`, which `-Werror` turns into a build failure on 32-bit armhf. The flag is scoped to the generated wrapper only.

This mirrors how previous bumps in this repository were structured: [#1742](https://github.com/sonic-net/sonic-sairedis/pull/1742) touched `SAI` plus `syncd/SwitchNotifications.h`, and [#1849](https://github.com/sonic-net/sonic-sairedis/pull/1849) paired `SAI` with `meta/*` and `unittest/meta/TestSaiSerialize.cpp`, including serialization support for the value types that bump introduced.

#### How did you verify/test it?
`git diff --check`, `tests/checkwhitespace.sh`, and `tests/swsslogentercheck.sh` pass locally; the compile and unit-test stages are verified by this PR's CI, which drove the last three additions. The first run failed to compile on the missing `on_ocs_port_state_change` initializer. The second run compiled and then failed `SaiSerialize.transfer_attributes` and `SaiSerialize.sai_serialize_attr_value`, both throwing "`SAI_ATTR_VALUE_TYPE_PORT_ILT_LANE_TRAINING_STATUS_LIST` is not implemented, FIXME" — those tests walk every value type, so the `default:` labels that kept the build green throw at run time. The third run passed `Build amd64`, `BuildAsan amd64`, `BuildArm arm64`, and `BuildSwss amd64`, and failed only `BuildArm armhf` on the generated wrapper.

Rather than keep chasing one error per run, I enumerated the whole breaking surface between the two pins directly: exactly one new `sai_attr_value_type_t` enumerator (the ILT list), exactly two new `*_NOTIFY` switch attributes (both initialized here), and no other exhaustive-switch site — the `syncd/FlexCounter.cpp` reference to the analogous latch-status type is feature-specific and has no ILT equivalent.

Note that no earlier pin avoids this work: the ILT value type arrives with SAI #2303 on 2026-07-25, which predates SAI #2321 on 2026-07-28, so every revision carrying the `sai_test` changes needed here also carries the new value type.

#### Any platform specific information?
None specific to a platform, but the blast radius is repository-wide: every consumer of the SAI headers and generated metadata recompiles against the new revision. The two `nullptr` notification slots are inert — they change no runtime behavior for any vendor. The new serialization support is additive: it replaces a throwing `default:` path for a value type that nothing in this repository could previously handle.

**Version-string note, please read before approving.** The current pin `c67f1152` is tag `v1.18.1`, which lives on the `v1.18` release branch and is **not** an ancestor of SAI master. Moving to master therefore looks like it drops commits, so I checked all 8 that `v1.18.1` has and master does not: 7 are patch-identical to commits already on master (CEILR interfaces `#2256`, strict-flag enum meta `#2264`, PRBS pattern `#2262`, DASH ENI/port counters `#2251`, `SAI_HASH_ALGORITHM_END` `#2255`, RIF QoS map `#2208`, MACSec attribute enhancements `#2213`). The only one absent from master is `c67f115` itself, "Update SAI version to v1.18.1". No functional content is lost.

The consequence is that `SAI_API_VERSION` reports **1.18.0 instead of 1.18.1** after this change, because master has not taken that version-string bump, even though the tree is 32 commits newer in content. I could not find a better target: the `v1.18` release-branch head is the commit we are already pinned to, there is no tag newer than `v1.18.1`, and the metadata this work needs (`dei` / `vc`, `valueprecision`, `SAI_SWITCH_ATTR_NEXT_HOP_GROUP_HW_PROTECTION_SWITCHOVER_NOTIFY`) exists only on master. If maintainers would rather wait for upstream to cut a tag containing these changes, I am happy to park this PR — that would block the VPP SAI CI matrix until then.

### Documentation
No documentation changes. Context for why this bump is needed by the SAIVPP unit-test work is in `sonic-buildimage/devdocs/merge-p3.md`.

### Dependencies and merge order
Self-contained and based on current upstream `master`. Both pointed-to SAI changes are already merged upstream, so this points at an upstream SHA rather than a fork commit. It unblocks the runtime matrix in the VPP SAI CI PR, but nothing else in the Phase 3 series has to merge before or after it.
