### PR TITLE
[vpp] Clear stale VPP ACL when a table's last rule is removed

### DIFF
--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -1246,8 +1246,15 @@ sai_status_t SwitchVpp::AclTblConfig(
         SWSS_LOG_INFO("Allocated tunterm ACL with %u rules", tunterm_acl->count);
     }
 
-    // Apply the ACL configurations
-    if (acl != NULL) {
+    // Apply the ACL configurations. acl is NULL when the table has no regular
+    // rules left - e.g. the mux drop entry is deleted when a port transitions
+    // standby -> active. In that case acl_add_replace() replaces the previously
+    // programmed VPP ACL with an empty placeholder (see its acl == NULL branch),
+    // so a stale rule such as deny 0/0->0/0 is not left bound to the mux ports
+    // and silently dropping for-us/punt traffic. Only route a NULL acl through
+    // acl_add_replace() when the table was already programmed in VPP, otherwise
+    // there is nothing to clear and vpp_acl_add_replace() must not see a NULL.
+    if (acl != NULL || m_acl_swindex_map.find(tbl_oid) != m_acl_swindex_map.end()) {
         status = acl_add_replace(acl, tbl_oid, aces, ordered_aces);
     }
 


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

On a dual-ToR VPP setup, the mux ingress drop ACL is bound to the mux member ports on the VPP l2-input arc. When a port transitions standby → active, orchagent deletes that drop entry, so the ACL table's last regular rule is removed.

In `AclTblConfig()` an empty rule set produces a `NULL` converted `vpp_acl_t`, and the apply step was guarded by if (acl != NULL). As a result the reprogram was skipped entirely and the previously programmed VPP ACL (deny 0.0.0.0/0 -> 0.0.0.0/0) was left bound to the interface. That stale deny then keeps silently dropping for-us / ip2me punts (mux/BFD/ICMP heartbeat) even though SONiC believes the rule is gone — so the now-active ToR's mux/heartbeat traffic is black-holed and the mux state flaps/goes unhealthy.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


##### Work item tracking
- Microsoft ADO **(number only)**: 39251238
- Tracking issue: sonic-net/sonic-buildimage#28996

#### How did you do it?

The fix widens the guard in AclTblConfig() that if the table is NULL but programmed before, still call `acl_add_replace` to reprogram the VPP dataplane.

#### How did you verify/test it?
* Reproduced on the VPP dual-ToR KVM testbed: flap a mux port standby → active, then confirm a stale deny 0/0 -> 0/0 ACL remains bound to the mux member interfaces (docker exec syncd vppctl show acl-plugin interface) and for-us/heartbeat punts are dropped, driving the mux unhealthy.
* After the fix: on the same transition the table's VPP swindex is reprogrammed to the placeholder ACL (permit dst 0.0.0.0/32), the stale deny is gone, punt traffic to the CPU is restored, and the mux returns/stays HEALTHY on both ToRs.


#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

