### PR TITLE
[vpp][dualtor] Preserve coexisting host route on mux transition

### DIFF
--- a/vslib/vpp/SwitchVppNbr.cpp
+++ b/vslib/vpp/SwitchVppNbr.cpp
@@ -207,7 +207,18 @@ sai_status_t SwitchVpp::addRemoveIpNbr(
 
         create_route_prefix_entry(&route_entry, ip_route);
         ip_route->vrf_id = vrf_id;
-        ip_route->is_multipath = false;
+        // The neighbor host route (<ip>/32 or /128 via the BVI) can share its VPP
+        // FIB prefix with a dual-ToR tunnel-encap route that MuxOrch installs for the
+        // same server IP. VPP's ip_route_add_del() deletes the ENTIRE prefix (all
+        // paths) when is_multipath=0 on remove, so removing the neighbor with
+        // is_multipath=false clobbers a coexisting tunnel route.
+        // MuxOrch always adds the new contributor before removing the old one, so:
+        //   add    -> is_multipath=false: authoritatively (re)install this single
+        //             attached path, replacing whatever occupied the prefix.
+        //   remove -> is_multipath=true : retract only the neighbor's own path; if a
+        //             tunnel route has already replaced it the remove is a harmless
+        //             no-op, so the tunnel route is preserved.
+        ip_route->is_multipath = !is_add;
         ip_route->nexthop_cnt = 1;
 
         nexthop_grp_member_t member;

--- a/vslib/vpp/SwitchVppRoute.cpp
+++ b/vslib/vpp/SwitchVppRoute.cpp
@@ -233,7 +233,14 @@ sai_status_t SwitchVpp::IpRouteAddRemove(
         }
         create_route_prefix_entry(&route_entry, ip_route);
         ip_route->vrf_id = vrf_id;
-        ip_route->is_multipath = (nxthop_group->nmembers > 1) ? true : false;
+        // Single-NH routes: replace on add (authoritative) but retract only this
+        // path on remove. A host route (/32, /128) can share its FIB prefix with a
+        // coexisting neighbor host route in dual-ToR; deleting the whole prefix on
+        // remove (is_multipath=0) would clobber that coexisting route. Removing only
+        // this path leaves any other contributor intact, and is equivalent to a
+        // whole-prefix delete when this is the only path. ECMP (nmembers>1) is
+        // already path-based on both add and remove.
+        ip_route->is_multipath = (nxthop_group->nmembers > 1) || !is_add;
 
         nexthop_grp_member_t *nxt_grp_member;
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
On active-standby dualtor VPP testbeds, no tunnel routes are present for neighbors on the standby mux ports. Downstream traffic to those servers is blackholed — the missing `<ip>/32` (and `<ip>/128`) tunnel-encap route falls through to the covering 192.168.0.0/21 glean instead of being encapsulated toward the peer ToR.

Root cause: a server's `<ip>/32` VPP FIB prefix can have two independent libsaivs contributors that share the same prefix — the neighbor host route via the VLAN BVI (`SwitchVpp::addRemoveIpNbr`) and the mux tunnel-encap ROUTE_ENTRY (`SwitchVpp::IpRouteAddRemove`). Both programmed the route with `is_multipath=false`, which tells VPP to replace the whole prefix on add and delete the whole prefix (all paths) on remove.

`MuxOrch` always adds the new contributor before removing the old one on both transitions, so the trailing whole-prefix delete **clobbered** the route the leading add had just installed:

* active → standby: `addRoutes()` creates the tunnel route, then `disableNeighbors()` removes the neighbor. The neighbor host-route removal (`is_multipath=false`) deleted the entire `/32` and wiped the just-created tunnel route → standby ToR left with no tunnel route (the observed symptom).
* standby → active: `enableNeighbors()` adds the neighbor, then `removeRoutes()` removes the tunnel route. That removal (`is_multipath=false`) would delete the entire `/32` and wipe the neighbor's BVI path — a symmetric latent second clobber, masked only because the first bug had already removed the tunnel route (making this remove a no-op).

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


##### Work item tracking
- Microsoft ADO **(number only)**: 39256894
- Tracking issue: sonic-net/sonic-buildimage#28997

#### How did you do it?
Made the add authoritative (replace) and the remove path-specific, so a transition's trailing remove targets a path that was already replaced away — a harmless no-op that preserves any coexisting route for the same prefix (last-add-wins).

#### How did you verify/test it?
```
dualtor_io/test_normal_op.py::test_normal_op_downstream_lower_tor[active-standby] PASSED                                                                                                                                                             [100%]

================================================================================================ 1 passed, 1 deselected, 129 warnings in 210.23s (0:03:30) =================================================================================================
```

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

