### PR TITLE
[nvidia]: Add warmboot SAI profile settings

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -435,9 +435,29 @@ config_syncd_mlnx()
     awk -F= '!seen[$1]++' /tmp/sai-temp.profile > /tmp/sai.profile
     rm -f /tmp/sai-temp.profile
 
-    # Update sai.profile with MAC_ADDRESS and WARM_BOOT settings
+    # Update sai.profile with MAC_ADDRESS settings
     echo "DEVICE_MAC_ADDRESS=$MAC_ADDRESS" >> /tmp/sai.profile
-    echo "SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/" >> /tmp/sai.profile
+
+    # Derive warm-boot paths from SAI XML <issu-enabled> (0/1/2)
+    # NVIDIA warmboot (2): isolate under /var/warmboot/sai_warmboot_nvda/
+    # NVIDIA fastfast (1) / disabled (0) / unset: keep legacy /var/warmboot/
+    SAI_INIT_CONFIG_FILE=$(awk -F= '/^SAI_INIT_CONFIG_FILE=/{print $2; exit}' /tmp/sai.profile)
+    ISSU_ENABLED=""
+    if [[ -f "${SAI_INIT_CONFIG_FILE}" ]]; then
+        ISSU_ENABLED=$(
+            sed -n 's:.*<issu-enabled>\([0-9]*\)</issu-enabled>.*:\1:p' "${SAI_INIT_CONFIG_FILE}" |
+            head -n1
+        )
+    fi
+
+    # Update sai.profile with WARM_BOOT settings
+    if [[ "${ISSU_ENABLED}" == "2" ]]; then
+        WARM_BOOT_FILE="/var/warmboot/sai_warmboot_nvda/"
+        echo "SAI_WARM_BOOT_WRITE_FILE=${WARM_BOOT_FILE}" >> /tmp/sai.profile
+        echo "SAI_WARM_BOOT_READ_FILE=${WARM_BOOT_FILE}" >> /tmp/sai.profile
+    else
+        echo "SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/" >> /tmp/sai.profile
+    fi
 
     if [[ "$DUAL_TOR" == "enable" ]] && [[ "$DSCP_REMAPPING" == "enable" ]]; then
        echo "SAI_DSCP_REMAPPING_ENABLED=1" >> /tmp/sai.profile


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add **NVIDIA warmboot** SAI profile settings in `config_syncd_mlnx()` so warmboot
uses an isolated SAI warm-boot directory derived from SAI XML `<issu-enabled>`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

NVIDIA warmboot uses community warm-reboot for in-place upgrade on capable
platforms. On Mellanox, syncd previously always wrote:

```
SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/
```

For warmboot (`<issu-enabled>2</issu-enabled>`), SAI serialization must use a
dedicated directory under `/var/warmboot/` so it stays isolated from fastfast /
legacy warm-boot artifacts.

#### Work item tracking

* N/A

#### How did you do it?

In `syncd/scripts/syncd_init_common.sh` (`config_syncd_mlnx()`):

1. Read SAI XML path from `/tmp/sai.profile` (`SAI_INIT_CONFIG_FILE`)
2. Parse `<issu-enabled>` from that XML (`0` / `1` / `2`)
3. Set warm-boot profile keys:

   * `<issu-enabled>2</issu-enabled>` (warmboot):
     ```
     SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/sai_warmboot_nvda/
     SAI_WARM_BOOT_READ_FILE=/var/warmboot/sai_warmboot_nvda/
     ```
   * `<issu-enabled>1</issu-enabled>` (fastfast), `0` (disabled), or unset:
     keep legacy
     ```
     SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/
     ```

#### How did you verify/test it?

1. **Warmboot** (`<issu-enabled>2</issu-enabled>`, e.g. ACS-SN5600)
   * Start syncd / warm-reboot
   * Confirm `/tmp/sai.profile` contains:
     * `SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/sai_warmboot_nvda/`
     * `SAI_WARM_BOOT_READ_FILE=/var/warmboot/sai_warmboot_nvda/`
   * Confirm warmboot files are created under that directory

2. **fastfast / disabled** (`<issu-enabled>1</issu-enabled>` or `0`)
   * Confirm `/tmp/sai.profile` keeps
     `SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/`
   * Confirm no `SAI_WARM_BOOT_READ_FILE` override to `sai_warmboot_nvda`

3. **End-to-end**
   * On ACS-SN5600: `sudo warm-reboot` with `SONIC_BOOT_TYPE=warm`
   * Confirm warmboot completes and SAI restore uses the isolated path

#### Any platform specific information?

Mellanox / NVIDIA only (`config_syncd_mlnx()`).

SAI XML `<issu-enabled>` selects the mode:
`<issu-enabled>0</issu-enabled>` = disabled,
`<issu-enabled>1</issu-enabled>` = fastfast,
`<issu-enabled>2</issu-enabled>` = warmboot.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

* N/A

#### A picture of a cute animal (not mandatory but encouraged)

```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```