### PR TITLE
[2039] FDB Notification becomes stale in notification enqueue buffer due to continuous mac movement between local and vtep syncd: fix lost condition-variable wakeup in NotificationProcessor 

### DIFF
--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -1138,13 +1138,24 @@ void NotificationProcessor::ntf_process_function()
 {
     SWSS_LOG_ENTER();
 
-    std::mutex ntf_mutex;
-
-    std::unique_lock<std::mutex> ulock(ntf_mutex);
-
     while (m_runThread)
     {
-        m_cv.wait(ulock);
+        {
+            std::unique_lock<std::mutex> ulock(m_mtx);
+
+            // Wait on a predicate so a signal() that races ahead of this wait
+            // (queue already made non-empty by enqueue) is not lost. With the
+            // previous predicate-less m_cv.wait(), the tail of a notification
+            // burst could sit stuck in the queue until the next enqueue happened
+            // to re-signal the thread. m_mtx is held ONLY around the wait, never
+            // during processNotification(), to stay clear of the syncd mutex
+            // taken while processing.
+
+            m_cv.wait(ulock, [this]()
+            {
+                return !m_runThread || m_notificationQueue->getQueueSize() > 0;
+            });
+        }
 
         // this is notifications processing thread context, which is different
         // from SAI notifications context, we can safe use syncd mutex here,
@@ -1173,7 +1184,11 @@ void NotificationProcessor::stopNotificationsProcessingThread()
 {
     SWSS_LOG_ENTER();
 
-    m_runThread = false;
+    {
+        std::lock_guard<std::mutex> lock(m_mtx);
+
+        m_runThread = false;
+    }
 
     m_cv.notify_all();
 
@@ -1188,6 +1203,11 @@ void NotificationProcessor::stopNotificationsProcessingThread()
 void NotificationProcessor::signal()
 {
     SWSS_LOG_ENTER();
+
+    // Hold m_mtx while notifying so the wakeup cannot slip in between the
+    // processing thread evaluating its wait predicate and blocking in wait().
+
+    std::lock_guard<std::mutex> lock(m_mtx);
 
     m_cv.notify_all();
 }

--- a/syncd/NotificationProcessor.h
+++ b/syncd/NotificationProcessor.h
@@ -11,6 +11,7 @@
 #include <thread>
 #include <memory>
 #include <condition_variable>
+#include <mutex>
 #include <functional>
 
 namespace syncd
@@ -205,6 +206,12 @@ namespace syncd
             // that some notification arrived
 
             std::condition_variable m_cv;
+
+            // mutex paired with m_cv; guards the wait predicate so that a
+            // producer signal() cannot race with the consumer going to sleep
+            // and cause a lost wakeup (tail notification stuck in the queue)
+
+            std::mutex m_mtx;
 
             // determine whether notification thread is running
 

--- a/unittest/syncd/TestNotificationProcessor.cpp
+++ b/unittest/syncd/TestNotificationProcessor.cpp
@@ -8,6 +8,13 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <mutex>
+#include <vector>
+#include <string>
+
 using namespace syncd;
 
 static std::string natData =
@@ -143,4 +150,157 @@ TEST(NotificationProcessor, NotificationProcessorTest)
     translator->insertRidAndVid(0x123456789abcdef, 0x123456789abcdef);
     notificationProcessor->syncProcessNotification(flowBulkGetSessionEventItem);
     translator->eraseRidAndVid(0x123456789abcdef, 0x123456789abcdef);
+}
+
+// ---------------------------------------------------------------------------
+// Lost-wakeup / wait-predicate tests for the NotificationProcessor threading.
+//
+// ntf_process_function() now waits on a predicate (queue non-empty || !running)
+// under the member mutex m_mtx, and signal()/stop take that same mutex around
+// notify_all(). The old predicate-less m_cv.wait() could miss a wakeup that
+// raced ahead of the wait, leaving the tail of a burst stuck in the queue.
+//
+// processNotification(NotificationItem) forwards a normal notification to
+// processNotification(item.notification) -> the constructor-supplied
+// synchronizer, so a counting synchronizer is the observation point: no SAI
+// deserialize / redis / translator is needed, and producer & client (only
+// stored on this path) can be nullptr.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+    // A notification whose op is NOT the flow-bulk event, so it routes through
+    // processNotification(item.notification) -> synchronizer. The key doubles
+    // as a payload marker.
+    swss::KeyOpFieldsValuesTuple makeNtf(const std::string& key)
+    {
+        std::vector<swss::FieldValueTuple> values;
+        return swss::KeyOpFieldsValuesTuple(key, "test-op", values);
+    }
+
+    bool waitUntil(const std::function<bool()>& pred, int timeoutMs = 5000)
+    {
+        auto deadline = std::chrono::steady_clock::now()
+                        + std::chrono::milliseconds(timeoutMs);
+        while (std::chrono::steady_clock::now() < deadline)
+        {
+            if (pred())
+            {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return pred();
+    }
+
+    struct Sink
+    {
+        std::atomic<int> processed{0};
+        std::mutex mtx;
+        std::vector<std::string> keys;
+
+        std::function<void(const swss::KeyOpFieldsValuesTuple&)> fn()
+        {
+            return [this](const swss::KeyOpFieldsValuesTuple& item)
+            {
+                {
+                    std::lock_guard<std::mutex> l(mtx);
+                    keys.push_back(kfvKey(item));
+                }
+                processed++;
+            };
+        }
+    };
+}
+
+// Core regression: an item enqueued BEFORE the thread starts and with NO
+// signal() must still be processed, because the first predicate check sees
+// queueSize > 0. With the old predicate-less wait() the thread blocks forever
+// here and the test times out.
+TEST(NotificationProcessor, LostWakeup_EnqueueBeforeStart_NoSignal)
+{
+    Sink sink;
+    auto np = std::make_shared<NotificationProcessor>(nullptr, nullptr, sink.fn());
+
+    np->getQueue()->enqueue(makeNtf("evt-0"));      // queue non-empty first
+    np->startNotificationsProcessingThread();       // ... then start, no signal()
+
+    EXPECT_TRUE(waitUntil([&]{ return sink.processed.load() == 1; }));
+
+    np->stopNotificationsProcessingThread();
+    EXPECT_EQ(sink.processed.load(), 1);
+    EXPECT_EQ(np->getQueue()->getQueueSize(), 0u);  // nothing left stuck
+}
+
+// Producer hammers enqueue()+signal() concurrently with the consumer's
+// wait/drain cycle. Every enqueued item must be processed exactly once.
+TEST(NotificationProcessor, LostWakeup_ConcurrentEnqueueSignal_NoneLost)
+{
+    const int N = 500;
+    Sink sink;
+    auto np = std::make_shared<NotificationProcessor>(nullptr, nullptr, sink.fn());
+
+    np->startNotificationsProcessingThread();
+
+    std::thread producer([&]()
+    {
+        for (int i = 0; i < N; ++i)
+        {
+            np->getQueue()->enqueue(makeNtf("evt-" + std::to_string(i)));
+            np->signal();                            // race against wait/drain
+        }
+    });
+    producer.join();
+
+    EXPECT_TRUE(waitUntil([&]{ return sink.processed.load() == N; }));
+
+    np->stopNotificationsProcessingThread();
+    EXPECT_EQ(sink.processed.load(), N);
+    EXPECT_EQ(np->getQueue()->getQueueSize(), 0u);
+
+    std::lock_guard<std::mutex> l(sink.mtx);
+    EXPECT_EQ((int)sink.keys.size(), N);             // no duplicates / no loss
+}
+
+// A whole burst enqueued, then a SINGLE signal(): the drain loop plus the
+// non-empty predicate must process every item from that one wakeup, even if
+// the signal races ahead of the wait.
+TEST(NotificationProcessor, BurstThenSingleSignal_AllDrained)
+{
+    const int M = 1000;
+    Sink sink;
+    auto np = std::make_shared<NotificationProcessor>(nullptr, nullptr, sink.fn());
+
+    np->startNotificationsProcessingThread();
+
+    for (int i = 0; i < M; ++i)
+    {
+        np->getQueue()->enqueue(makeNtf("burst-" + std::to_string(i)));
+    }
+    np->signal();                                    // one signal for the burst
+
+    EXPECT_TRUE(waitUntil([&]{ return sink.processed.load() == M; }));
+
+    np->stopNotificationsProcessingThread();
+    EXPECT_EQ(sink.processed.load(), M);
+    EXPECT_EQ(np->getQueue()->getQueueSize(), 0u);
+}
+
+// The !m_runThread branch of the predicate: a thread blocked on an empty queue
+// must wake and exit promptly on stop (stop must not hang).
+TEST(NotificationProcessor, ShutdownWakesWaitingThread)
+{
+    Sink sink;
+    auto np = std::make_shared<NotificationProcessor>(nullptr, nullptr, sink.fn());
+
+    np->startNotificationsProcessingThread();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50)); // let it block in wait()
+
+    auto t0 = std::chrono::steady_clock::now();
+    np->stopNotificationsProcessingThread();                    // joins the thread
+    auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::steady_clock::now() - t0).count();
+
+    EXPECT_LT(elapsedMs, 1000);                      // woke via predicate, no hang
+    EXPECT_EQ(sink.processed.load(), 0);
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
[2039] FDB Notification becomes stale in notification enqueue buffer due to continuous mac movement between local and vtep 


NotificationProcessor::ntf_process_function() waited on a std::condition_variable with a predicate-less m_cv.wait() using a function-local mutex, while signal() called notify_all() without holding that mutex. A condition variable does not remember a notify sent when no thread is waiting, so a notification enqueued in the window after the consumer drains the queue but before it re-parks in wait() is lost. The tail of a notification burst (e.g. an FDB event storm) then stays stranded in NotificationQueue and is not forwarded to orchagent. When traffic stops there is no next enqueue, so it is never processed; it only self-heals when a later FDB event re-signals the thread (which then drains both the stale and the new notifications).

Impact: dropped/stuck SAI notifications (FDB and others) between syncd and orchagent -> stale state; under storm conditions notification processing can stall.

Involved APIs: producer NotificationHandler::enqueueNotification() ->
NotificationQueue::enqueue() -> NotificationProcessor::signal() -> notify_all(); consumer NotificationProcessor::ntf_process_function() -> m_cv.wait() -> NotificationQueue::tryDequeue() -> processNotification().
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix
---
- Wait on a predicate (queue non-empty || !m_runThread) so an already-enqueued item (or shutdown) is handled without sleeping.
- Add a member mutex m_mtx paired with m_cv, held only around the wait (never during processNotification(), to avoid the syncd mutex lock-ordering hazard).
- Take m_mtx in signal() and in stopNotificationsProcessingThread() around notify_all(), so a wakeup cannot slip in between the consumer evaluating its predicate and blocking in wait().


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
  During internal testing, a MAC-move loop caused an FDB entry to flap continuously between the VTEP (remote) and the local port. Under that burst, syncd stopped propagating FDB notifications to orchagent, and both devices ended up stuck
  showing the MAC as local — the final "move" notification was never delivered, so APPL_DB/STATE_DB kept the stale (local) state.

  Root cause: NotificationProcessor used a predicate-less std::condition_variable::wait() with an unsynchronized signal(). A notification enqueued in the window between the consumer draining the queue and re-parking in wait() is lost (a
  CV doesn't remember a notify sent when no thread is waiting), so the tail of the burst is stranded in NotificationQueue and never forwarded. With traffic settled, there's no further enqueue to re-signal the thread, so it never recovers
  on its own.

##### Work item tracking
- Microsoft ADO **(number only)**:
2039

#### How did you do it?
This test was validated using celestica DS2000 device.

#### How did you verify/test it?
  Unit tests — added 4 gtests in unittest/syncd/TestNotificationProcessor.cpp targeting the wakeup path (a counting synchronizer is the observation point, so no SAI/redis needed):
  - LostWakeup_EnqueueBeforeStart_NoSignal — item enqueued before the thread parks, with no signal(), must still be processed (the core regression).
  - LostWakeup_ConcurrentEnqueueSignal_NoneLost — 500 concurrent enqueue()+signal(), none lost.
  - BurstThenSingleSignal_AllDrained — 1000 items + a single signal(), all drained.
  - ShutdownWakesWaitingThread — stop() wakes a parked thread (no hang).

  Built and run (./configure --with-sai=vs --enable-code-coverage && make):
  [==========] 4 tests from NotificationProcessor
  [  PASSED  ] 4 tests.

  Negative control — reverting to the old predicate-less m_cv.wait(ulock) makes LostWakeup_EnqueueBeforeStart_NoSignal hang and FAIL (5 s timeout), confirming the test actually catches the bug; restoring the fix makes it pass again.

  Coverage — changed functions are 100% line-covered (ntf_process_function + wait-predicate lambda, signal, start/stopNotificationsProcessingThread, processNotification).

  Integration image — built the full docker-sonic-vs image from master with the fix for DVS/FDB validation.


#### Any platform specific information?
None generic

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
