### PR TITLE
[ci] select libnexthopgroup package for target Debian version

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -23,6 +23,10 @@ parameters:
 - name: artifact_name
   type: string
 
+- name: debian_version
+  type: string
+  default: bookworm
+
 - name: asan
   type: boolean
   default: false
@@ -68,7 +72,7 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
-      patterns: '**/target/debs/*/libnexthopgroup_*.deb'
+      patterns: 'target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb'
     displayName: "Download sonic-buildimage libnexthopgroup package"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -117,7 +121,7 @@ jobs:
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
       cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
-      find $(Build.ArtifactStagingDirectory)/download -name 'libnexthopgroup_*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
+      cp -v $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb .azure-pipelines/docker-sonic-vs/debs
 
       pushd .azure-pipelines
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,6 +150,7 @@ stages:
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs
+      debian_version: ${{ parameters.debian_version }}
 
 - stage: BuildDockerAsan
   dependsOn:
@@ -163,6 +164,7 @@ stages:
       sairedis_artifact_name: sonic-sairedis-asan-${{ parameters.debian_version }}
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs-asan
+      debian_version: ${{ parameters.debian_version }}
       asan: true
 
 - stage: Test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes docker-sonic-vs build failure
```
1.000 The following packages have unmet dependencies:
1.057  libnexthopgroup : Depends: libstdc++6 (>= 13.1) but 12.2.0-14+deb12u1 is to be installed
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
The common-lib artifact contains libnexthopgroup packages for both Bookworm and Trixie. The existing wildcard downloaded packages from every Debian version:
`**/target/debs/*/libnexthopgroup_*.deb`
Both packages have the same filename. Copying them into one directory could therefore overwrite the Bookworm package with the Trixie package. The Trixie package requires a newer libstdc++6 than the Bookworm VS image provides.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
- Added a debian_version parameter to the docker-sonic-vs build template.
- Passed the pipeline's selected Debian version to the normal and ASan Dockerbuild jobs.
- Restricted the artifact download
#### How did you verify/test it?
PR checker passed

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
202605: The CI failure for 202605 can be addressed.
#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
