### PR TITLE
[vpp] Fix MAC event byte-order bug and disable unknown-unicast flooding

### DIFF
--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1287,8 +1287,12 @@ void SwitchVpp::processFdbEntriesForAging()
 
         auto bd_it = m_swif_to_bdid.find(ev.sw_if_index);
         if (bd_it == m_swif_to_bdid.end()) {
-            SWSS_LOG_DEBUG("FDB: unknown sw_if_index %u in MAC event, skipping",
-                           ev.sw_if_index);
+            SWSS_LOG_WARN("FDB: dropping MAC event for untracked sw_if_index %u "
+                          "(action %u, MAC %02x:%02x:%02x:%02x:%02x:%02x); "
+                          "VPP L2FIB will desync from ASIC_DB/STATE_DB",
+                          ev.sw_if_index, ev.action,
+                          ev.mac[0], ev.mac[1], ev.mac[2],
+                          ev.mac[3], ev.mac[4], ev.mac[5]);
             events.pop();
             continue;
         }

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -582,6 +582,20 @@ sai_status_t SwitchVpp::vpp_create_vlan_member(
         return SAI_STATUS_FAILURE;
     }
 
+    /* Disable unknown-unicast flooding on this bridge domain.
+     *
+     * VPP auto-creates the bridge domain (with all flooding enabled by
+     * default) when the first member is added above. Clearing UU_FLOOD makes
+     * VPP drop unknown-unicast frames (destination MAC not in the L2FIB)
+     * instead of flooding them to all BD members. Broadcast/multicast
+     * flooding (VPP_BD_FLAG_FLOOD) is left enabled so ARP/ND still work.
+     *
+     * Best-effort: on failure the member still comes up, only unknown-unicast
+     * flooding remains enabled.
+     */
+    if (set_bridge_domain_flags(bridge_id, VPP_BD_FLAG_UU_FLOOD, false) != 0) {
+        SWSS_LOG_WARN("Failed to disable UU flood on bridge domain %u", bridge_id);
+    }
 
     return SAI_STATUS_SUCCESS;
 }
@@ -1998,6 +2012,27 @@ sai_status_t SwitchVpp::vpp_fdbentry_del(
 
     uint32_t bd_id = attr.value.u16; /* bd_id is same as VLAN ID for .1Q bridge */
 
+    /*
+     * Remove any stale entry from the m_vpp_fdb_entries dedup snapshot.
+     * This snapshot is used to suppress duplicate LEARNED notifications in
+     * processFdbEntriesForAging(). If we delete the L2FIB entry here (or
+     * orchagent removes it) but leave the snapshot key behind, a subsequent
+     * VPP re-learn of the same MAC is treated as "already known" and no
+     * LEARNED notification is generated -- leaving ASIC_DB/STATE_DB out of
+     * sync with the VPP dataplane until an explicit fdb flush.
+     */
+    VppFdbKey snap_key;
+    memcpy(snap_key.mac, fdb_entry.mac_address, sizeof(snap_key.mac));
+    snap_key.bd_id = bd_id;
+
+    auto snap_it = m_vpp_fdb_entries.find(snap_key);
+    if (snap_it != m_vpp_fdb_entries.end())
+    {
+        m_vpp_fdb_entries.erase(snap_it);
+        SWSS_LOG_INFO("FDB: removed stale snapshot entry for MAC %s bd %u on delete",
+                sai_serialize_mac(fdb_entry.mac_address).c_str(), bd_id);
+    }
+
     std::string ifname;
 
     if (vpp_get_hwif_name(port_id, 0, ifname) == true)
@@ -2318,6 +2353,19 @@ void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)
     if (swif != (uint32_t)~0u)
     {
         m_swif_to_bdid[swif] = bd_id;
+        SWSS_LOG_NOTICE("FDB: tracking sw_if_index %u -> bd %u for %s",
+                        swif, bd_id, hwif_name);
+    }
+    else
+    {
+        // vpp_get_swif_idx_by_name() resolves against a locally cached
+        // interface table populated by sw_interface_dump. A miss here means
+        // every MAC learn/age event VPP reports for this interface will be
+        // dropped (its sw_if_index never enters m_swif_to_bdid), silently
+        // desyncing the VPP L2FIB from ASIC_DB/STATE_DB.
+        SWSS_LOG_ERROR("FDB: cannot resolve sw_if_index for %s (bd %u); "
+                       "MAC events for this interface will be dropped",
+                       hwif_name, bd_id);
     }
 }
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1395,7 +1395,20 @@ vl_api_l2_macs_event_t_handler (vl_api_l2_macs_event_t *mp)
             vl_api_mac_entry_t *e = &mp->mac[off + i];
             memcpy(g_mac_event_batch[i].mac, e->mac_addr, 6);
             g_mac_event_batch[i].sw_if_index = ntohl(e->sw_if_index);
-            g_mac_event_batch[i].action = (uint8_t)e->action;
+            /*
+             * mac_entry.action is a 4-byte vl_api_mac_event_action_t that VPP
+             * sends in network byte order, exactly like sw_if_index above:
+             *   l2fib_scan(): mp->mac[evt_idx].action = htonl(...action);
+             * Casting the raw field to uint8_t without ntohl() truncates to the
+             * least significant byte, which on little-endian hosts is 0 for every
+             * non-zero action:
+             *   ADD    (0) -> htonl(0) = 0x00000000 -> 0 -> ADD    (correct by luck)
+             *   DELETE (1) -> htonl(1) = 0x01000000 -> 0 -> ADD    (WRONG)
+             *   MOVE   (2) -> htonl(2) = 0x02000000 -> 0 -> ADD    (WRONG)
+             * i.e. aged-out and flushed MACs were reported to SONiC as LEARNED,
+             * repopulating ASIC_DB/STATE_DB with entries VPP had just deleted.
+             */
+            g_mac_event_batch[i].action = (uint8_t)ntohl((uint32_t)e->action);
         }
         g_mac_event_cb(g_mac_event_batch, chunk, g_mac_event_ctx);
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix MAC event byte-order bug and disable unknown-unicast flooding

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
Three related FDB defects in the VPP virtual platform:

1. **VPP L2FIB and ASIC_DB/STATE_DB silently desynced.** `vl_api_l2_macs_event_t_handler()`
   decoded the MAC event `action` field incorrectly, so *every* event was
   interpreted as ADD. Aged-out and flushed MACs were reported to SONiC as
   LEARNED, so `fdbshow` re-populated with entries VPP had just deleted. This
   was directly observable: after `sonic-clear fdb all`, `vppctl show l2fib all`
   returned 0 entries while `show mac` reported the 25 entries that had just
   been removed.

2. **Stale dedup snapshot on FDB delete.** `vpp_fdbentry_del()` removed the entry
   from the VPP dataplane and ASIC_DB but left the key in the
   `m_vpp_fdb_entries` snapshot. Because that snapshot suppresses duplicate
   LEARNED notifications, a later re-learn of the same MAC was treated as
   "already known" and never notified, leaving ASIC_DB/STATE_DB out of sync
   until an explicit flush.

3. **Unknown-unicast frames were flooded.** VPP auto-creates the bridge domain
   with all flooding enabled, so frames with an unknown destination MAC were
   flooded to every BD member instead of being dropped.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
**`vppxlate/SaiVppXlate.c`** — `mac_entry.action` is a 4-byte
`vl_api_mac_event_action_t` that VPP sends in network byte order
(`l2fib_scan(): mp->mac[i].action = htonl(action);`), exactly like
`sw_if_index`. The handler applied `ntohl()` to `sw_if_index` but cast `action`
straight to `uint8_t`, truncating to the least-significant byte — which on
little-endian hosts is 0 for every non-zero action:

| action | on the wire | truncated | decoded as |
|---|---|---|---|
| ADD (0) | `0x00000000` | 0 | ADD (correct by luck) |
| DELETE (1) | `0x01000000` | 0 | ADD (wrong) |
| MOVE (2) | `0x02000000` | 0 | ADD (wrong) |

Fixed by applying `ntohl()` before the narrowing cast. This matters because VPP
reports each learn exactly once — the scan harvests the `LRN_EVT` bit and clears
it — so any misdecoded or dropped event is a permanent, self-perpetuating desync.

**`SwitchVppFdb.cpp`**
- `vpp_fdbentry_del()`: erase the matching `VppFdbKey` from `m_vpp_fdb_entries`
  so a subsequent re-learn generates a LEARNED notification.
- `vpp_create_vlan_member()`: call
  `set_bridge_domain_flags(bridge_id, VPP_BD_FLAG_UU_FLOOD, false)` after the
  member joins the bridge domain. Broadcast/multicast flooding
  (`VPP_BD_FLAG_FLOOD`) is deliberately left enabled so ARP/ND still work.
  Best-effort: on failure the member still comes up.
- `swif_bdid_track()`: added an `else` branch. `vpp_get_swif_idx_by_name()`
  resolves against a locally cached interface table, and a miss previously
  skipped tracking *silently*. Any such miss means every MAC event for that
  interface is discarded, so this now logs at ERROR.

**`SwitchVpp.cpp`** — `processFdbEntriesForAging()`: the dropped-event log for an
untracked `sw_if_index` was `SWSS_LOG_DEBUG` (invisible at default log levels)
and omitted the MAC. Raised to `SWSS_LOG_WARN` and included the action and MAC,
since this path indicates a real desync.
#### How did you verify/test it?
Run arp/test_unknown_mac.py and and the test passed.
`
------------------------------------------- generated xml file: /data/tests/temp_logs/arp/test_unknown_mac.xml -------------------------------------------
====================================================== 3 passed, 148 warnings in 250.80s (0:04:10) =======================================================
`
#### Any platform specific information?
vpp
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
