### PR TITLE
[syncd]: Reduce FDB flush log level from NOTICE to INFO

### DIFF
--- a/lib/Recorder.cpp
+++ b/lib/Recorder.cpp
@@ -295,7 +295,7 @@ void Recorder::recordFlushFdbEntries(
     // NOTE ! we actually give switch ID since FLUSH is not real object
     std::string key = serializedObjectType + ":" + sai_serialize_object_id(switchId);
 
-    SWSS_LOG_NOTICE("flush key: %s, fields: %lu", key.c_str(), entry.size());
+    SWSS_LOG_INFO("flush key: %s, fields: %lu", key.c_str(), entry.size());
 
     recordFlushFdbEntries(key, entry);
 }

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1808,7 +1808,7 @@ sai_status_t Syncd::processFdbFlush(
 
     if (status == SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_NOTICE("fdb flush succeeded, updating redis database");
+        SWSS_LOG_INFO("fdb flush succeeded, updating redis database");
 
         // update database right after fdb flush success (not in notification)
         // build artificial notification here to reuse code


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Reduced FDB flush log messages from SWSS_LOG_NOTICE to SWSS_LOG_INFO level in two places:
1, lib/Recorder.cpp (recordFlushFdbEntries): logs every FDB flush key and field count
2, syncd/Syncd.cpp (processFdbFlush): logs "fdb flush succeeded" on every successful flush

FDB flush is a routine event triggered on port state changes, VLAN updates, and MAC mobility. On active networks these events occur frequently, causing continuous NOTICE-level log noise that obscures genuinely actionable events. NOTICE level should be reserved for significant state changes. INFO is the appropriate level for routine operational confirmations.

Background: Similar log level reduction was already applied for port snoop notifications in commit da6ca16e ("Reduce port snoop notification log level from NOTICE to INFO"). This PR applies the same principle to FDB flush.

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

FDB flush operations are triggered frequently during normal network operation (port flaps, VLAN changes, MAC mobility events). The NOTICE log level for these routine confirmations creates log noise that:
1, Floods syslog on busy networks
2, Obscures higher-priority events that genuinely require attention
3, Makes log-based monitoring and alerting harder to tune

#### How did you do it?t

Two 1-line changes — SWSS_LOG_NOTICE -> SWSS_LOG_INFO:
lib/Recorder.cpp:298 — recordFlushFdbEntries: flush key message
syncd/Syncd.cpp:1811 — fdb flush succeeded, updating redis database message
No functional change. Log level only.

#### How did you verify/test it?

Tested on sonic-vs (community virtual switch, SONiC master branch, commit 1658c9049):

Before fix — both messages appear at NOTICE on sonic-clear fdb all:
NOTICE swss#orchagent: :- recordFlushFdbEntries: flush key: SAI_OBJECT_TYPE_FDB_FLUSH:oid:0x21000000000000, fields: 1
NOTICE syncd#syncd: :- processFdbFlush: fdb flush succeeded, updating redis database

After fix — both messages no longer appear at NOTICE level (downgraded to INFO, not shown in default log output):
(neither message appears in show logging output)

UT Logs: 
[FDB-Flush-UT.txt](https://github.com/user-attachments/files/31211127/FDB-Flush-UT.txt)

#### Any platform specific information?

None. Change is platform-agnostic — applies to all SONiC platforms using sairedis.

### Documentation

No documentation update required. Log level reduction, no behavior change.