### PR TITLE
fix(vpp): reconcile tap MAC on active IP path

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -443,7 +443,7 @@ namespace saivs
                     _In_ sai_object_id_t lag_member_oid);
 	    sai_status_t vpp_remove_lag_member(
                     _In_ sai_object_id_t lag_member_oid);
-	    void restorePortTapMac(
+	    sai_status_t restorePortTapMac(
                     _In_ sai_object_id_t port_oid);
 	    sai_status_t vpp_ensure_lag_lcp(
                     _In_ sai_object_id_t lag_oid);

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1662,7 +1662,11 @@ sai_status_t SwitchVpp::removeLagMember(
     // VPP keeps the switch MAC, so the routed port would drop L3 traffic sent to the tap MAC.
     if (port_oid != SAI_NULL_OBJECT_ID)
     {
-        restorePortTapMac(port_oid);
+        if (restorePortTapMac(port_oid) != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("failed to restore the tap MAC for port %s; continuing LAG member removal",
+                    sai_serialize_object_id(port_oid).c_str());
+        }
     }
     else
     {
@@ -1677,20 +1681,18 @@ sai_status_t SwitchVpp::removeLagMember(
     return SAI_STATUS_SUCCESS;
 }
 
-void SwitchVpp::restorePortTapMac(
+sai_status_t SwitchVpp::restorePortTapMac(
         _In_ sai_object_id_t port_oid)
 {
     SWSS_LOG_ENTER();
 
-    // Best effort repair, the caller must still drop the SAI LAG member because the VPP
-    // detach already happened and failing here would leave the object model inconsistent.
     std::string if_name;
 
     if (getTapNameFromPortId(port_oid, if_name) == false)
     {
         SWSS_LOG_ERROR("no tap found for port %s, switch MAC not restored",
                 sai_serialize_object_id(port_oid).c_str());
-        return;
+        return SAI_STATUS_FAILURE;
     }
 
     sai_attribute_t attr;
@@ -1706,7 +1708,7 @@ void SwitchVpp::restorePortTapMac(
                 sai_serialize_object_id(m_switch_id).c_str(),
                 sai_serialize_status(status).c_str(),
                 if_name.c_str());
-        return;
+        return status;
     }
 
     if (vs_set_dev_mac_address(if_name.c_str(), attr.value.mac) < 0)
@@ -1715,12 +1717,14 @@ void SwitchVpp::restorePortTapMac(
                 "traffic addressed to its tap MAC",
                 sai_serialize_mac(attr.value.mac).c_str(),
                 if_name.c_str());
-        return;
+        return SAI_STATUS_FAILURE;
     }
 
-    SWSS_LOG_NOTICE("restored switch MAC %s on tap %s after LAG member removal",
+    SWSS_LOG_NOTICE("restored switch MAC %s on tap %s",
             sai_serialize_mac(attr.value.mac).c_str(),
             if_name.c_str());
+
+    return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t SwitchVpp::vpp_remove_lag_member(

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1086,6 +1086,14 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr (
         hw_ifname = hwifname;
     }
 
+    if (is_add &&
+        rif_type == SAI_ROUTER_INTERFACE_TYPE_PORT &&
+        ot == SAI_OBJECT_TYPE_PORT)
+    {
+        // Reassert the tap MAC immediately before the port starts carrying L3 traffic.
+        CHECK_STATUS(restorePortTapMac(obj_id));
+    }
+
     int ret = interface_ip_address_add_del(hw_ifname, &vpp_ip_prefix, is_add);
 
     if (ret == 0)

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -1086,14 +1086,6 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr (
         hw_ifname = hwifname;
     }
 
-    if (is_add &&
-        rif_type == SAI_ROUTER_INTERFACE_TYPE_PORT &&
-        ot == SAI_OBJECT_TYPE_PORT)
-    {
-        // Reassert the tap MAC immediately before the port starts carrying L3 traffic.
-        CHECK_STATUS(restorePortTapMac(obj_id));
-    }
-
     int ret = interface_ip_address_add_del(hw_ifname, &vpp_ip_prefix, is_add);
 
     if (ret == 0)
@@ -1195,6 +1187,7 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
 
     std::string full_if_name;
     std::string ip_prefix_str;
+    std::string intf_data;
 
     if (is_add)
     {
@@ -1205,8 +1198,6 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
             return SAI_STATUS_FAILURE;
         }
     } else {
-        std::string intf_data;
-
         if (vpp_intf_get_prefix_entry(ip_prefix_key, intf_data) == false)
         {
             SWSS_LOG_DEBUG("No interface ip address found for %s", ip_prefix_key.c_str());
@@ -1249,14 +1240,11 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
 
         copy(saiIpPrefix, intf_ip_prefix);
 
-        std::string intf_data;
         std::string sai_prefix;
 
         sai_prefix = sai_serialize_ip_prefix(saiIpPrefix);
 
         vpp_serialize_intf_data(full_if_name, sai_prefix, intf_data);
-
-        m_intf_prefix_map[ip_prefix_key] = intf_data;
     } else {
         sai_ip_prefix_t saiIpPrefix;
 
@@ -1265,8 +1253,6 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
         sai_deserialize_ip_prefix(ip_prefix_str, saiIpPrefix);
 
         intf_ip_prefix = getIpPrefixFromSaiPrefix(saiIpPrefix);
-
-        vpp_intf_remove_prefix_entry(ip_prefix_key);
     }
 
     vpp_ip_route_t vpp_ip_prefix;
@@ -1334,12 +1320,35 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
     }
     SWSS_LOG_NOTICE("Setting ip on hw_ifname %s", hw_ifname);
 
+    if (is_add)
+    {
+        sai_object_id_t port_oid = getPortIdFromIfName(full_if_name);
+
+        if (port_oid != SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_NOTICE("reconciling tap MAC for %s before IP programming",
+                    full_if_name.c_str());
+            CHECK_STATUS(restorePortTapMac(port_oid));
+        }
+        else
+        {
+            SWSS_LOG_DEBUG("tap MAC reconciliation is not applicable to %s",
+                    full_if_name.c_str());
+        }
+    }
+
     int ret = interface_ip_address_add_del(hw_ifname, &vpp_ip_prefix, is_add);
 
     if (ret == 0)
     {
-        if (is_add) {
+        if (is_add)
+        {
+            m_intf_prefix_map[ip_prefix_key] = intf_data;
             m_tunnel_mgr_ipip.retry_pending_unnumbered(vpp_ip_prefix.prefix_addr);
+        }
+        else
+        {
+            vpp_intf_remove_prefix_entry(ip_prefix_key);
         }
         return SAI_STATUS_SUCCESS;
     }

--- a/vslib/vpp/SwitchVppRoute.cpp
+++ b/vslib/vpp/SwitchVppRoute.cpp
@@ -229,7 +229,7 @@ sai_status_t SwitchVpp::IpRouteAddRemove(
         status = route_obj->get_attr(attr);
 
         if (status == SAI_STATUS_SUCCESS && SAI_PACKET_ACTION_FORWARD == attr.value.s32) {
-            vpp_add_del_intf_ip_addr_norif(serializedObjectId, route_entry, is_add);
+            return vpp_add_del_intf_ip_addr_norif(serializedObjectId, route_entry, is_add);
         }
     }
     else if (SAI_OBJECT_TYPE_NEXT_HOP == RealObjectIdManager::objectTypeQuery(next_hop_oid))


### PR DESCRIPTION
### Description of PR

Summary:
Reconcile the Linux LCP tap MAC with the switch source MAC on the active physical-port IP programming path.

Related: sonic-net/sonic-mgmt#27062

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

When the Linux team driver removes a port from a PortChannel, it publishes the port-removed event before restoring the port's saved MAC. That event can reach `teamsyncd`, orchagent, and the #2020 repair before the kernel performs its final MAC restore. If that happens, the kernel write wins the race and leaves the Linux tap using the per-port MAC while VPP still uses the switch MAC.

This change adds a final reconciliation immediately before the physical port IP is programmed, so the port cannot start carrying L3 traffic with a mismatched tap MAC.

##### Work item tracking
- Microsoft ADO **(number only)**: Not applicable

#### How did you do it?

- Changed `restorePortTapMac()` to return a SAI status.
- Kept LAG-member removal best effort because the VPP detach has already occurred.
- Moved the final reconciliation to the active `vpp_add_del_intf_ip_addr_norif()` path.
- Propagated its status through `IpRouteAddRemove()`.
- Updated the prefix map only after VPP IP programming succeeds.

#### How did you verify/test it?

- Built and loaded `libsaivs` against the same VPP ABI as the reproducing image.
- Kept the port routed with no LAG transition, forced its tap to a different MAC, then added the interface IP.
- Confirmed the active-path log fired, the tap returned to the switch MAC, and VPP received the interface IP.
- Ran `git diff --check`.
- Ran `tests/swsslogentercheck.sh`.

#### Any platform specific information?

This change is limited to the VPP implementation and physical port router interfaces.

### Documentation

Not applicable. This is a VPP behavior fix with no user-facing interface change.
