### PR TITLE
Drop tagged frames for untagged bridge members.

### DIFF
--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -107,6 +107,7 @@ using namespace saivs;
 static bool     s_l2_punt_classify_inited = false;
 static uint32_t s_punt_next_index = ~0;       /* linux-cp-punt (untagged + LLDP) */
 static uint32_t s_trap_fixup_next_index = ~0; /* sonic-ext-l2-trap-fixup (tagged DHCP only) */
+static uint32_t s_drop_next_index = ~0;       /* error-drop (access-port ingress VLAN filter) */
 
 /* Untagged member tables: ip4 slot holds DHCPv4 broadcast,
  * other slot holds LLDP.  No chain between them (different ethertype
@@ -175,6 +176,20 @@ static int l2_punt_classify_init()
         SWSS_LOG_NOTICE("l2_punt_classify_init: trap_fixup_next_index=%u",
                         s_trap_fixup_next_index);
     }
+
+    /* error-drop next: drops tagged frames arriving on an untagged
+     * (access) bridge member. An access port only carries untagged
+     * frames on the wire, so any 802.1Q-tagged frame has a VID that is
+     * not configured on the port and must be dropped (ingress VLAN
+     * filtering) rather than L2-flooded. Not fatal if unavailable: the
+     * invalid-VID drop session is simply not installed. */
+    if (vpp_add_node_next("l2-input-classify", "error-drop",
+                                &s_drop_next_index) != 0) {
+        SWSS_LOG_WARN("l2_punt_classify_init: error-drop not registered; "
+                      "tagged frames on access members will not be dropped");
+        s_drop_next_index = ~0;
+    }
+
     SWSS_LOG_NOTICE("l2_punt_classify_init: punt_next_index=%u", s_punt_next_index);
 
     /* --- Untagged IP4-slot table (DHCPv4 broadcast) ---
@@ -231,7 +246,7 @@ static int l2_punt_classify_init()
         mask[12] = 0xFF; mask[13] = 0xFF;
 
         if (vpp_classify_table_create(
-                8 /*nbuckets*/, 4*1024 /*memory_size: 1 session*/,
+                8 /*nbuckets*/, 4*1024 /*memory_size: 2 sessions*/,
                 0 /*skip*/, 1 /*match_n_vectors*/,
                 ~0 /*next_table=none*/,
                 ~0 /*miss_next=continue*/,
@@ -244,6 +259,16 @@ static int l2_punt_classify_init()
         uint8_t m[16] = {0}; m[12] = 0x88; m[13] = 0xCC;
         vpp_classify_session_add(s_untag_other_table, s_punt_next_index,
                                  m, 16, 0, 0, SAIVS_CLASSIFY_ACTION_NONE);
+
+        /* 802.1Q 0x8100 → error-drop (ingress VLAN filter). Runs at
+         * l2-input-classify, BEFORE l2-fwd/l2-flood, so a tagged frame
+         * with an unconfigured VID on an access member is dropped
+         * instead of flooded within the bridge domain. */
+        if (s_drop_next_index != ~0u) {
+            uint8_t md[16] = {0}; md[12] = 0x81; md[13] = 0x00;
+            vpp_classify_session_add(s_untag_other_table, s_drop_next_index,
+                                     md, 16, 0, 0, SAIVS_CLASSIFY_ACTION_NONE);
+        }
     }
 
     /* --- Tagged DHCP table.  Frame at l2-input-classify on a tagged
@@ -292,10 +317,10 @@ static int l2_punt_classify_init()
     s_l2_punt_classify_inited = true;
     SWSS_LOG_NOTICE("L2 punt classify tables initialized: "
                     "untag_ip4=%u untag_other=%u tag_dhcp=%u "
-                    "punt_next=%u trap_fixup_next=%u",
+                    "punt_next=%u trap_fixup_next=%u drop_next=%u",
                     s_untag_ip4_table, s_untag_other_table,
                     s_tag_dhcp_table,
-                    s_punt_next_index, s_trap_fixup_next_index);
+                    s_punt_next_index, s_trap_fixup_next_index, s_drop_next_index);
     return 0;
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
On the SONiC‑VPP platform, an access (untagged) VLAN member is realized in VPP as the raw physical interface added directly to the VLAN's bridge domain. VPP flags such a physical L2 bridge port to match every 802.1Q tag‑count and treats the tag as opaque payload, so it performs no ingress VLAN filtering: a frame tagged with a VID that is not configured on the port is L2‑flooded within the bridge domain instead of being dropped. This PR adds ingress VLAN filtering for access members by dropping tagged frames at l2-input-classify (before l2-fwd/l2-flood).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
test_vlan_tc3_send_invalid_vid sends a broadcast tagged with a reserved/unconfigured VID (4095) into a VLAN member and expects that no other port receives it (standard 802.1Q ingress VLAN filtering). On SONiC‑VPP the frame was instead flooded out the other access members, because access members are modeled as raw physical L2 bridge ports, which VPP matches for all tag‑counts (MATCH_0..3_TAG) and forwards tag‑agnostically. Trunk members are unaffected: they are exact‑match VLAN sub‑interfaces, so a frame with an unconfigured VID has no matching sub‑interface and is already dropped by ethernet-input.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
In vslib/vpp/SwitchVppFdb.cpp, l2_punt_classify_init():

- Registered error-drop as a graph next of l2-input-classify (s_drop_next_index).
- Added a classify session matching outer ethertype 0x8100 (any single‑tagged frame) → error-drop to the untagged/access member's "other‑slot" classify table, and bumped that table's session capacity to hold it.

Because l2-input-classify runs before l2-fwd/l2-flood, a tagged frame arriving on an access member is dropped before it can be flooded. Only untagged/access members use this table (trunk members use a separate tagged table), so trunk behavior is unchanged. If the error-drop node can't be registered the session is simply skipped (non‑fatal).

#### How did you verify/test it?
Built a SONiC‑VPP image containing this change and ran the sonic‑mgmt vlan/ suite on a vms-kvm-vpp-t0 testbed:

- vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid now passes — the invalid‑VID tagged broadcast is dropped instead of being flooded to peer access ports.
- No regression to the cases that already ran: untagged L2 forwarding unchanged; control‑plane punt on access members (LLDP/ARP/DHCP) still works; trunk members unchanged.
```
- generated xml file: /data/sonic-mgmt/tests/logs/logs_full_tests_vlan/_single_vlan/vlan.xml -
20/08/2026 15:04:00 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
=========================== short test summary info ============================
SKIPPED [1] vlan/test_secondary_subnet.py:142: No secondary subnet found on DUT, skipping test
SKIPPED [1] vlan/test_vlan.py:199: Test skipped: No portchannels detected when sending untagged packets
SKIPPED [1] vlan/test_vlan.py:259: Test skipped: No portchannels detected when sending tagged packets
SKIPPED [1] vlan/test_vlan.py:450: Test skipped: No portchannels detected when sending untagged packets
SKIPPED [1] vlan/test_vlan.py:509: Unsupported platform.
=========== 14 passed, 5 skipped, 800 warnings in 1480.53s (0:24:40) ===========
```

#### Any platform specific information?
SONiC‑VPP (asic_type: vpp) only — the change is confined to the VPP vslib L2 punt/classify path and does not touch hardware‑ASIC platforms.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
