### PR TITLE
[ci] switch from Azure hosted agent pool to sonicso1ES-amd64 to fix no space left issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,6 +102,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
+      pool: sonicso1ES-amd64
       artifact_name: sonic-sairedis-trixie
       syslog_artifact_name: sonic-sairedis-trixie.syslog
       run_unit_test: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes `no space left on device` issue
```
{standard input}: Assembler messages:
{standard input}: Fatal error: can't write 3900 bytes to section .debug_info of tests-TestClientServerSai.o: 'No space left on device'
{standard input}: Fatal error: tests-TestClientServerSai.o: No such file or directory
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
The `BuildTrixie amd64` pipeline can run out of disk space. Change the build jobs to run on the sonicso1ES-amd64 1ES hosted pool instead of the Microsoft-hosted ubuntu-22.04 image. The sonicso1ES-amd64 pool provides much more headroom: 1 TB Premium data disk + ~150 GB resource volume. `arm64` and `armhf` are already using the 1ES agents. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
Configure the amd64 Trixie build to use the sonicso1ES-amd64 agent pool
#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
