### PR TITLE
[syncd]: Use bulk redis operations in warm boot APPLY_VIEW

### DIFF
--- a/syncd/RedisClient.cpp
+++ b/syncd/RedisClient.cpp
@@ -669,14 +669,36 @@ void RedisClient::setVidAndRidMap(
     m_dbAsic->del(VIDTORID);
     m_dbAsic->del(RIDTOVID);
 
+    if (map.empty())
+    {
+        return;
+    }
+
+    // Use a pipeline to avoid a round trip per map entry, same as done in
+    // insertVidsAndRids(). Default pipeline size is used on purpose here, so
+    // that replies are flushed periodically and memory stays bounded.
+
+    swss::RedisPipeline pipe(m_dbAsic.get());
+
     for (auto &kv: map)
     {
         std::string strVid = sai_serialize_object_id(kv.first);
         std::string strRid = sai_serialize_object_id(kv.second);
 
-        m_dbAsic->hset(VIDTORID, strVid, strRid);
-        m_dbAsic->hset(RIDTOVID, strRid, strVid);
+        {
+            swss::RedisCommand hset;
+            hset.format("HSET %s %s %s", VIDTORID, strVid.c_str(), strRid.c_str());
+            pipe.push(hset, REDIS_REPLY_INTEGER);
+        }
+
+        {
+            swss::RedisCommand hset;
+            hset.format("HSET %s %s %s", RIDTOVID, strRid.c_str(), strVid.c_str());
+            pipe.push(hset, REDIS_REPLY_INTEGER);
+        }
     }
+
+    pipe.flush();
 }
 
 std::vector<std::string> RedisClient::getAsicStateKeys() const
@@ -889,10 +911,17 @@ void RedisClient::removeAsicStateTable()
 
     const auto &asicStateKeys = m_dbAsic->keys(ASIC_STATE_TABLE ":*");
 
-    for (const auto &key: asicStateKeys)
+    if (asicStateKeys.empty())
     {
-        m_dbAsic->del(key);
+        return;
     }
+
+    // Keys returned by keys() already contain the table prefix. Removing them
+    // with a single del() call issues chunked pipelined DEL commands, instead
+    // of one round trip per key, which at route scale dominates the time spent
+    // in warm boot APPLY_VIEW.
+
+    m_dbAsic->del(asicStateKeys);
 }
 
 void RedisClient::removeTempAsicStateTable()
@@ -901,10 +930,14 @@ void RedisClient::removeTempAsicStateTable()
 
     const auto &tempAsicStateKeys = m_dbAsic->keys(TEMP_PREFIX ASIC_STATE_TABLE ":*");
 
-    for (const auto &key: tempAsicStateKeys)
+    if (tempAsicStateKeys.empty())
     {
-        m_dbAsic->del(key);
+        return;
     }
+
+    // Same as in removeAsicStateTable(), remove all keys in bulk.
+
+    m_dbAsic->del(tempAsicStateKeys);
 }
 
 std::map<sai_object_id_t, swss::TableDump> RedisClient::getAsicView()

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -47,6 +47,12 @@
 #define SAI_FAILURE_DUMP_SCRIPT "/usr/bin/sai_failure_dump.sh"
 #define SYNCD_ZMQ_RESPONSE_BUFFER_SIZE (128*1024*1024)
 
+// Number of ASIC objects written to redis database in a single bulk
+// call when saving temporary view as current view. Bulk write builds an
+// intermediate hash of the objects, so writing all of them at once at
+// route scale would cause a significant memory spike during warm boot.
+#define ASIC_STATE_BULK_WRITE_CHUNK_SIZE (10000u)
+
 using namespace syncd;
 using namespace saimeta;
 using namespace sairediscommon;
@@ -5936,6 +5942,13 @@ void Syncd::updateRedisDatabase(
     m_client->removeTempAsicStateTable();
 
     // Save temporary views as current view in redis database.
+    //
+    // Objects are written in bulk, since createAsicObject() issues a separate
+    // redis call per object attribute, which at route scale is the dominant
+    // cost of the whole warm boot APPLY_VIEW. Writing is done in chunks to keep
+    // the memory used by the intermediate hash bounded.
+
+    std::unordered_map<std::string, std::vector<swss::FieldValueTuple>> multiHash;
 
     for (auto& tv: temporaryViews)
     {
@@ -5954,8 +5967,23 @@ void Syncd::updateRedisDatabase(
                 entry.emplace_back(saiAttr->getStrAttrId(), saiAttr->getStrAttrValue());
             }
 
-            m_client->createAsicObject(obj->m_meta_key, entry);
+            // NOTE: key must be without table prefix, since createAsicObjects()
+            // is adding it internally
+
+            multiHash[sai_serialize_object_meta_key(obj->m_meta_key)] = std::move(entry);
+
+            if (multiHash.size() >= ASIC_STATE_BULK_WRITE_CHUNK_SIZE)
+            {
+                m_client->createAsicObjects(multiHash);
+
+                multiHash.clear();
+            }
         }
+    }
+
+    if (multiHash.size() > 0)
+    {
+        m_client->createAsicObjects(multiHash);
     }
 
     /*

--- a/syncd/tests/Makefile.am
+++ b/syncd/tests/Makefile.am
@@ -5,7 +5,7 @@ LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main
 bin_PROGRAMS = tests
 
 tests_SOURCES = \
-    main.cpp TestSyncdBrcm.cpp TestSyncdMlnx.cpp TestSyncdNvdaBf.cpp TestSyncdLib.cpp TestSyncdLinkEventDamping.cpp TestDisabledRedisClient.cpp TestZmqRedisClient.cpp
+    main.cpp TestSyncdBrcm.cpp TestSyncdMlnx.cpp TestSyncdNvdaBf.cpp TestSyncdLib.cpp TestSyncdLinkEventDamping.cpp TestDisabledRedisClient.cpp TestZmqRedisClient.cpp TestRedisClient.cpp
 tests_CXXFLAGS = \
     $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDADD = \

--- a/syncd/tests/TestRedisClient.cpp
+++ b/syncd/tests/TestRedisClient.cpp
@@ -1,0 +1,195 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <swss/logger.h>
+#include <swss/dbconnector.h>
+#include <swss/table.h>
+
+#include "RedisClient.h"
+#include "sairediscommon.h"
+#include "meta/sai_serialize.h"
+
+using namespace syncd;
+
+class RedisClientTest : public ::testing::Test
+{
+public:
+    RedisClientTest() = default;
+    virtual ~RedisClientTest() = default;
+
+public:
+    virtual void SetUp() override
+    {
+        SWSS_LOG_ENTER();
+
+        m_dbAsic = std::make_shared<swss::DBConnector>("ASIC_DB", 0, true);
+
+        // start from a known state, since ASIC_DB is shared between tests
+
+        m_dbAsic->flushdb();
+
+        m_redisClient = std::make_shared<RedisClient>(m_dbAsic);
+    }
+
+    virtual void TearDown() override
+    {
+        SWSS_LOG_ENTER();
+
+        m_redisClient.reset();
+
+        m_dbAsic->flushdb();
+
+        m_dbAsic.reset();
+    }
+
+protected:
+
+    static sai_object_meta_key_t makeRouteMetaKey(
+            uint32_t ip4Addr)
+    {
+        SWSS_LOG_ENTER();
+
+        sai_object_meta_key_t metaKey;
+
+        metaKey.objecttype = SAI_OBJECT_TYPE_ROUTE_ENTRY;
+        metaKey.objectkey.key.route_entry.switch_id = 0x21000000000000;
+        metaKey.objectkey.key.route_entry.vr_id = 0x300000000000a;
+        metaKey.objectkey.key.route_entry.destination.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+        metaKey.objectkey.key.route_entry.destination.addr.ip4 = ip4Addr;
+        metaKey.objectkey.key.route_entry.destination.mask.ip4 = 0xffffffff;
+
+        return metaKey;
+    }
+
+    size_t countKeys(
+            const std::string& pattern) const
+    {
+        SWSS_LOG_ENTER();
+
+        return m_dbAsic->keys(pattern).size();
+    }
+
+    std::shared_ptr<swss::DBConnector> m_dbAsic;
+    std::shared_ptr<RedisClient> m_redisClient;
+};
+
+// removeAsicStateTable() removes every ASIC_STATE key. It writes more objects
+// than a single DEL chunk holds, so the chunked bulk removal is exercised.
+TEST_F(RedisClientTest, removeAsicStateTableRemovesAllObjects)
+{
+    const size_t count = 300;
+
+    for (size_t idx = 0; idx < count; idx++)
+    {
+        m_redisClient->createAsicObject(makeRouteMetaKey(static_cast<uint32_t>(idx)),
+                {{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD"}});
+    }
+
+    EXPECT_EQ(m_redisClient->getAsicStateKeys().size(), count);
+
+    m_redisClient->removeAsicStateTable();
+
+    EXPECT_EQ(m_redisClient->getAsicStateKeys().size(), 0u);
+}
+
+// Removing an already empty table must be a no-op and must not throw.
+TEST_F(RedisClientTest, removeAsicStateTableOnEmptyTable)
+{
+    EXPECT_EQ(m_redisClient->getAsicStateKeys().size(), 0u);
+
+    EXPECT_NO_THROW(m_redisClient->removeAsicStateTable());
+
+    EXPECT_EQ(m_redisClient->getAsicStateKeys().size(), 0u);
+}
+
+// removeTempAsicStateTable() must only remove TEMP keys and must leave the
+// current view untouched.
+TEST_F(RedisClientTest, removeTempAsicStateTableLeavesAsicStateIntact)
+{
+    const size_t count = 300;
+
+    for (size_t idx = 0; idx < count; idx++)
+    {
+        auto metaKey = makeRouteMetaKey(static_cast<uint32_t>(idx));
+
+        m_redisClient->createAsicObject(metaKey,
+                {{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD"}});
+
+        m_redisClient->createTempAsicObject(metaKey,
+                {{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD"}});
+    }
+
+    EXPECT_EQ(countKeys(TEMP_PREFIX ASIC_STATE_TABLE ":*"), count);
+
+    m_redisClient->removeTempAsicStateTable();
+
+    EXPECT_EQ(countKeys(TEMP_PREFIX ASIC_STATE_TABLE ":*"), 0u);
+    EXPECT_EQ(m_redisClient->getAsicStateKeys().size(), count);
+
+    EXPECT_NO_THROW(m_redisClient->removeTempAsicStateTable());
+}
+
+// createAsicObjects() is the bulk equivalent of createAsicObject(): it must
+// produce the same keys, and an object with no attributes must still be
+// written, as a NULL:NULL entry.
+TEST_F(RedisClientTest, createAsicObjectsWritesSameKeysAsCreateAsicObject)
+{
+    auto withAttrs = makeRouteMetaKey(0x0a000001);
+    auto withoutAttrs = makeRouteMetaKey(0x0a000002);
+
+    std::unordered_map<std::string, std::vector<swss::FieldValueTuple>> multiHash;
+
+    multiHash[sai_serialize_object_meta_key(withAttrs)] =
+        {{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x5000000000041"}};
+
+    multiHash[sai_serialize_object_meta_key(withoutAttrs)] = {};
+
+    m_redisClient->createAsicObjects(multiHash);
+
+    EXPECT_EQ(m_redisClient->getAsicStateKeys().size(), 2u);
+
+    auto attrs = m_redisClient->getAttributesFromAsicKey(
+            (ASIC_STATE_TABLE ":") + sai_serialize_object_meta_key(withAttrs));
+
+    EXPECT_EQ(attrs["SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID"], "oid:0x5000000000041");
+
+    auto empty = m_redisClient->getAttributesFromAsicKey(
+            (ASIC_STATE_TABLE ":") + sai_serialize_object_meta_key(withoutAttrs));
+
+    EXPECT_EQ(empty["NULL"], "NULL");
+}
+
+// setVidAndRidMap() must write both directions of the map, and must replace
+// any previously stored map.
+TEST_F(RedisClientTest, setVidAndRidMapWritesBothDirections)
+{
+    const sai_object_id_t vid1 = 0x1000000000001;
+    const sai_object_id_t vid2 = 0x1000000000002;
+    const sai_object_id_t rid1 = 0x2000000000001;
+    const sai_object_id_t rid2 = 0x2000000000002;
+
+    std::unordered_map<sai_object_id_t, sai_object_id_t> map;
+
+    map[vid1] = rid1;
+    map[vid2] = rid2;
+
+    m_redisClient->setVidAndRidMap(map);
+
+    auto vid2rid = m_redisClient->getVidToRidMap();
+    auto rid2vid = m_redisClient->getRidToVidMap();
+
+    EXPECT_EQ(vid2rid.size(), 2u);
+    EXPECT_EQ(rid2vid.size(), 2u);
+
+    EXPECT_EQ(vid2rid[vid1], rid1);
+    EXPECT_EQ(rid2vid[rid2], vid2);
+
+    // an empty map must clear what was stored before
+
+    m_redisClient->setVidAndRidMap({});
+
+    EXPECT_EQ(m_redisClient->getVidToRidMap().size(), 0u);
+    EXPECT_EQ(m_redisClient->getRidToVidMap().size(), 0u);
+}


### PR DESCRIPTION
### Description of PR

Summary:
Fixes sonic-net/sonic-buildimage#29101

During warm boot at full IPv6 route scale (~418K routes, ~421.5K ASIC objects), syncd `APPLY_VIEW` takes ~94s end to end, and `updateRedisDatabase()` alone accounts for ~59.6s of that. ASIC programming is not the bottleneck — the comparison logic produced only 84 ASIC operations and applying them took ~0.1s. The cost is redis I/O: the current view rewrite talks to redis one key, and even one attribute, at a time.

This PR switches that rewrite onto the pipelined bulk helpers that already exist in this tree.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [x] Test improvement

### Approach

#### What is the motivation for this PR?

`Syncd::updateRedisDatabase()` is on the warm boot critical path, and at route scale it is dominated entirely by redis round trips:

| call | current behaviour | round trips at ~421.5K objects |
| --- | --- | --- |
| `removeAsicStateTable()` | `KEYS` + one `DEL` per key | ~421K |
| `removeTempAsicStateTable()` | `KEYS` + one `DEL` per key | ~421K |
| `createAsicObject()` | one `HSET` per **attribute**, unpipelined | ~600K+ |
| `setVidAndRidMap()` | two `HSET` per entry, unpipelined | 2 per entry |

At this runtime syncd's 30s `TimerWatchdog` logs an ERR for `notify:APPLY_VIEW`, and warm boot only completes because orchagent temporarily raises its response timeout to 480s for the Mellanox platform. Without that workaround `APPLY_VIEW` would fail at the default 60s response timeout.

The tree already has pipelined bulk helpers, used by the normal bulk create/remove path — they were simply never wired into the `APPLY_VIEW` rewrite. There is also a long-standing in-tree `TODO` on this function.

#### How did you do it?

- **Bulk table wipe.** `removeAsicStateTable()` / `removeTempAsicStateTable()` now remove all keys with a single `del()` on the vector of keys, which issues chunked pipelined `DEL` commands (`KEY_DEL_CHUNK_SIZE` = 128 keys per command in swss-common) instead of one round trip per key.

  Note the keys returned by `keys()` already carry the table prefix, so they are handed to `m_dbAsic->del()` directly rather than through `RedisClient::removeAsicObjects()`, which prepends the prefix itself and would double it.

- **Bulk view rewrite.** `updateRedisDatabase()` now accumulates objects and writes them with `createAsicObjects()` (pipelined `HSET` per object, all fields in one command) instead of a `createAsicObject()` per object.

  Because the bulk helper materialises an intermediate hash of everything it is given, objects are written in chunks of `ASIC_STATE_BULK_WRITE_CHUNK_SIZE` (10,000). Writing all ~421K objects in a single call would materialise the map twice — once by the caller and once inside the helper, which prepends the table prefix into a fresh map — for a peak of several hundred MB during warm boot. Chunking keeps that bounded at a few MB while still keeping the pipeline saturated.

- **Pipelined VID/RID map.** `setVidAndRidMap()` now uses `swss::RedisPipeline`, exactly as the neighbouring `insertVidsAndRids()` already does. The default pipeline size is used deliberately so replies are flushed periodically and memory stays bounded. This also benefits the cold boot path, since `HardReiniter` calls the same method.

**Behaviour is unchanged.** The same keys are written with the same table prefix, and objects with no attributes are still stored as `NULL:NULL` — `createAsicObjects()` handles that case identically to `createAsicObject()`. `ZmqRedisClient` overrides both the single and bulk variants and its two implementations are equivalent, so the ZMQ path is unaffected; `DisabledRedisClient` stubs both as no-ops.

Estimated effect on the rewrite: round trips drop from roughly 1.4M to a few thousand pipeline flushes, which should take `updateRedisDatabase()` from ~59.6s to low single-digit seconds, and `APPLY_VIEW` from ~94s to roughly ~35s.

That clears the orchagent 60s default response timeout and removes the need for the 480s workaround, but it does **not** by itself get under syncd's 30s watchdog warn span — the remaining time is the ~17.5s combined `getAsicView` of both views plus ~5.7s of comparison logic. That view-load cost is the secondary target called out in the issue and is intentionally left out of this PR to keep the change reviewable.

#### How did you verify/test it?

Added `syncd/tests/TestRedisClient.cpp`, covering the paths this PR changes:

- `removeAsicStateTable()` removes every ASIC_STATE key, using more objects than a single `DEL` chunk holds so the chunked bulk removal is actually exercised
- `removeAsicStateTable()` on an already empty table is a no-op and does not throw
- `removeTempAsicStateTable()` removes only TEMP keys and leaves the current view intact
- `createAsicObjects()` writes the same keys as `createAsicObject()`, including the empty-attribute `NULL:NULL` case
- `setVidAndRidMap()` writes both directions and an empty map clears a previously stored one

I do not have a SONiC build environment available, so I have not been able to compile the tree or run the suite locally — I would appreciate a CI run. The changed logic was checked in isolation against this project's exact warning set from `configure.ac` (`-Wall -Wextra -Wconversion -Werror`), and the tests follow the live-redis pattern already used by `TestZmqRedisClient.cpp`.

The ~94s / ~59.6s figures are from the syncd logs in the linked issue, not from a run of my own; I do not have access to a 418K-route setup to measure the improvement directly.

#### Any platform specific information?

None. The change is platform generic, though the issue was reported against Mellanox, where orchagent's 480s `APPLY_VIEW` timeout workaround currently masks the problem.

### Documentation

No documentation change — this is an internal performance fix with no user-facing behaviour or config change.
