### PR TITLE
[202605] Backport LAG subinterface hwif name resolution

### DIFF
--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -343,6 +343,9 @@ bool SwitchVpp::vpp_get_hwif_name (
 {
     SWSS_LOG_ENTER();
 
+    const char *hwifname = nullptr;
+    char hw_bondifname[32];
+
     if (objectTypeQuery(object_id) == SAI_OBJECT_TYPE_LAG) {
         platform_bond_info_t bond_info;
         sai_status_t status = get_lag_bond_info(object_id, bond_info);
@@ -350,21 +353,23 @@ bool SwitchVpp::vpp_get_hwif_name (
         {
             return false;
         }
-        ifname = std::string(BONDETHERNET_PREFIX) + std::to_string(bond_info.id);
-        return true;
+        snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%u", BONDETHERNET_PREFIX, bond_info.id);
+        hwifname = hw_bondifname;
+    } else {
+        std::string if_name;
+        bool found = getTapNameFromPortId(object_id, if_name);
+
+        if (found == false)
+        {
+            SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(object_id).c_str());
+            return false;
+        }
+        hwifname = tap_to_hwif_name(if_name.c_str());
     }
 
-    std::string if_name;
-    bool found = getTapNameFromPortId(object_id, if_name);
+    if (!hwifname) return false;
 
-    if (found == false)
-    {
-        SWSS_LOG_NOTICE("host interface for port id %s not found", sai_serialize_object_id(object_id).c_str());
-        return false;
-    }
-
-    const char *hwifname = tap_to_hwif_name(if_name.c_str());
-    char hw_subifname[32];
+    char hw_subifname[64];
     const char *hw_ifname;
 
     if (vlan_id) {
@@ -1591,7 +1596,15 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
         snprintf(host_subifname, sizeof(host_subifname), "%s.%u", dev, vlan_id);
 
         /* The host(tap) subinterface is also created as part of the vpp subinterface creation */
-        create_sub_interface(tap_to_hwif_name(dev), vlan_id, vlan_id);
+        const char *parent_hwif;
+        char hw_subif_parent[32];
+        if (ot == SAI_OBJECT_TYPE_LAG) {
+            snprintf(hw_subif_parent, sizeof(hw_subif_parent), "%s%u", BONDETHERNET_PREFIX, bond_info.id);
+            parent_hwif = hw_subif_parent;
+        } else {
+            parent_hwif = tap_to_hwif_name(dev);
+        }
+        create_sub_interface(parent_hwif, vlan_id, vlan_id);
 
         /* Get new list of physical interfaces from VS */
         refresh_interfaces_list();
@@ -1877,7 +1890,18 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
     uint16_t vlan_id = attr.value.u16;
 
     std::string if_name;
-    bool found = getTapNameFromPortId(obj_id, if_name);
+    platform_bond_info_t bond_info;
+    bool found;
+    if (ot == SAI_OBJECT_TYPE_LAG) {
+        status = get_lag_bond_info(obj_id, bond_info);
+        if (status != SAI_STATUS_SUCCESS) {
+            return status;
+        }
+        if_name = std::string(BONDETHERNET_PREFIX) + std::to_string(bond_info.id);
+        found = true;
+    } else {
+        found = getTapNameFromPortId(obj_id, if_name);
+    }
     if (found == false)
     {
         SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(obj_id).c_str());
@@ -1886,7 +1910,15 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
 
     const char *dev = if_name.c_str();
 
-    delete_sub_interface(tap_to_hwif_name(dev), vlan_id);
+    const char *parent_hwif;
+    char hw_del_parent[32];
+    if (ot == SAI_OBJECT_TYPE_LAG) {
+        snprintf(hw_del_parent, sizeof(hw_del_parent), "%s%u", BONDETHERNET_PREFIX, bond_info.id);
+        parent_hwif = hw_del_parent;
+    } else {
+        parent_hwif = tap_to_hwif_name(dev);
+    }
+    delete_sub_interface(parent_hwif, vlan_id);
     /* Get new list of physical interfaces from VS */
     refresh_interfaces_list();
 


### PR DESCRIPTION
### Description of PR

Summary:

Manual 202605 backport of https://github.com/sonic-net/sonic-sairedis/pull/1883.

Conflict tracing for the VPP VLAN/LAG DHCP backport https://github.com/sonic-net/sonic-sairedis/pull/2048 found that #1883 is a missing master prerequisite on 202605. Without it, LAG subinterface operations can resolve `PortChannelX.<vlan>` to the parent `BondEthernetX` or to `Unknown` instead of `BondEthernetX.<vlan>`.

Deliver this prerequisite before rebuilding or reconciling #2048.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

The 202605 branch lacks the LAG-aware VPP hardware-interface resolution added by #1883. The missing change caused the `SwitchVppRif.cpp` conflict while backporting #1981 and left shared nonzero-VLAN callers resolving the parent bond rather than the LAG subinterface.

##### Work item tracking
- Microsoft ADO **(number only)**: 39310227

#### How did you do it?

Cherry-picked #1883 onto the current 202605 branch without source conflicts. The backport patch is byte-equivalent to the original #1883 patch.

#### How did you verify/test it?

- Clean cherry-pick onto current 202605.
- `git diff --check` passed.
- Stable patch ID matches the original #1883 patch.
- Repository CI is requested on this exact head.

#### Any platform specific information?

VPP only.

### Documentation

Not applicable; this is a release backport of an existing fix.