### PR TITLE
[flexcounter] Remove stale ACL counters after ACL removal

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -4374,6 +4374,7 @@ void FlexCounter::removeCounter(
     {
         if (hasCounterContext(ATTR_TYPE_ACL_COUNTER))
         {
+            removeDataFromCountersDB(vid, "");
             getCounterContext(ATTR_TYPE_ACL_COUNTER)->removeObject(vid);
         }
     }

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -788,7 +788,7 @@ TEST(FlexCounter, addRemoveCounter)
         {"SAI_ACL_COUNTER_ATTR_PACKETS"},
         {"1000"},
         counterVerifyFunc,
-        false);
+        true);
 
     // Bulk create mode to satisfy the coverage requirement
     testAddRemoveCounter(
@@ -798,7 +798,7 @@ TEST(FlexCounter, addRemoveCounter)
         {"SAI_ACL_COUNTER_ATTR_PACKETS"},
         {"1000"},
         counterVerifyFunc,
-        false,
+        true,
         STATS_MODE_READ,
         true);
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

Fixes https://github.com/sonic-net/sonic-sairedis/issues/1982

When an ACL rule is deleted, orchagent removes the SAI object, the
`ACL_COUNTER_RULE_MAP` entry, and the `FLEX_COUNTER_DB` polling entry, but the
`COUNTERS:oid:<oid>` hash written by syncd's flex counter poll is never removed.
`FlexCounter::removeCounter()` only erased its in-memory polling maps for
`SAI_OBJECT_TYPE_ACL_COUNTER`; no component issues the `DEL`, so the entries
survive until `COUNTERS_DB` is flushed on a cold restart.

On a production device with ACL rule churn this reached 582,805 orphaned
`COUNTERS:oid:0x9*` entries against 111 live ACL rules (>99.98% leak rate),
causing unbounded `COUNTERS_DB` growth and misleading monitoring/telemetry data.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 39402687

#### How did you do it?

Added the missing `removeDataFromCountersDB()` call to the
`SAI_OBJECT_TYPE_ACL_COUNTER` branch of `FlexCounter::removeCounter()`, so the
`COUNTERS:oid:<oid>` hash is deleted when the ACL counter is deregistered.


#### How did you verify/test it?

- `unittest/syncd/TestFlexCounter.cpp`: the two `SAI_OBJECT_TYPE_ACL_COUNTER`
  cases in `TEST(FlexCounter, addRemoveCounter)` (single-add and bulk-add) now pass
  `autoRemoveDbEntry = true`. The helper therefore no longer deletes the key on
  the test's behalf, and its closing `ASSERT_TRUE(keys.empty())` asserts that
  syncd itself removed the `COUNTERS:oid:` entry. Without this fix those cases fail.
- Built with `--with-sai=vs` and ran `unittest/syncd` against a local redis.

- Verified on hardware: Broadcom 7050CX3, `internal-202605` image built with this fix
  (`202605` + this commit), syncd container replaced on a switch otherwise running the
  unpatched build. The test creates ACL rules with counters, waits for the flex counter to
  publish the `COUNTERS:oid:` hashes, deletes the rules and table, waits until ASIC_DB /
  FLEX_COUNTER_DB / `ACL_COUNTER_RULE_MAP` are cleaned up, then inspects COUNTERS_DB:

  | syncd | 5 rules x 1 cycle | 20 rules x 3 cycles |
  | --- | --- | --- |
  | before (unpatched) | **5/5 leaked** | - |
  | after (this fix) | **0/5 leaked** | **0/60 leaked** |

  Before the fix every OID reported `ASIC_DB=removed FLEX_COUNTER_DB=removed COUNTERS_DB=STALE`,
  leaving behind the all-zero `SAI_ACL_COUNTER_ATTR_BYTES` / `SAI_ACL_COUNTER_ATTR_PACKETS`
  hash described in the issue. After the fix every OID reports `COUNTERS_DB=removed` and the
  device ends with 0 ACL counter keys in COUNTERS_DB.

  The reproducer script used here is posted on
  https://github.com/sonic-net/sonic-sairedis/issues/1982 (exit 1 = leak reproduced,
  exit 0 = fix present, so it works as a before/after gate).

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

