### PR TITLE
[SONiC-VPP] Ingress-filter tagged frames on access members via the l2-vlan-filter node

### DIFF
--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -97,6 +97,10 @@ using namespace saivs;
  *   - sonic-ext-l2-trap-fixup: tagged DHCPv4 only (rewrites VLIB_RX
  *     from bridged sub-if to parent phys before handing to linux-
  *     cp-punt, because a bridged sub-if has no LCP pair).
+ *   - sonic-ext-l2-vlan-filter: 802.1Q frames on an untagged (access)
+ *     member.  Accepts frames whose VID equals the member's access
+ *     VLAN (pops the tag and re-bridges) and drops any other VID, so
+ *     the tag-agnostic access bridge port does not flood foreign VLANs.
  * Untagged DHCP does not need the fixup node: VLIB_RX on an untagged
  * bridge member is already the parent phys, so linux-cp-punt resolves
  * the right LCP pair directly.
@@ -107,6 +111,7 @@ using namespace saivs;
 static bool     s_l2_punt_classify_inited = false;
 static uint32_t s_punt_next_index = ~0;       /* linux-cp-punt (untagged + LLDP) */
 static uint32_t s_trap_fixup_next_index = ~0; /* sonic-ext-l2-trap-fixup (tagged DHCP only) */
+static uint32_t s_vlan_filter_next_index = ~0; /* sonic-ext-l2-vlan-filter (access-port ingress VLAN filter) */
 
 /* Untagged member tables: ip4 slot holds DHCPv4 broadcast,
  * other slot holds LLDP.  No chain between them (different ethertype
@@ -175,6 +180,23 @@ static int l2_punt_classify_init()
         SWSS_LOG_NOTICE("l2_punt_classify_init: trap_fixup_next_index=%u",
                         s_trap_fixup_next_index);
     }
+
+    /* sonic-ext-l2-vlan-filter next: ingress VLAN filter for untagged
+     * (access) bridge members.  A tagged frame on an access member is
+     * classified (outer ethertype 0x8100) and handed to this node,
+     * which compares the frame's VID against the member's own access
+     * VLAN (derived from its bridge-domain id): if they match it pops
+     * the tag and re-bridges the frame; otherwise it drops it.  Runs at
+     * l2-input-classify, BEFORE l2-fwd/l2-flood.  Not fatal if
+     * unavailable: the ingress VLAN filter session is simply not
+     * installed (tagged frames then follow the default L2 path). */
+    if (vpp_add_node_next("l2-input-classify", "sonic-ext-l2-vlan-filter",
+                                &s_vlan_filter_next_index) != 0) {
+        SWSS_LOG_WARN("l2_punt_classify_init: sonic-ext-l2-vlan-filter not registered; "
+                      "ingress VLAN filtering on access members disabled");
+        s_vlan_filter_next_index = ~0;
+    }
+
     SWSS_LOG_NOTICE("l2_punt_classify_init: punt_next_index=%u", s_punt_next_index);
 
     /* --- Untagged IP4-slot table (DHCPv4 broadcast) ---
@@ -231,7 +253,7 @@ static int l2_punt_classify_init()
         mask[12] = 0xFF; mask[13] = 0xFF;
 
         if (vpp_classify_table_create(
-                8 /*nbuckets*/, 4*1024 /*memory_size: 1 session*/,
+                8 /*nbuckets*/, 4*1024 /*memory_size: 2 sessions*/,
                 0 /*skip*/, 1 /*match_n_vectors*/,
                 ~0 /*next_table=none*/,
                 ~0 /*miss_next=continue*/,
@@ -244,6 +266,18 @@ static int l2_punt_classify_init()
         uint8_t m[16] = {0}; m[12] = 0x88; m[13] = 0xCC;
         vpp_classify_session_add(s_untag_other_table, s_punt_next_index,
                                  m, 16, 0, 0, SAIVS_CLASSIFY_ACTION_NONE);
+
+        /* 802.1Q 0x8100 → sonic-ext-l2-vlan-filter (ingress VLAN
+         * filter). Runs at l2-input-classify, BEFORE l2-fwd/l2-flood.
+         * The node accepts frames whose VID equals the access member's
+         * own VLAN (popping the tag and re-bridging) and drops frames
+         * carrying any other (unconfigured) VID, instead of letting the
+         * tag-agnostic bridge domain flood them. */
+        if (s_vlan_filter_next_index != ~0u) {
+            uint8_t md[16] = {0}; md[12] = 0x81; md[13] = 0x00;
+            vpp_classify_session_add(s_untag_other_table, s_vlan_filter_next_index,
+                                     md, 16, 0, 0, SAIVS_CLASSIFY_ACTION_NONE);
+        }
     }
 
     /* --- Tagged DHCP table.  Frame at l2-input-classify on a tagged
@@ -292,10 +326,10 @@ static int l2_punt_classify_init()
     s_l2_punt_classify_inited = true;
     SWSS_LOG_NOTICE("L2 punt classify tables initialized: "
                     "untag_ip4=%u untag_other=%u tag_dhcp=%u "
-                    "punt_next=%u trap_fixup_next=%u",
+                    "punt_next=%u trap_fixup_next=%u vlan_filter_next=%u",
                     s_untag_ip4_table, s_untag_other_table,
                     s_tag_dhcp_table,
-                    s_punt_next_index, s_trap_fixup_next_index);
+                    s_punt_next_index, s_trap_fixup_next_index, s_vlan_filter_next_index);
     return 0;
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # [#25775](https://github.com/sonic-net/sonic-buildimage/issues/25775)
Wire the sonic-ext-l2-vlan-filter VPP node into the L2 punt-classify tables so access (untagged) VLAN members enforce ingress VLAN filtering. On SONiC-VPP an access member is the raw physical interface added to the VLAN's bridge domain, which is tag-agnostic (ethernet-input matches MATCH_0..3_TAG), so a frame bearing any 802.1Q VID is accepted and L2-flooded instead of being VID-filtered. This change installs an l2-input-classify session (outer ethertype 0x8100) on untagged members whose hit-next is the new node; the node accepts frames tagged with the member's own access VLAN (pops the tag and re-bridges) and drops any other VID. 

Dependency: requires the companion sonic-platform-vpp PR that adds the sonic-ext-l2-vlan-filter node first: https://github.com/sonic-net/sonic-platform-vpp/pull/277

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
Access ports must drop ingress frames tagged with an unconfigured VID (ingress VLAN filtering). On VPP the access member is a plain, tag-agnostic L2 bridge port, so such frames are flooded within the bridge domain instead of dropped — the gap behind test_vlan_tc3_send_invalid_vid failing on t0-vpp. A pure classifier can't fix it (a classify hit is terminal and can't pop a tag), so the fix routes tagged frames on access members to a dedicated node that can filter by VID and pop the tag.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
In l2_punt_classify_init() (vslib/vpp/SwitchVppFdb.cpp):

- Registered the node as an l2-input-classify next via vpp_add_node_next("l2-input-classify", "sonic-ext-l2-vlan-filter", &s_vlan_filter_next_index).
- Added a session to the untagged members' OTHER-slot table matching outer ethertype 0x8100, with hit-next = the node (runs before l2-fwd/l2-flood).
- Guarded on node availability (skips the session with a warning if the node isn't registered), and updated the init log line.
Only untagged (access) members receive this session — tagged (trunk) members use the existing exact-match sub-interface path and are unchanged. (This replaces an earlier blanket-drop approach that also dropped legitimately own-VID-tagged frames.)

#### How did you verify/test it?
Built a sonic-vpp image with this change plus the companion VPP node and ran on a t0-vpp testbed:
- arp/test_tagged_arp.py::test_tagged_arp_pkt — passes: frames tagged with the access VLAN's own VID (e.g. 1000/108) are accepted, tag popped, ARP learned.
- vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid — the targeted case: a VID-4095 tagged frame on an access port is dropped instead of flooded (run -t vlan/ to confirm).
- Untagged traffic unaffected (tc1, normal L2 learning of member MACs).

#### Any platform specific information?
VPP platform only (asic_type == 'vpp'); no effect on other ASICs. 

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
