### PR TITLE
syncd: Avoid false nonexisting-object log during FlexCounter removal

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1509,7 +1509,8 @@ public:
         SWSS_LOG_ENTER();
 
         auto iter = m_objectIdsMap.find(vid);
-        if (iter != m_objectIdsMap.end())
+        const bool removedFromObjectMap = iter != m_objectIdsMap.end();
+        if (removedFromObjectMap)
         {
             auto rid = iter->second->rid;
             m_failedPolls.erase({rid, vid});
@@ -1518,7 +1519,9 @@ public:
 
         // An object can be in both m_objectIdsMap and the bulk context
         // when bulk polling is supported by some counter prefixes but unsupported by some others
-        if (!removeBulkStatsContext(vid) && log)
+        const bool removedFromBulkContext = removeBulkStatsContext(vid);
+
+        if (!removedFromObjectMap && !removedFromBulkContext && log)
         {
             SWSS_LOG_NOTICE("Trying to remove nonexisting %s %s",
                             sai_serialize_object_type(m_objectType).c_str(),


### PR DESCRIPTION
## Description

 Fix a false `Trying to remove nonexisting` notice emitted by `FlexCounter::removeObject()`.

An object can legitimately be tracked in `m_objectIdsMap` without being present in the bulk-stats context. Previously,   Syncd used only the bulk-context removal result to decide whether the object was nonexisting, which could produce a misleading notice after successful removal from `m_objectIdsMap`.

The fix tracks removal results from both locations and emits the notice only when the object is absent from both.

Fixes #2053

## How I Tested
Validated on hardware by disabling and re-enabling PHY counter polling:

  ```bash
  counterpoll phy disable
  counterpoll phy enable
 ```

No false Trying to remove nonexisting SAI_OBJECT_TYPE_PORT messages were observed in Syncd logs.

