### PR TITLE
vpp: refresh speed cache after successful update

### DIFF
--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -801,7 +801,23 @@ sai_status_t SwitchVpp::vpp_set_port_speed (
         // SAI port speed is in Mbps, VPP link speed is in Kbps
         uint32_t link_speed = speed * 1000;
 
-        sw_interface_set_link_speed(hwif_name, link_speed);
+        int status = sw_interface_set_link_speed(hwif_name, link_speed);
+
+        if (status != 0)
+        {
+            SWSS_LOG_ERROR("Failed to update port %s speed to %u Mbps: %d",
+                           hwif_name, speed, status);
+            return SAI_STATUS_FAILURE;
+        }
+
+        /* Refresh SAI-VPP's cached speed before the set operation returns.
+         * SONiC queries operational speed before bringing the port back up. */
+        if (vpp_refresh_interface_speed(hwif_name) != 0)
+        {
+            SWSS_LOG_WARN("Failed to refresh VPP speed for %s after setting %u Mbps",
+                          hwif_name, speed);
+        }
+
         SWSS_LOG_NOTICE("Updating port %s speed to %u Mbps", hwif_name, speed);
     }
     return SAI_STATUS_SUCCESS;


### PR DESCRIPTION
### Description of PR

Summary:

Refreshes the cached operational speed after a successful VPP interface speed update. This prevents operational state from temporarily retaining the previous speed after a runtime speed change.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?

SAI-VPP could return a cached speed immediately after successfully changing an interface speed, causing the reported operational speed to remain stale.

##### Work item tracking

- Microsoft ADO **(number only)**: N/A

#### How did you do it?

- Check the result of the VPP speed-update request.
- Return failure if the speed update fails.
- Refresh the cached interface speed after a successful update.
- Log a warning if the cache refresh fails.

#### How did you verify/test it?

Verified repeated 1G-to-10G and 10G-to-1G transitions. The configured and operational speed states converged correctly without requiring an additional interface flap.

### Tested Branch and UT logs:

Verified the fix on 202603 branch.
Test results/UT logs: 
[arctos_saivpp_speed_cache_refresh_ut_20260825.txt](https://github.com/user-attachments/files/31654725/arctos_saivpp_speed_cache_refresh_ut_20260825.txt)


#### Any platform specific information?

This change applies to the VPP SAI implementation.

### Documentation

No documentation changes are required.