### PR TITLE
vpp: Disable ipv6 in lag member and support bond hw_intf lookup

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -449,6 +449,9 @@ namespace saivs
                     _In_ sai_object_id_t lag_member_oid);
 	    void restorePortTapMac(
                     _In_ sai_object_id_t port_oid);
+	    void vpp_set_lag_member_ip6(
+                    _In_ sai_object_id_t port_oid,
+                    _In_ bool enable);
 	    sai_status_t vpp_ensure_lag_lcp(
                     _In_ sai_object_id_t lag_oid);
 	    sai_status_t vpp_set_lag_member_egress_disable(

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -1386,9 +1386,59 @@ sai_status_t SwitchVpp::vpp_create_lag_member(
     // than the member, neither of which the member accepts unless promiscuous.
     interface_set_promiscuous(hwifname, true);
 
+    // vs_create_hostif_tap_interface() unconditionally enables IPv6 on every port
+    // hwif to give it a link-local address. IPv4 has no such explicit enable, it is
+    // refcounted by VPP and drops away on its own when the member's RIF addresses
+    // are removed on joining the PortChannel. IPv6 has to be turned off explicitly
+    // so the member does not keep a link-local and an active ip6 config while L3 is
+    // owned by the bond. It stays disabled for as long as the port is a member,
+    // including across egress-disable detach/re-attach, and is restored in
+    // removeLagMember().
+    vpp_set_lag_member_ip6(lag_port_oid, false);
+
     CHECK_STATUS(vpp_ensure_lag_lcp(lag_oid));
 
     return SAI_STATUS_SUCCESS;
+}
+
+void SwitchVpp::vpp_set_lag_member_ip6(
+        _In_ sai_object_id_t port_oid,
+        _In_ bool enable)
+{
+    SWSS_LOG_ENTER();
+
+    // Best effort, the caller must still complete the LAG member add/remove because
+    // the VPP bond membership change already happened and failing here would leave
+    // the object model inconsistent.
+    std::string if_name;
+
+    if (getTapNameFromPortId(port_oid, if_name) == false)
+    {
+        SWSS_LOG_ERROR("no tap found for port %s, IPv6 not %s",
+                sai_serialize_object_id(port_oid).c_str(),
+                enable ? "enabled" : "disabled");
+        return;
+    }
+
+    const char *hwif_name = tap_to_hwif_name(if_name.c_str());
+
+    if (hwif_name == nullptr)
+    {
+        SWSS_LOG_ERROR("no hwif found for tap %s, IPv6 not %s",
+                if_name.c_str(),
+                enable ? "enabled" : "disabled");
+        return;
+    }
+
+    if (sw_interface_ip6_enable_disable(hwif_name, enable) < 0)
+    {
+        SWSS_LOG_ERROR("failed to %s IPv6 on %s",
+                enable ? "enable" : "disable", hwif_name);
+        return;
+    }
+
+    SWSS_LOG_NOTICE("%s IPv6 on LAG member %s",
+            enable ? "Enabled" : "Disabled", hwif_name);
 }
 
 sai_status_t SwitchVpp::vpp_ensure_lag_lcp(
@@ -1663,10 +1713,16 @@ sai_status_t SwitchVpp::removeLagMember(
     if (port_oid != SAI_NULL_OBJECT_ID)
     {
         restorePortTapMac(port_oid);
+
+        // Undo the disable done in vpp_create_lag_member(), the port is a routed port
+        // again and needs the link-local address that vs_create_hostif_tap_interface()
+        // gave it. Done here rather than in vpp_remove_lag_member() so it also covers
+        // an egress-disabled member, which skips the bond detach above.
+        vpp_set_lag_member_ip6(port_oid, true);
     }
     else
     {
-        SWSS_LOG_WARN("no port found for LAG member %s, tap MAC not restored",
+        SWSS_LOG_WARN("no port found for LAG member %s, tap MAC and IPv6 not restored",
                 sai_serialize_object_id(lag_member_oid).c_str());
     }
 
@@ -2217,6 +2273,31 @@ inline sai_object_id_t SwitchVpp::resolvePortIdFromSwIfIndex(uint32_t sw_if_inde
         return it->second;
 
     sai_object_id_t port_id = getPortIdFromSwIfIndex(sw_if_index);
+
+    if (port_id == SAI_NULL_OBJECT_ID)
+    {
+        /*
+         * A LAG (BondEthernet<N>) is created directly via create_bond_interface()
+         * and has no SAI hostif tap, so it is absent from the hwif->hostif ifmap
+         * that getPortIdFromSwIfIndex() relies on. Resolve it from the bond map
+         * instead: SAI_BRIDGE_PORT_ATTR_PORT_ID of a PortChannel bridge port is
+         * the LAG OID, which is exactly what findBridgeVlanForPortVlan() matches
+         * on. Without this, every MAC learned on a PortChannel is dropped and
+         * never reaches ASIC_DB/STATE_DB (invisible to fdbshow).
+         */
+        for (const auto &kv : m_lag_bond_map)
+        {
+            if (kv.second.sw_if_index == sw_if_index)
+            {
+                port_id = kv.first;
+                SWSS_LOG_NOTICE("FDB: resolved sw_if_index %u to LAG %s (bond %u)",
+                                sw_if_index, sai_serialize_object_id(port_id).c_str(),
+                                kv.second.id);
+                break;
+            }
+        }
+    }
+
     if (port_id != SAI_NULL_OBJECT_ID)
         m_swif_to_port_id[sw_if_index] = port_id;
 

--- a/vslib/vpp/SwitchVppHostif.cpp
+++ b/vslib/vpp/SwitchVppHostif.cpp
@@ -775,7 +775,8 @@ const char* SwitchVpp::hwif_to_tap_name(
 
     if (it == m_hwif_hostif_map.end())
     {
-        // not all hwif are mapped to hostif, e.g. vxlan tunnel interface, bvi interface.
+        // not all hwif are mapped to hostif, e.g. vxlan tunnel interface, bvi interface,
+        // and BondEthernet<N> (LAG) which has no SAI hostif tap.
         SWSS_LOG_NOTICE("failed to find hostif info entry for hwif device: %s", tap_name.c_str());
 
         return "Unknown";


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (N/A)

Two fixes in the VPP vslib LAG path:

1. **IPv6 was left enabled on a port after it was enslaved into a PortChannel.**
   `vs_create_hostif_tap_interface()` unconditionally calls `sw_interface_ip6_enable_disable(hwif, true)` on every port hwif so it gets a link-local address derived from its MAC. IPv4 has no equivalent explicit enable — VPP refcounts it, so it drops away on its own once the member's RIF addresses are removed as the port joins the PortChannel. IPv6 has no such refcount, and nothing in the LAG member path ever disabled it (`sw_interface_ip6_enable_disable(hwif, false)` was only reachable from `vs_remove_hostif_tap_interface()`). The result was an asymmetry: an enslaved member had IPv4 disabled but IPv6 still enabled, retaining a link-local address, an active `ip6-unicast` feature arc and ND state on the member `sw_if_index`, while L3 is actually owned by `BondEthernet<N>`. When the interface is detached from LAG when it is egress-disabled, it is capable to receive ipv6 packet but not ipv4. This caused test_lag_member_forwarding failed, which sent ipv6 ping through a member interface after it is egress-disabled.

2. **MACs learned on a PortChannel never reached the FDB.**
   `resolvePortIdFromSwIfIndex()` relied solely on `getPortIdFromSwIfIndex()`, which walks the hwif→hostif map. A LAG is created directly via `create_bond_interface()` and has no SAI hostif tap, so `BondEthernet<N>` is absent from that map. Every MAC learned on a PortChannel resolved to `SAI_NULL_OBJECT_ID` and was dropped, never reaching ASIC_DB/STATE_DB and therefore invisible to `fdbshow`.

Reviewers should start at `SwitchVpp::vpp_create_lag_member()` / `SwitchVpp::removeLagMember()` in `vslib/vpp/SwitchVppFdb.cpp`.

No dependencies on other repos or submodule bumps.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?

A PortChannel member should behave consistently for both address families: while the port is enslaved, L3 belongs to the bond, not to the member. Leaving IPv6 enabled on the member produces stale link-locals in `show ip6 interface`, lingering ip6 neighbour state on the member `sw_if_index`, and `ip6-enable` returning `VALUE_EXIST` on re-add paths.

Separately, FDB learning over PortChannels was silently broken, which breaks L2 forwarding visibility and any test or feature that depends on `show mac` reflecting MACs learned on a LAG.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How did you do it?

**IPv6 on LAG members**

Added `SwitchVpp::vpp_set_lag_member_ip6(port_oid, enable)`, which resolves port → tap → hwif and calls `sw_interface_ip6_enable_disable()`. It is best effort: on failure it logs and returns rather than failing the caller, because the VPP bond membership change has already happened and aborting would leave the SAI object model inconsistent. This follows the existing convention of `restorePortTapMac()`.

Call sites are placed at the SAI LAG *membership* boundaries only:

| Site | Action |
| --- | --- |
| `vpp_create_lag_member()`, after the promiscuous re-apply | disable IPv6 |
| `removeLagMember()`, next to `restorePortTapMac()` | re-enable IPv6 |

Two deliberate placement decisions:

- The re-enable lives in `removeLagMember()` rather than `vpp_remove_lag_member()`, because the latter is skipped for an egress-disabled member (it is already detached from the bond). Placing it in `removeLagMember()` covers both paths.
- `vpp_set_lag_member_egress_disable()` is **untouched**. It only toggles bond membership for egress distribution; the port remains a SAI LAG member throughout, so IPv6 correctly stays disabled across detach/re-attach.

**FDB LAG resolution**

`resolvePortIdFromSwIfIndex()` now falls back to a scan of `m_lag_bond_map` when the hwif→hostif lookup misses, matching on `platform_bond_info_t::sw_if_index` and returning the LAG OID. That OID is exactly what `SAI_BRIDGE_PORT_ATTR_PORT_ID` holds for a PortChannel bridge port, which is what `findBridgeVlanForPortVlan()` matches on. Results are cached in `m_swif_to_port_id` as before, so the scan happens at most once per `sw_if_index`. Also clarified the `hwif_to_tap_name()` comment to list LAGs as an expected unmapped-hwif case.

Files touched:

- `vslib/vpp/SwitchVpp.h`
- `vslib/vpp/SwitchVppFdb.cpp`
- `vslib/vpp/SwitchVppHostif.cpp` (comment only)

#### How did you verify/test it?

IPv6 behaviour:

```bash
# Before adding to PortChannel: member has a link-local
vppctl show ip6 interface <member-hwif>

sudo config portchannel member add PortChannel101 Ethernet0

# Expect: no link-local / ip6 not enabled on the member; BondEthernet<N> owns L3
vppctl show ip6 interface <member-hwif>
vppctl show interface addr

# Egress-disable must NOT re-enable ipv6 on the member
vppctl show ip6 interface <member-hwif>   # still disabled
vppctl show bond details                  # member detached from active members

sudo config portchannel member del PortChannel101 Ethernet0

# Expect: link-local restored on the member
vppctl show ip6 interface <member-hwif>
```

Syslog should show `Disabled IPv6 on LAG member <hwif>` on add and `Enabled IPv6 on LAG member <hwif>` on delete, and nothing on egress-disable transitions.

FDB behaviour:

```bash
# Send traffic from a source MAC over PortChannel101, then:
show mac
vppctl show l2fdb all
```

Expect the learned MAC to appear against `PortChannel101`, plus a syslog line `FDB: resolved sw_if_index <N> to LAG <oid> (bond <id>)`.

Regression checks: L2 and L3 forwarding over the PortChannel, PortChannel sub-interfaces, LACP convergence via teamd over the member LCP taps, and member add/remove/re-add cycles.

In addition to the manual inspection, the change is validated by pc/test_lag_member_forwarding.py and pc/test_lag_member.py. The former validates egress disable and latter Mac learning over portchannel member interface.
#### Any platform specific information?

VPP platform only. All changes are confined to `vslib/vpp/`; no other ASIC vendor or the generic vslib path is affected. Requires a VPP build with `sw_interface_ip6_enable_disable` and the bonding plugin, both already used by this vslib.

### Documentation

No documentation or Wiki update required — this is a bug fix with no user-facing configuration or API change.