### PR TITLE
[ci][DO-NOT-MERGE]: Validate sonic-swss #4821 reusable CI interfaces

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,6 @@ stages:
       sairedis_current_run: true
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs
-      debian_version: ${{ parameters.debian_version }}
       debug_pkg: libsairedis-dbgsym
       include_gcov: false
       include_vpp: true
@@ -176,7 +175,6 @@ stages:
       sairedis_current_run: true
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs-asan
-      debian_version: ${{ parameters.debian_version }}
       debug_pkg: libsairedis-dbgsym
       include_gcov: false
       include_vpp: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,7 +161,6 @@ stages:
       debug_pkg: libsairedis-dbgsym
       include_gcov: false
       include_vpp: true
-      include_nexthopgroup: true
 
 - stage: BuildDockerAsan
   dependsOn:
@@ -181,7 +180,6 @@ stages:
       debug_pkg: libsairedis-dbgsym
       include_gcov: false
       include_vpp: true
-      include_nexthopgroup: true
       asan: true
 
 - stage: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,9 @@ resources:
     type: github
     name: sonic-net/sonic-swss
     endpoint: sonic-net
+    # Validation-only: consume the exact SWSS PR merge ref and its reusable
+    # Build/Docker/VS-test templates. Revert to master before any real merge.
+    ref: refs/pull/4821/merge
 
 parameters:
   - name: debian_version
@@ -130,28 +133,35 @@ stages:
   dependsOn: Build
   condition: succeeded('Build')
   jobs:
-  - template: .azure-pipelines/build-swss-template.yml
+  - template: .azure-pipelines/build-template.yml@sonic-swss
     parameters:
+      repo: sonic-swss
       arch: amd64
       timeout: 90
       pool: sonicso1ES-amd64
-      swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
-      sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
-      syslog_artifact_name: sonic-swss.syslog
       artifact_name: sonic-swss-${{ parameters.debian_version }}
       debian_version: ${{ parameters.debian_version }}
+      staged_upstreams:
+        - artifact: sonic-sairedis-${{ parameters.debian_version }}
+          name: sonic-sairedis
 
 - stage: BuildDocker
   dependsOn: BuildSwss
   condition: succeeded('BuildSwss')
   jobs:
-  - template: .azure-pipelines/build-docker-sonic-vs-template.yml
+  - template: .azure-pipelines/build-docker-sonic-vs-template.yml@sonic-swss
     parameters:
+      repo: sonic-swss
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
+      sairedis_current_run: true
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs
       debian_version: ${{ parameters.debian_version }}
+      debug_pkg: libsairedis-dbgsym
+      include_gcov: false
+      include_vpp: true
+      include_nexthopgroup: true
 
 - stage: BuildDockerAsan
   dependsOn:
@@ -159,21 +169,29 @@ stages:
     - BuildSwss
   condition: and(succeeded('BuildAsan'), succeeded('BuildSwss'))
   jobs:
-  - template: .azure-pipelines/build-docker-sonic-vs-template.yml
+  - template: .azure-pipelines/build-docker-sonic-vs-template.yml@sonic-swss
     parameters:
+      repo: sonic-swss
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       sairedis_artifact_name: sonic-sairedis-asan-${{ parameters.debian_version }}
+      sairedis_current_run: true
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs-asan
       debian_version: ${{ parameters.debian_version }}
+      debug_pkg: libsairedis-dbgsym
+      include_gcov: false
+      include_vpp: true
+      include_nexthopgroup: true
       asan: true
 
 - stage: Test
   dependsOn: BuildDocker
   condition: succeeded('BuildDocker')
   jobs:
-  - template: .azure-pipelines/test-docker-sonic-vs-template.yml
+  - template: .azure-pipelines/test-docker-sonic-vs-template.yml@sonic-swss
     parameters:
+      repo: sonic-swss
+      timeout: 360
       log_artifact_name: log
       debian_version: ${{ parameters.debian_version }}
 
@@ -181,9 +199,12 @@ stages:
   dependsOn: BuildDockerAsan
   condition: succeeded('BuildDockerAsan')
   jobs:
-  - template: .azure-pipelines/test-docker-sonic-vs-template.yml
+  - template: .azure-pipelines/test-docker-sonic-vs-template.yml@sonic-swss
     parameters:
+      repo: sonic-swss
+      timeout: 360
       docker_sonic_vs_name: docker-sonic-vs-asan
       log_artifact_name: log-asan
       asan: true
+      continue_on_error: true
       debian_version: ${{ parameters.debian_version }}


### PR DESCRIPTION
## DO NOT MERGE — downstream validation only

Validate that sonic-swss PR [#4821](https://github.com/sonic-net/sonic-swss/pull/4821)
contains every reusable interface needed by sonic-sairedis CI.

SWSS PR build [`1203769`](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1203769)
is green across all required checks (Build/ASAN, ARM, Trixie, Docker/ASAN,
normal VS, TestAsan, coverage and analysis). The Azure run is
`partiallySucceeded` only because the ASAN test command exited under its
intentional `continueOnError` policy; the TestAsan check is SUCCESS.

### What this validation consumes

The `sonic-swss` GitHub repository resource is pinned to
`refs/pull/4821/merge`, so Azure compiles and executes the exact templates/code
under review rather than sonic-swss master.

### End-to-end downstream paths exercised

- **BuildSwss** references `build-template.yml@sonic-swss`, checks out the SWSS
  PR merge ref, stages this sairedis run's newly built artifact as required
  `sonic-sairedis`, and builds/publishes SWSS inside the sairedis pipeline.
- **BuildDocker / BuildDockerAsan** reference the SWSS PR's generalized
  `build-docker-sonic-vs-template.yml`, consume this run's sairedis/SWSS
  artifacts, and opt into the sairedis-specific debug package and VPP behavior
  (without SWSS gcov payloads). libnexthopgroup remains provided by the base
  docker-sonic-vs image.
- **Test / TestAsan** reference the SWSS PR's generalized
  `test-docker-sonic-vs-template.yml` and run the sairedis normal/ASAN VS paths
  using the docker images produced above.

This is stronger than merely downloading a prebuilt SWSS package: it verifies
that the SWSS PR's source, template contracts, same-run staging, produced
artifacts, docker image construction, and test execution all work from a real
downstream consumer pipeline.

### Result

Azure build [`1205700`](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1205700) passed every required check after removing redundant nexthopgroup download/reinstallation. The reused SWSS PR templates successfully staged current-run sairedis, built/published SWSS, built normal/ASAN docker-sonic-vs images using the base image's nexthopgroup package, and ran normal/ASAN VS tests. The overall Azure result is `partiallySucceeded` only from sairedis BuildTrixie auto diff-coverage metadata warnings; all GitHub/Azure checks are SUCCESS.

### Validation-only pin

The `refs/pull/4821/merge` resource pin must not merge. Once #4821 lands, the
real sairedis migration will reference sonic-swss master and remove the local
copies in a separate production PR.


