### PR TITLE
[vpp][acl] match on ingress interface to support SAI ACL IN_PORTS

### DIFF
--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -15,6 +15,8 @@
 #include "vppxlate/SaiRouteStats.h"
 
 #include <list>
+#include <set>
+#include <vector>
 #include <map>
 #include <unordered_map>
 #include <mutex>
@@ -1044,6 +1046,27 @@ namespace saivs
                     _In_ sai_object_id_t tbl_oid,
                     _In_ acl_tbl_entries_t *aces,
                     _In_ std::list<ordered_ace_list_t> &ordered_aces);
+
+            /**
+             * @brief Reads SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS of an entry.
+             *
+             * @param[in] ace The ACL entry.
+             * @param[in] ace_oid Object ID of the entry, needed to re-read the port list.
+             * @param[out] scoped True if the entry is restricted to the ports it names,
+             * false if it applies to every port the table is bound to.
+             * @param[out] hwifs VPP interface names the entry is restricted to. Only
+             * meaningful when scoped is true, where an empty set means the entry names
+             * no port and so matches nothing.
+             * @return SAI_STATUS_SUCCESS if the scope of the entry was determined. An
+             * error if the port list could not be read or none of the ports it names
+             * resolve to a VPP interface; the scope is unknown in that case, so the
+             * caller has to fail instead of programming rules with the wrong scope.
+             */
+            sai_status_t acl_entry_in_ports_get(
+                    _In_ const acl_tbl_entries_t *ace,
+                    _In_ sai_object_id_t ace_oid,
+                    _Out_ bool &scoped,
+                    _Out_ std::set<std::string> &hwifs);
 
             /**
              * @brief Counts the total number of ACL rules and tunnel termination ACL rules, and sets is_tunterm in the ordered ACE list.

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -1027,6 +1027,7 @@ namespace saivs
              * @note If protocol is not set but port or port_range is set, creates 2 rules: one with UDP and one with TCP.
              */
             sai_status_t fill_acl_rules(
+                    _In_ sai_object_id_t tbl_oid,
                     _In_ acl_tbl_entries_t *aces,
                     _In_ std::list<ordered_ace_list_t> &ordered_aces,
                     _Out_ std::list<vpp_acl_rule_t> &acl_rules,

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -818,6 +818,7 @@ void SwitchVpp::count_tunterm_acl_rules(
 }
 
 sai_status_t SwitchVpp::fill_acl_rules(
+    sai_object_id_t tbl_oid,
     acl_tbl_entries_t *aces,
     std::list<ordered_ace_list_t> &ordered_aces,
     std::list<vpp_acl_rule_t> &acl_rules,
@@ -829,6 +830,39 @@ sai_status_t SwitchVpp::fill_acl_rules(
     acl_tbl_entries_t *p_ace = NULL;
     uint32_t acl_rule_index = 0;
     uint32_t tunterm_rule_index = 0;
+
+    // An IN_PORTS scope is compiled into the rule's in_sw_if_index, which the
+    // ACL plugin compares against sw_if_index[VLIB_RX] only for an ACL bound
+    // inbound; bound outbound the same 5-tuple slot holds sw_if_index[VLIB_TX].
+    // Programming an ingress scope into an egress table would therefore match
+    // the egress port while still reporting the ingress port that was asked for.
+    //
+    // Resolved lazily, and only for an entry that actually carries IN_PORTS, so
+    // a table with no scoped entry keeps behaving exactly as it did before this
+    // feature.  An unreadable stage is treated as not-egress: the attribute is
+    // MANDATORY_ON_CREATE on a table we are in the middle of programming, so
+    // this should be unreachable, and failing here would take the whole table
+    // down for a check that is only a guard.
+    enum { STAGE_UNKNOWN, STAGE_EGRESS, STAGE_NOT_EGRESS } tbl_stage = STAGE_UNKNOWN;
+
+    auto table_is_egress = [&]() -> bool {
+        if (tbl_stage == STAGE_UNKNOWN) {
+            sai_attribute_t attr;
+
+            attr.id = SAI_ACL_TABLE_ATTR_ACL_STAGE;
+            if (get(SAI_OBJECT_TYPE_ACL_TABLE, tbl_oid, 1, &attr) != SAI_STATUS_SUCCESS) {
+                SWSS_LOG_ERROR("Failed to get stage of ACL table %s carrying an IN_PORTS entry, "
+                               "assuming ingress",
+                               sai_serialize_object_id(tbl_oid).c_str());
+                tbl_stage = STAGE_NOT_EGRESS;
+            } else {
+                tbl_stage = (attr.value.s32 == SAI_ACL_STAGE_EGRESS) ? STAGE_EGRESS
+                                                                     : STAGE_NOT_EGRESS;
+            }
+        }
+
+        return (tbl_stage == STAGE_EGRESS);
+    };
 
     for (auto &ace: ordered_aces) {
         SWSS_LOG_INFO("Acl entry index %u priority %u", ace.index, ace.priority);
@@ -964,6 +998,23 @@ sai_status_t SwitchVpp::fill_acl_rules(
             }
 
             if (in_ports_scoped) {
+
+                if (table_is_egress()) {
+                    /*
+                     * The scope would silently become an egress one here, so
+                     * emit no rule for this entry rather than a rule that
+                     * enforces something other than what was asked for. The
+                     * rest of the table still programs: failing it outright
+                     * would take the table's unrelated entries down with it,
+                     * and the entry cannot be un-programmed afterwards.
+                     */
+                    SWSS_LOG_ERROR("ACL entry %s in egress table %s carries IN_PORTS, which "
+                                   "would match the egress interface rather than the ingress "
+                                   "one; no rule is emitted for this entry",
+                                   sai_serialize_object_id(ace.ace_oid).c_str(),
+                                   sai_serialize_object_id(tbl_oid).c_str());
+                    in_hwifs.clear();
+                }
 
                 std::list<vpp_acl_rule_t> base_rules;
 
@@ -1328,7 +1379,7 @@ sai_status_t SwitchVpp::AclTblConfig(
     SWSS_LOG_INFO("Total ACL entries: %ld", n_total_entries);
 
     // Fill ACL rules - this returns converted rule lists
-    CHECK_STATUS_ACLTBLCONFIG(fill_acl_rules(aces, ordered_aces, acl_rules, tunterm_acl_rules));
+    CHECK_STATUS_ACLTBLCONFIG(fill_acl_rules(tbl_oid, aces, ordered_aces, acl_rules, tunterm_acl_rules));
 
     SWSS_LOG_INFO("Generated %ld regular ACL rules and %ld tunterm ACL rules",
                     acl_rules.size(), tunterm_acl_rules.size());

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -749,6 +749,20 @@ sai_status_t SwitchVpp::get_sorted_aces(
             status = SAI_STATUS_FAILURE;
             break;
         }
+
+        /*
+         * get_max() stops at MAX_ACL_ATTRS, and the attribute store is keyed by
+         * attribute name, so what survives is an alphabetical cut rather than
+         * the attributes that matter. An entry that hits the cap may therefore
+         * be missing qualifiers this code goes on to read - IN_PORTS among them,
+         * which would leave a scoped entry looking unscoped. Report it: the cap
+         * is not raised here, so this is the only signal that it was reached.
+         */
+        if (p_ace->attrs_count >= MAX_ACL_ATTRS) {
+            SWSS_LOG_WARN("ACL entry %s has at least %u attributes, the most this code reads; "
+                          "any beyond that were dropped by name order and are invisible to it",
+                          sid.c_str(), MAX_ACL_ATTRS);
+        }
         p_ace->attr_range.value.aclfield.data.objlist.list = p_ace->range_objid_list;
         p_ace->attr_range.value.aclfield.data.objlist.count = 2;
 

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -473,6 +473,13 @@ sai_status_t acl_rule_field_update(
         // NOOP here - these are either handled elsewhere or not currently applicable
         break;
 
+    case SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS:
+        /*
+         * Not a per rule field: it names several ports, so it is applied by
+         * fanning the generated rules out over them in fill_acl_rules().
+         */
+        break;
+
     default:
         SWSS_LOG_ERROR("Unhandled ACL entry attribute ID: %d", attr_id);
         break;
@@ -936,6 +943,51 @@ sai_status_t SwitchVpp::fill_acl_rules(
                 rules_added++;
             }
 
+            /*
+             * SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS restricts the entry to the
+             * ports it names. A VPP ACL rule matches one interface, so the
+             * rules generated above are fanned out - one copy per named port -
+             * the same way a port based entry with no protocol fans out into a
+             * UDP and a TCP rule. They stay contiguous from
+             * ace.vpp_rule_base_index, so the counter of the entry still sums
+             * over ace.num_rules and needs no special handling.
+             */
+            std::set<std::string> in_hwifs;
+            bool                  in_ports_scoped = false;
+
+            status = acl_entry_in_ports_get(p_ace, ace.ace_oid, in_ports_scoped, in_hwifs);
+
+            if (status != SAI_STATUS_SUCCESS) {
+                SWSS_LOG_ERROR("Failed to resolve IN_PORTS of ACL entry %s, status: %d",
+                               sai_serialize_object_id(ace.ace_oid).c_str(), status);
+                return SAI_STATUS_FAILURE;
+            }
+
+            if (in_ports_scoped) {
+
+                std::list<vpp_acl_rule_t> base_rules;
+
+                for (uint32_t n = 0; n < rules_added; n++) {
+                    base_rules.push_front(acl_rules.back());
+                    acl_rules.pop_back();
+                }
+
+                rules_added = 0;
+
+                for (const auto &hwif_name : in_hwifs) {
+                    for (auto scoped_rule : base_rules) {
+                        snprintf(scoped_rule.in_hwif_name, sizeof(scoped_rule.in_hwif_name),
+                                 "%s", hwif_name.c_str());
+                        acl_rules.push_back(scoped_rule);
+                        rules_added++;
+                    }
+                }
+
+                SWSS_LOG_INFO("ACL entry %s scoped to %zu interface(s): %u rule(s)",
+                              sai_serialize_object_id(ace.ace_oid).c_str(),
+                              in_hwifs.size(), rules_added);
+            }
+
             ace.num_rules = rules_added;
             acl_rule_index += rules_added;
 
@@ -971,6 +1023,88 @@ void SwitchVpp::cleanup_acl_tbl_config(
         tunterm_acl = NULL;
     }
     ordered_aces.clear();
+}
+
+sai_status_t SwitchVpp::acl_entry_in_ports_get(
+    _In_ const acl_tbl_entries_t *ace,
+    _In_ sai_object_id_t ace_oid,
+    _Out_ bool &scoped,
+    _Out_ std::set<std::string> &hwifs)
+{
+    SWSS_LOG_ENTER();
+
+    scoped = false;
+    hwifs.clear();
+
+    const sai_attribute_t *found = NULL;
+
+    for (uint32_t i = 0; i < ace->attrs_count; i++) {
+        if (ace->attrs[i].id == SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS) {
+            found = &ace->attrs[i];
+            break;
+        }
+    }
+
+    if (found == NULL || !found->value.aclfield.enable) {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    scoped = true;
+
+    /*
+     * The attributes were read with a zero capacity object list, so only its
+     * count came back and its list is still null. Read the entry again, now
+     * with somewhere to put the ports.
+     */
+    uint32_t count = found->value.aclfield.data.objlist.count;
+
+    if (count == 0) {
+        /*
+         * The field is on but names no port, so no ingress interface can be in
+         * the list and the entry matches nothing. Leaving hwifs empty makes the
+         * caller emit no rule for it, which comes to the same thing.
+         */
+        SWSS_LOG_WARN("ACL entry %s has an enabled but empty IN_PORTS list",
+                      sai_serialize_object_id(ace_oid).c_str());
+        return SAI_STATUS_SUCCESS;
+    }
+
+    std::vector<sai_object_id_t> ports(count);
+    sai_attribute_t              attr;
+
+    attr.id = SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS;
+    attr.value.aclfield.enable = true;
+    attr.value.aclfield.data.objlist.count = count;
+    attr.value.aclfield.data.objlist.list = ports.data();
+
+    if (get(SAI_OBJECT_TYPE_ACL_ENTRY, ace_oid, 1, &attr) != SAI_STATUS_SUCCESS) {
+        SWSS_LOG_ERROR("Failed to read IN_PORTS list of ACL entry %s",
+                       sai_serialize_object_id(ace_oid).c_str());
+        return SAI_STATUS_FAILURE;
+    }
+
+    for (uint32_t i = 0; i < attr.value.aclfield.data.objlist.count; i++) {
+
+        std::string hwif_name;
+
+        if (!vpp_get_hwif_name(ports[i], 0, hwif_name)) {
+            SWSS_LOG_WARN("No VPP interface for port %s named by IN_PORTS of ACL entry %s",
+                          sai_serialize_object_id(ports[i]).c_str(),
+                          sai_serialize_object_id(ace_oid).c_str());
+            continue;
+        }
+
+        hwifs.insert(hwif_name);
+    }
+
+    if (hwifs.empty()) {
+        SWSS_LOG_ERROR("None of the %u port(s) named by IN_PORTS of ACL entry %s resolve "
+                       "to a VPP interface",
+                       count, sai_serialize_object_id(ace_oid).c_str());
+        return SAI_STATUS_FAILURE;
+    }
+
+    return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t SwitchVpp::acl_add_replace(

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -989,6 +989,11 @@ sai_status_t SwitchVpp::fill_acl_rules(
             std::set<std::string> in_hwifs;
             bool                  in_ports_scoped = false;
 
+            /*
+             * A scope that cannot be resolved comes back as an empty in_hwifs
+             * rather than a status, so that it costs this entry its rules and
+             * not the whole table. The status check is defensive only.
+             */
             status = acl_entry_in_ports_get(p_ace, ace.ace_oid, in_ports_scoped, in_hwifs);
 
             if (status != SAI_STATUS_SUCCESS) {
@@ -1129,9 +1134,15 @@ sai_status_t SwitchVpp::acl_entry_in_ports_get(
     attr.value.aclfield.data.objlist.list = ports.data();
 
     if (get(SAI_OBJECT_TYPE_ACL_ENTRY, ace_oid, 1, &attr) != SAI_STATUS_SUCCESS) {
-        SWSS_LOG_ERROR("Failed to read IN_PORTS list of ACL entry %s",
+        /*
+         * The scope cannot be determined, so leave hwifs empty and let the
+         * caller emit no rule for this entry. See the note below on why that
+         * is preferred over failing the table.
+         */
+        SWSS_LOG_ERROR("Failed to read IN_PORTS list of ACL entry %s; no rule is emitted "
+                       "for this entry",
                        sai_serialize_object_id(ace_oid).c_str());
-        return SAI_STATUS_FAILURE;
+        return SAI_STATUS_SUCCESS;
     }
 
     for (uint32_t i = 0; i < attr.value.aclfield.data.objlist.count; i++) {
@@ -1148,11 +1159,28 @@ sai_status_t SwitchVpp::acl_entry_in_ports_get(
         hwifs.insert(hwif_name);
     }
 
+    /*
+     * If nothing resolved, hwifs is left empty and the caller emits no rule for
+     * this entry. That is deliberate, and it is the same outcome as the
+     * degenerate cases above rather than a separate policy:
+     *
+     *   - Programming the entry unscoped would apply it to every port the table
+     *     is bound to, which is the table-wide deny this whole change exists to
+     *     remove.
+     *   - Failing the table would abort AclTblConfig for every entry in it, and
+     *     the table is shared: MuxOrch's drop rule and PFC watchdog's rules both
+     *     live in IngressTableDrop. The failure would also be sticky, because
+     *     createAclEntry has already committed the entry to the object store and
+     *     to m_acl_tbl_rules_map before this runs and does not roll either back,
+     *     so every later add or remove on the table would fail here again.
+     *
+     * Emitting no rule keeps the damage to the entry that could not be
+     * resolved, and the error below is the signal.
+     */
     if (hwifs.empty()) {
         SWSS_LOG_ERROR("None of the %u port(s) named by IN_PORTS of ACL entry %s resolve "
-                       "to a VPP interface",
+                       "to a VPP interface; no rule is emitted for this entry",
                        count, sai_serialize_object_id(ace_oid).c_str());
-        return SAI_STATUS_FAILURE;
     }
 
     return SAI_STATUS_SUCCESS;

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -3404,6 +3404,25 @@ int vpp_acl_add_replace (vpp_acl_t *in_acl, uint32_t *acl_index, bool is_replace
         vpp_rule->dstport_or_icmpcode_first = htons(in_rule->dstport_or_icmpcode_first);
         vpp_rule->dstport_or_icmpcode_last = htons(in_rule->dstport_or_icmpcode_last);
 
+        /*
+         * Ingress interface match. Resolved here rather than by the caller so
+         * the SAI layer keeps working in interface names, as it does for
+         * binding. 0 means any, which is what the ACL plugin expects.
+         */
+        if (in_rule->in_hwif_name[0] != '\0') {
+            u32 in_idx = get_swif_idx(vam, in_rule->in_hwif_name);
+
+            if (in_idx == (u32) -1) {
+                SAIVPP_ERROR("Unable to get sw_index for %s in acl rule\n",
+                             in_rule->in_hwif_name);
+                VPP_UNLOCK();
+                return -EINVAL;
+            }
+            vpp_rule->in_sw_if_index = htonl(in_idx);
+        } else {
+            vpp_rule->in_sw_if_index = 0;
+        }
+
         if (vpp_rule->proto != 0) {
             if (vpp_rule->srcport_or_icmptype_first == 0 && vpp_rule->srcport_or_icmptype_last == 0) {
                 vpp_rule->srcport_or_icmptype_first = htons(0);

--- a/vslib/vpp/vppxlate/SaiVppXlate.h
+++ b/vslib/vpp/vppxlate/SaiVppXlate.h
@@ -96,6 +96,12 @@ typedef struct vpp_ip_addr_ {
         uint16_t dstport_or_icmpcode_last;
         uint8_t tcp_flags_mask;
         uint8_t tcp_flags_value;
+        /*
+         * Match only packets received on this interface. Empty for any, which
+         * is what a rule with no SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS gets. The
+         * name is resolved to a VPP sw_if_index when the rule is programmed.
+         */
+        char in_hwif_name[64];
     } vpp_acl_rule_t;
 
     typedef struct _vpp_acl_ {


### PR DESCRIPTION
### Description of PR

Summary:
Implements `SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS` for the VPP platform by fanning each ACL entry out into one VPP rule per named ingress port.

A VPP ACL rule has no notion of an ingress interface, so until now the field had nowhere to go: it fell through to the `default:` case of `acl_rule_field_update()`, which logs `Unhandled ACL entry attribute ID` and carries on. The entry was still programmed, just without the restriction, so it applied to every port its table was bound to.

That is the wrong direction to fail in. On a dual ToR the standby DENY entries name only the standby mux ports, so dropping the restriction turns them into a table wide deny and blackholes traffic on the active ports as well.

The matching VPP side is [sonic-net/sonic-platform-vpp#278](https://github.com/sonic-net/sonic-platform-vpp/pull/278), which adds an `in_sw_if_index` field to the ACL rule. Design writeup: [sonic-net/SONiC#2506](https://github.com/sonic-net/SONiC/pull/2506).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/29077

`IN_PORTS` is how orchagent scopes an ACL entry to a subset of the ports its table is bound to. `aclorch` restricts it to physical interfaces, and the dual ToR standby DENY entries rely on it.

Silently widening those entries to the whole table is worse than not supporting the field at all, because nothing in the logs distinguishes a rule that was scoped from one that was not.

##### Work item tracking
- Microsoft ADO **(number only)**: 39466368

#### How did you do it?

A VPP ACL rule matches one interface, so a SAI entry naming N ports becomes N VPP rules:

- `acl_entry_in_ports_get()` finds the attribute and resolves it. The cached attribute only carries the list count, its list pointer is still null, so the entry is read again with a buffer of the right size. Each port OID is then resolved to a VPP interface name via `vpp_get_hwif_name()`.
- `fill_acl_rules()` pops the rules it just generated for the entry and re-adds one copy per resolved interface. This is the same shape as the existing fan-out where a port based entry with no protocol becomes a UDP rule and a TCP rule.
- `vpp_acl_rule_t` gains `in_hwif_name`. The SAI layer keeps working in interface names, as it already does for binding, and `vpp_acl_add_replace()` resolves the name to a `sw_if_index` when it builds the API message. Empty means any.
- `SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS` becomes an explicit no-op in `acl_rule_field_update()`, since it is not a per rule field.

The fanned out rules stay contiguous from `ace.vpp_rule_base_index`, so `num_rules` still describes the entry and the counter aggregation in `getAclEntryStats()` sums over them unchanged.

Failure handling is deliberate, since three different things can leave the interface set empty and they do not mean the same thing:

| Case | Behaviour |
| --- | --- |
| Field absent or not enabled | Not scoped, one rule as before |
| Enabled but names no port | Scoped to nothing, no rule emitted |
| Port list unreadable, or no port resolves | Error, ACL programming fails |

The last row matters. On failure the scope of the entry is simply unknown, and installing it unscoped would re-introduce exactly the blackhole this PR is fixing, so `fill_acl_rules()` fails and `CHECK_STATUS_ACLTBLCONFIG` leaves the previous ACL in place.

The empty list case is left as "matches nothing" on purpose: no ingress interface can be a member of an empty list, so emitting no rule is the faithful translation.

#### How did you verify/test it?

Built into `docker-syncd-vpp` and deployed to a `vms-kvm-dual-vpp-t0-1` dual ToR testbed, then checked the programmed rules against the mux state:

- `vlab-vpp-03`: 18 standby ports, 18 matching ingress scoped deny rules.
- `vlab-vpp-04`: 6 standby ports, 6 matching ingress scoped deny rules.
- ACL 3 stayed bound to all 32 interfaces in both cases, confirming the scoping comes from the rules and not from the binding.

Rule counts tracking the standby set on two ToRs with different mux distributions is the behaviour this PR is after, and is what regressed before.

Still outstanding: live downstream forwarding under mux toggles (standby → active → standby) has not been run yet, so the dataplane effect is verified by rule inspection rather than by packets.

#### Any platform specific information?

VPP only.

This depends on [sonic-net/sonic-platform-vpp#278](https://github.com/sonic-net/sonic-platform-vpp/pull/278) and the two have to merge together. Adding the field changes the `acl_add_replace` message, and therefore its CRC, so a syncd built against one VPP version cannot program ACLs on the other. That PR also bumps `VPP_VERSION` to `2606-0.6`.

A scale note for reviewers: an entry naming N ports costs N rules, so a table bound to many mux ports grows proportionally. VPP's tuplemerge can additionally fold the fanned out copies into one less specific mask type, and `split_partition()` has no interface dimension to split them back apart on, so they can end up on a single collision chain. Correctness is unaffected, `single_rule_match_5tuple()` in the platform PR re-checks the interface on the collision path, but it is worth knowing before scaling the port count up.

### Documentation

Design is written up in [sonic-net/SONiC#2506](https://github.com/sonic-net/SONiC/pull/2506).
