### PR TITLE
[syncd] Optimize APPLY_VIEW warm-restart reconciliation with identity-based indexing [28787]

### DIFF
--- a/syncd/AsicView.cpp
+++ b/syncd/AsicView.cpp
@@ -9,12 +9,16 @@
 #include <inttypes.h>
 
 #include <algorithm>
+#include <sstream>
+#include <unordered_set>
+#include <vector>
 
 using namespace syncd;
 using namespace saimeta;
 
 AsicView::AsicView():
-    m_asicOperationId(0)
+    m_asicOperationId(0),
+    m_nhgMemberIndexBuilt(false)
 {
     SWSS_LOG_ENTER();
 
@@ -23,7 +27,8 @@ AsicView::AsicView():
 
 AsicView::AsicView(
         _In_ const swss::TableDump &dump):
-    m_asicOperationId(0)
+    m_asicOperationId(0),
+    m_nhgMemberIndexBuilt(false)
 {
     SWSS_LOG_ENTER();
 
@@ -1338,4 +1343,287 @@ sai_object_id_t AsicView::getSwitchVid() const
     }
 
     SWSS_LOG_THROW("no SWITCH present in ASIC view, FATAL");
+}
+
+bool AsicView::isAttrIncludedInIdentityKey(
+        _In_ const sai_attr_metadata_t *meta)
+{
+    SWSS_LOG_ENTER();
+
+    if (meta == nullptr)
+    {
+        return false;
+    }
+
+    if (SAI_HAS_FLAG_READ_ONLY(meta->flags))
+    {
+        return false;
+    }
+
+    if (meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_OBJECT_LIST)
+    {
+        return false;
+    }
+
+    /*
+     * NEXT_HOP_ID on a group member is CREATE_AND_SET, but comparison logic
+     * treats the next-hop RID as identity. Members that only share a group
+     * must not be paired. Include it so a CREATE_ONLY-only key (group id)
+     * cannot uniquely match the wrong member.
+     */
+    if (meta->objecttype == SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER &&
+        meta->attrid == SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID)
+    {
+        return true;
+    }
+
+    /*
+     * Identity keys must use CREATE_ONLY attributes. CREATE_AND_SET values can
+     * be updated in place, so including them would match the object whose
+     * current value happens to be equal instead of the object the graph
+     * heuristics would select (for example ACL table groups bound to a port).
+     */
+    if (!SAI_HAS_FLAG_CREATE_ONLY(meta->flags))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+std::string AsicView::computeCreateOnlyKey(
+        _In_ const std::shared_ptr<const SaiObj> &obj,
+        _In_ const ObjectIdMap &vidToRid,
+        _In_ const std::set<sai_attr_id_t> *attrFilter)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<sai_attr_id_t> attrIds;
+
+    for (const auto &kvp: obj->getAllAttributes())
+    {
+        attrIds.push_back(kvp.first);
+    }
+
+    std::sort(attrIds.begin(), attrIds.end());
+
+    std::ostringstream key;
+
+    for (sai_attr_id_t attrId: attrIds)
+    {
+        if (attrFilter != nullptr && attrFilter->find(attrId) == attrFilter->end())
+        {
+            continue;
+        }
+
+        const auto attrIt = obj->getAllAttributes().find(attrId);
+
+        if (attrIt == obj->getAllAttributes().end())
+        {
+            continue;
+        }
+
+        const auto &attr = attrIt->second;
+
+        const sai_attr_metadata_t *meta = attr->getAttrMetadata();
+
+        if (!isAttrIncludedInIdentityKey(meta))
+        {
+            continue;
+        }
+
+        if (key.tellp() > 0)
+        {
+            key << ";";
+        }
+
+        key << attr->getStrAttrId() << "=";
+
+        if (meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_OBJECT_ID ||
+            (meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID &&
+             attr->getSaiAttr()->value.aclaction.enable))
+        {
+            sai_object_id_t vid = attr->getOid();
+
+            if (vid == SAI_NULL_OBJECT_ID)
+            {
+                key << sai_serialize_object_id(SAI_NULL_OBJECT_ID);
+                continue;
+            }
+
+            auto it = vidToRid.find(vid);
+
+            if (it == vidToRid.end())
+            {
+                return "";
+            }
+
+            key << sai_serialize_object_id(it->second);
+        }
+        else
+        {
+            key << attr->getStrAttrValue();
+        }
+    }
+
+    return key.str();
+}
+
+std::string AsicView::computeNhgMemberKey(
+        _In_ sai_object_id_t nhgVid,
+        _In_ const ObjectIdMap &vidToRid) const
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<sai_object_id_t> nhRids;
+
+    for (const auto &member: getObjectsByObjectType(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER))
+    {
+        if (!member->hasAttr(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID))
+        {
+            continue;
+        }
+
+        if (member->getSaiAttr(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID)->getOid() != nhgVid)
+        {
+            continue;
+        }
+
+        if (!member->hasAttr(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID))
+        {
+            return "";
+        }
+
+        sai_object_id_t nhVid = member->getSaiAttr(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID)->getOid();
+
+        auto it = vidToRid.find(nhVid);
+
+        if (it == vidToRid.end())
+        {
+            return "";
+        }
+
+        nhRids.push_back(it->second);
+    }
+
+    if (nhRids.empty())
+    {
+        return "";
+    }
+
+    std::sort(nhRids.begin(), nhRids.end());
+
+    std::ostringstream key;
+
+    for (size_t i = 0; i < nhRids.size(); i++)
+    {
+        if (i > 0)
+        {
+            key << ";";
+        }
+
+        key << sai_serialize_object_id(nhRids.at(i));
+    }
+
+    return key.str();
+}
+
+std::string AsicView::attrFilterCacheKey(
+        _In_ sai_object_type_t objectType,
+        _In_ const std::set<sai_attr_id_t> &attrFilter)
+{
+    SWSS_LOG_ENTER();
+
+    std::ostringstream oss;
+
+    oss << objectType << ":";
+
+    for (sai_attr_id_t id: attrFilter)
+    {
+        oss << id << ",";
+    }
+
+    return oss.str();
+}
+
+const std::unordered_map<std::string, std::shared_ptr<SaiObj>>* AsicView::getCreateOnlyIndex(
+        _In_ sai_object_type_t objectType,
+        _In_ const std::set<sai_attr_id_t> &attrFilter) const
+{
+    SWSS_LOG_ENTER();
+
+    const std::string cacheKey = attrFilterCacheKey(objectType, attrFilter);
+
+    auto cacheIt = m_createOnlyIndexCache.find(cacheKey);
+
+    if (cacheIt != m_createOnlyIndexCache.end())
+    {
+        return &cacheIt->second;
+    }
+
+    std::unordered_map<std::string, std::shared_ptr<SaiObj>> index;
+    std::unordered_set<std::string> duplicateKeys;
+
+    for (const auto &obj: getNotProcessedObjectsByObjectType(objectType))
+    {
+        const std::string key = computeCreateOnlyKey(obj, m_vidToRid, &attrFilter);
+
+        if (key.empty())
+        {
+            continue;
+        }
+
+        if (duplicateKeys.find(key) != duplicateKeys.end())
+        {
+            continue;
+        }
+
+        auto existingIt = index.find(key);
+
+        if (existingIt != index.end())
+        {
+            /*
+             * Two current objects project to the same CREATE_ONLY key. They are
+             * not interchangeable: types such as ACL_TABLE_GROUP are matched
+             * by graph heuristics (port/LAG binding). Drop the key so the
+             * identity index falls through to that slow path.
+             */
+
+            index.erase(existingIt);
+            duplicateKeys.insert(key);
+            continue;
+        }
+
+        index[key] = obj;
+    }
+
+    auto inserted = m_createOnlyIndexCache.emplace(cacheKey, std::move(index));
+
+    return &inserted.first->second;
+}
+
+const std::unordered_map<std::string, std::vector<std::shared_ptr<SaiObj>>>* AsicView::getNhgMemberIndex() const
+{
+    SWSS_LOG_ENTER();
+
+    if (m_nhgMemberIndexBuilt)
+    {
+        return &m_nhgMemberIndex;
+    }
+
+    for (const auto &nhg: getNotProcessedObjectsByObjectType(SAI_OBJECT_TYPE_NEXT_HOP_GROUP))
+    {
+        const std::string key = computeNhgMemberKey(nhg->getVid(), m_vidToRid);
+
+        if (key.empty())
+        {
+            continue;
+        }
+
+        m_nhgMemberIndex[key].push_back(nhg);
+    }
+
+    m_nhgMemberIndexBuilt = true;
+
+    return &m_nhgMemberIndex;
 }

--- a/syncd/AsicView.h
+++ b/syncd/AsicView.h
@@ -10,6 +10,8 @@ extern "C" {
 
 #include "swss/table.h"
 
+#include <set>
+
 namespace syncd
 {
     /**
@@ -249,7 +251,29 @@ namespace syncd
 
             void dumpVidToAsicOperatioId() const;
 
+            static std::string computeCreateOnlyKey(
+                    _In_ const std::shared_ptr<const SaiObj> &obj,
+                    _In_ const ObjectIdMap &vidToRid,
+                    _In_ const std::set<sai_attr_id_t> *attrFilter);
+
+            static bool isAttrIncludedInIdentityKey(
+                    _In_ const sai_attr_metadata_t *meta);
+
+            std::string computeNhgMemberKey(
+                    _In_ sai_object_id_t nhgVid,
+                    _In_ const ObjectIdMap &vidToRid) const;
+
+            const std::unordered_map<std::string, std::shared_ptr<SaiObj>>* getCreateOnlyIndex(
+                    _In_ sai_object_type_t objectType,
+                    _In_ const std::set<sai_attr_id_t> &attrFilter) const;
+
+            const std::unordered_map<std::string, std::vector<std::shared_ptr<SaiObj>>>* getNhgMemberIndex() const;
+
         private:
+
+            static std::string attrFilterCacheKey(
+                    _In_ sai_object_type_t objectType,
+                    _In_ const std::set<sai_attr_id_t> &attrFilter);
 
             void populateAttributes(
                     _In_ std::shared_ptr<SaiObj> &obj,
@@ -355,5 +379,11 @@ namespace syncd
             std::vector<AsicOperation> m_asicRemoveOperationsNonObjectId;
 
             std::map<sai_object_type_t, StrObjectIdToSaiObjectHash> m_sotAll;
+
+            mutable std::map<std::string, std::unordered_map<std::string, std::shared_ptr<SaiObj>>> m_createOnlyIndexCache;
+
+            mutable std::unordered_map<std::string, std::vector<std::shared_ptr<SaiObj>>> m_nhgMemberIndex;
+
+            mutable bool m_nhgMemberIndexBuilt;
     };
 }

--- a/syncd/BestCandidateFinder.cpp
+++ b/syncd/BestCandidateFinder.cpp
@@ -1693,6 +1693,46 @@ std::shared_ptr<SaiObj> BestCandidateFinder::findCurrentBestMatchForGenericObjec
 
     const auto notProcessedObjects = m_currentView.getNotProcessedObjectsByObjectType(object_type);
 
+    if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP)
+    {
+        auto match = findCurrentBestMatchForNextHopGroupUsingMemberIndex(temporaryObj);
+
+        if (match != nullptr)
+        {
+            return match;
+        }
+
+        std::vector<sai_object_compare_info_t> allCandidates;
+
+        for (const auto &obj: notProcessedObjects)
+        {
+            allCandidates.push_back({0, obj});
+        }
+
+        match = findCurrentBestMatchForNextHopGroup(temporaryObj, allCandidates);
+
+        if (match != nullptr)
+        {
+            return match;
+        }
+    }
+    else
+    {
+        auto match = findCurrentBestMatchUsingIdentityIndex(temporaryObj);
+
+        if (match != nullptr)
+        {
+            return match;
+        }
+    }
+
+    if (isSlowPathMatchType(object_type))
+    {
+        SWSS_LOG_WARN("APPLY_VIEW slow path for %s %s",
+                temporaryObj->m_str_object_type.c_str(),
+                temporaryObj->m_str_object_id.c_str());
+    }
+
     const auto attrs = temporaryObj->getAllAttributes();
 
     /*
@@ -1749,6 +1789,41 @@ std::shared_ptr<SaiObj> BestCandidateFinder::findCurrentBestMatchForGenericObjec
                         currentObj->m_str_object_id.c_str(),
                         attr.second->getStrAttrId().c_str(),
                         attr.second->getStrAttrValue().c_str());
+
+                if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER &&
+                    attrId == SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID &&
+                    currentObj->hasAttr(attrId) &&
+                    temporaryObj->hasAttr(attrId))
+                {
+                    sai_object_id_t tmpVid = temporaryObj->getSaiAttr(attrId)->getOid();
+                    sai_object_id_t curVid = currentObj->getSaiAttr(attrId)->getOid();
+
+                    auto tmpIt = m_temporaryView.m_vidToRid.find(tmpVid);
+                    auto curIt = m_currentView.m_vidToRid.find(curVid);
+
+                    if (tmpIt != m_temporaryView.m_vidToRid.end() &&
+                        curIt != m_currentView.m_vidToRid.end())
+                    {
+                        if (tmpIt->second == curIt->second)
+                        {
+                            soci.equal_attributes++;
+
+                            SWSS_LOG_INFO("NHGM NEXT_HOP_ID equal by RID for %s %s",
+                                    temporaryObj->m_str_object_id.c_str(),
+                                    currentObj->m_str_object_id.c_str());
+
+                            continue;
+                        }
+
+                        has_different_create_only_attr = true;
+
+                        SWSS_LOG_INFO("NHGM NEXT_HOP_ID differs by RID for %s %s",
+                                temporaryObj->m_str_object_id.c_str(),
+                                currentObj->m_str_object_id.c_str());
+
+                        break;
+                    }
+                }
 
                 /*
                  * Function hasEqualAttribute returns true only when both

--- a/syncd/BestCandidateFinder.h
+++ b/syncd/BestCandidateFinder.h
@@ -5,6 +5,7 @@
 #include "SaiSwitchInterface.h"
 
 #include <memory>
+#include <set>
 
 namespace syncd
 {
@@ -42,6 +43,24 @@ namespace syncd
 
             std::shared_ptr<SaiObj> findCurrentBestMatchForGenericObject(
                     _In_ const std::shared_ptr<const SaiObj> &temporaryObj);
+
+            std::shared_ptr<SaiObj> findCurrentBestMatchUsingIdentityIndex(
+                    _In_ const std::shared_ptr<const SaiObj> &temporaryObj);
+
+            std::shared_ptr<SaiObj> findCurrentBestMatchForNextHopGroupUsingMemberIndex(
+                    _In_ const std::shared_ptr<const SaiObj> &temporaryObj);
+
+            std::string resolveNhgMemberKeyViaIdentityIndex(
+                    _In_ sai_object_id_t tempNhgVid);
+
+            sai_object_id_t resolveNextHopRidForNhgKey(
+                    _In_ sai_object_id_t nhVid);
+
+            static std::set<sai_attr_id_t> buildAttrFilterFromObject(
+                    _In_ const std::shared_ptr<const SaiObj> &temporaryObj);
+
+            static bool isSlowPathMatchType(
+                    _In_ sai_object_type_t objectType);
 
             std::shared_ptr<SaiObj> findCurrentBestMatchForLag(
                     _In_ const std::shared_ptr<const SaiObj> &temporaryObj,

--- a/syncd/BestCandidateFinderIdentityIndex.cpp
+++ b/syncd/BestCandidateFinderIdentityIndex.cpp
@@ -1,0 +1,360 @@
+#include "BestCandidateFinder.h"
+
+#include "swss/logger.h"
+
+#include "meta/sai_serialize.h"
+
+#include <algorithm>
+#include <sstream>
+
+using namespace syncd;
+
+std::set<sai_attr_id_t> BestCandidateFinder::buildAttrFilterFromObject(
+        _In_ const std::shared_ptr<const SaiObj> &temporaryObj)
+{
+    SWSS_LOG_ENTER();
+
+    std::set<sai_attr_id_t> filter;
+
+    for (const auto &kvp: temporaryObj->getAllAttributes())
+    {
+        if (AsicView::isAttrIncludedInIdentityKey(kvp.second->getAttrMetadata()))
+        {
+            filter.insert(kvp.first);
+        }
+    }
+
+    return filter;
+}
+
+bool BestCandidateFinder::isSlowPathMatchType(
+        _In_ sai_object_type_t objectType)
+{
+    SWSS_LOG_ENTER();
+
+    return objectType == SAI_OBJECT_TYPE_NEXT_HOP ||
+           objectType == SAI_OBJECT_TYPE_NEXT_HOP_GROUP ||
+           objectType == SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER;
+}
+
+std::shared_ptr<SaiObj> BestCandidateFinder::findCurrentBestMatchUsingIdentityIndex(
+        _In_ const std::shared_ptr<const SaiObj> &temporaryObj)
+{
+    SWSS_LOG_ENTER();
+
+    const sai_object_type_t objectType = temporaryObj->getObjectType();
+
+    const std::set<sai_attr_id_t> attrFilter = buildAttrFilterFromObject(temporaryObj);
+
+    if (attrFilter.empty())
+    {
+        return nullptr;
+    }
+
+    const auto *index = m_currentView.getCreateOnlyIndex(objectType, attrFilter);
+
+    if (index == nullptr)
+    {
+        return nullptr;
+    }
+
+    const std::string key = AsicView::computeCreateOnlyKey(
+            temporaryObj,
+            m_temporaryView.m_vidToRid,
+            &attrFilter);
+
+    if (key.empty())
+    {
+        return nullptr;
+    }
+
+    const auto it = index->find(key);
+
+    if (it == index->end())
+    {
+        return nullptr;
+    }
+
+    if (it->second->getObjectStatus() != SAI_OBJECT_STATUS_NOT_PROCESSED)
+    {
+        return nullptr;
+    }
+
+    SWSS_LOG_NOTICE("identity index match for %s -> %s",
+            temporaryObj->m_str_object_id.c_str(),
+            it->second->m_str_object_id.c_str());
+
+    return it->second;
+}
+
+sai_object_id_t BestCandidateFinder::resolveNextHopRidForNhgKey(
+        _In_ sai_object_id_t nhVid)
+{
+    SWSS_LOG_ENTER();
+
+    if (nhVid == SAI_NULL_OBJECT_ID)
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    auto tmpIt = m_temporaryView.m_vidToRid.find(nhVid);
+
+    if (tmpIt != m_temporaryView.m_vidToRid.end())
+    {
+        return tmpIt->second;
+    }
+
+    auto nhObjIt = m_temporaryView.m_oOids.find(nhVid);
+
+    if (nhObjIt == m_temporaryView.m_oOids.end())
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    const auto &tempNh = nhObjIt->second;
+
+    const std::set<sai_attr_id_t> attrFilter = buildAttrFilterFromObject(tempNh);
+
+    if (!attrFilter.empty())
+    {
+        const std::string nhKey = AsicView::computeCreateOnlyKey(
+                tempNh,
+                m_temporaryView.m_vidToRid,
+                &attrFilter);
+
+        if (!nhKey.empty())
+        {
+            const auto *nhIndex = m_currentView.getCreateOnlyIndex(SAI_OBJECT_TYPE_NEXT_HOP, attrFilter);
+
+            if (nhIndex != nullptr)
+            {
+                const auto nhIt = nhIndex->find(nhKey);
+
+                if (nhIt != nhIndex->end())
+                {
+                    auto curVid = nhIt->second->getVid();
+                    auto curIt = m_currentView.m_vidToRid.find(curVid);
+
+                    if (curIt != m_currentView.m_vidToRid.end())
+                    {
+                        return curIt->second;
+                    }
+                }
+            }
+        }
+    }
+
+    if (!tempNh->hasAttr(SAI_NEXT_HOP_ATTR_TUNNEL_ID) || !tempNh->hasAttr(SAI_NEXT_HOP_ATTR_TYPE))
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    sai_object_id_t tunnelVid = tempNh->getSaiAttr(SAI_NEXT_HOP_ATTR_TUNNEL_ID)->getOid();
+    sai_object_id_t tunnelRid = SAI_NULL_OBJECT_ID;
+
+    auto tunnelTmpIt = m_temporaryView.m_vidToRid.find(tunnelVid);
+
+    if (tunnelTmpIt != m_temporaryView.m_vidToRid.end())
+    {
+        tunnelRid = tunnelTmpIt->second;
+    }
+    else
+    {
+        auto tunnelObjIt = m_temporaryView.m_oOids.find(tunnelVid);
+
+        if (tunnelObjIt != m_temporaryView.m_oOids.end())
+        {
+            const std::set<sai_attr_id_t> tunnelFilter = buildAttrFilterFromObject(tunnelObjIt->second);
+            const std::string tunnelKey = AsicView::computeCreateOnlyKey(
+                    tunnelObjIt->second,
+                    m_temporaryView.m_vidToRid,
+                    &tunnelFilter);
+
+            if (!tunnelKey.empty())
+            {
+                const auto *tunnelIndex = m_currentView.getCreateOnlyIndex(SAI_OBJECT_TYPE_TUNNEL, tunnelFilter);
+
+                if (tunnelIndex != nullptr)
+                {
+                    const auto tunnelIt = tunnelIndex->find(tunnelKey);
+
+                    if (tunnelIt != tunnelIndex->end())
+                    {
+                        auto curTunnelVid = tunnelIt->second->getVid();
+                        auto curTunnelIt = m_currentView.m_vidToRid.find(curTunnelVid);
+
+                        if (curTunnelIt != m_currentView.m_vidToRid.end())
+                        {
+                            tunnelRid = curTunnelIt->second;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (tunnelRid == SAI_NULL_OBJECT_ID)
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    const std::string nhType = tempNh->getSaiAttr(SAI_NEXT_HOP_ATTR_TYPE)->getStrAttrValue();
+
+    std::vector<sai_object_id_t> matchingRids;
+
+    for (const auto &curNh: m_currentView.getObjectsByObjectType(SAI_OBJECT_TYPE_NEXT_HOP))
+    {
+        if (!curNh->hasAttr(SAI_NEXT_HOP_ATTR_TUNNEL_ID) || !curNh->hasAttr(SAI_NEXT_HOP_ATTR_TYPE))
+        {
+            continue;
+        }
+
+        if (curNh->getSaiAttr(SAI_NEXT_HOP_ATTR_TYPE)->getStrAttrValue() != nhType)
+        {
+            continue;
+        }
+
+        sai_object_id_t curTunnelVid = curNh->getSaiAttr(SAI_NEXT_HOP_ATTR_TUNNEL_ID)->getOid();
+        auto curTunnelIt = m_currentView.m_vidToRid.find(curTunnelVid);
+
+        if (curTunnelIt == m_currentView.m_vidToRid.end())
+        {
+            continue;
+        }
+
+        if (curTunnelIt->second != tunnelRid)
+        {
+            continue;
+        }
+
+        auto curNhIt = m_currentView.m_vidToRid.find(curNh->getVid());
+
+        if (curNhIt != m_currentView.m_vidToRid.end())
+        {
+            matchingRids.push_back(curNhIt->second);
+        }
+    }
+
+    if (matchingRids.empty())
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    std::sort(matchingRids.begin(), matchingRids.end());
+
+    if (matchingRids.size() > 1)
+    {
+        SWSS_LOG_WARN("ambiguous tunnel NH match: count=%zu tunnel_rid=%s type=%s, falling back to slow path",
+                matchingRids.size(),
+                sai_serialize_object_id(tunnelRid).c_str(),
+                nhType.c_str());
+
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    return matchingRids.front();
+}
+
+std::string BestCandidateFinder::resolveNhgMemberKeyViaIdentityIndex(
+        _In_ sai_object_id_t tempNhgVid)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<sai_object_id_t> nhRids;
+
+    for (const auto &member: m_temporaryView.getObjectsByObjectType(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER))
+    {
+        if (!member->hasAttr(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID))
+        {
+            continue;
+        }
+
+        if (member->getSaiAttr(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID)->getOid() != tempNhgVid)
+        {
+            continue;
+        }
+
+        if (!member->hasAttr(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID))
+        {
+            return "";
+        }
+
+        sai_object_id_t nhVid = member->getSaiAttr(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID)->getOid();
+        sai_object_id_t nhRid = resolveNextHopRidForNhgKey(nhVid);
+
+        if (nhRid == SAI_NULL_OBJECT_ID)
+        {
+            return "";
+        }
+
+        nhRids.push_back(nhRid);
+    }
+
+    if (nhRids.empty())
+    {
+        return "";
+    }
+
+    std::sort(nhRids.begin(), nhRids.end());
+
+    std::ostringstream key;
+
+    for (size_t i = 0; i < nhRids.size(); i++)
+    {
+        if (i > 0)
+        {
+            key << ";";
+        }
+
+        key << sai_serialize_object_id(nhRids.at(i));
+    }
+
+    return key.str();
+}
+
+std::shared_ptr<SaiObj> BestCandidateFinder::findCurrentBestMatchForNextHopGroupUsingMemberIndex(
+        _In_ const std::shared_ptr<const SaiObj> &temporaryObj)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string key = resolveNhgMemberKeyViaIdentityIndex(temporaryObj->getVid());
+
+    if (key.empty())
+    {
+        return nullptr;
+    }
+
+    const auto *index = m_currentView.getNhgMemberIndex();
+    const auto it = index->find(key);
+
+    if (it == index->end())
+    {
+        return nullptr;
+    }
+
+    for (const auto &nhg: it->second)
+    {
+        if (nhg->getObjectStatus() != SAI_OBJECT_STATUS_NOT_PROCESSED)
+        {
+            continue;
+        }
+
+        if (it->second.size() > 1)
+        {
+            SWSS_LOG_NOTICE("NHG greedy member-key match for %s -> %s (pool size %zu)",
+                    temporaryObj->m_str_object_id.c_str(),
+                    nhg->m_str_object_id.c_str(),
+                    it->second.size());
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("NHG unique member-key match for %s -> %s",
+                    temporaryObj->m_str_object_id.c_str(),
+                    nhg->m_str_object_id.c_str());
+        }
+
+        return nhg;
+    }
+
+    return nullptr;
+}

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -19,6 +19,7 @@ libSyncd_a_SOURCES = \
 				AsicView.cpp \
 				AttrVersionChecker.cpp \
 				BestCandidateFinder.cpp \
+				BestCandidateFinderIdentityIndex.cpp \
 				BreakConfig.cpp \
 				BreakConfigParser.cpp \
 				CommandLineOptions.cpp \

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -9,6 +9,8 @@ tests_SOURCES = main.cpp \
                 MockHelper.cpp \
 				MockableSaiSwitchInterface.cpp \
 				TestBestCandidateFinder.cpp \
+				TestAsicViewIdentityIndex.cpp \
+				TestBestCandidateFinderIdentityIndex.cpp \
 				TestMySidWarmboot.cpp \
 				TestAttrVersionChecker.cpp \
 				TestCommandLineOptions.cpp \

--- a/unittest/syncd/TestAsicViewIdentityIndex.cpp
+++ b/unittest/syncd/TestAsicViewIdentityIndex.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <set>
+#include <string>
 #include <vector>
 
 using namespace syncd;
@@ -304,4 +305,158 @@ TEST(AsicViewIdentityIndex, getNhgMemberIndex_GroupsInterchangeableNhgs)
     const auto &pool = index->begin()->second;
 
     EXPECT_EQ(pool.size(), 2u);
+}
+
+TEST(AsicViewIdentityIndex, computeCreateOnlyKey_SkipsCreateAndSetInFilter)
+{
+    AsicView currentView;
+
+    const auto nhIds = deserializePair("oid:0x4000000000a01", "oid:0x4000000000f001");
+
+    auto nh = addOidObject(currentView, nhIds, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.90"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_VNI", "10100"},
+    });
+
+    std::set<sai_attr_id_t> filter = {
+        SAI_NEXT_HOP_ATTR_TYPE,
+        SAI_NEXT_HOP_ATTR_IP,
+        SAI_NEXT_HOP_ATTR_TUNNEL_VNI,
+    };
+
+    const std::string key = AsicView::computeCreateOnlyKey(nh, currentView.m_vidToRid, &filter);
+
+    EXPECT_NE(key.find("SAI_NEXT_HOP_ATTR_TYPE"), std::string::npos);
+    EXPECT_NE(key.find("SAI_NEXT_HOP_ATTR_IP"), std::string::npos);
+    EXPECT_EQ(key.find("SAI_NEXT_HOP_ATTR_TUNNEL_VNI"), std::string::npos);
+}
+
+TEST(AsicViewIdentityIndex, computeCreateOnlyKey_SerializesNullOid)
+{
+    AsicView currentView;
+
+    const auto nhg = deserializePair("oid:0x5000000003a01", "oid:0x5000000000f010");
+    const auto nhgm = deserializePair("oid:0x2d000000003a01", "oid:0x2d0000000000f010");
+
+    addOidObject(currentView, nhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    auto member = addOidObject(currentView, nhgm, {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003a01"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x0"},
+    });
+
+    const std::set<sai_attr_id_t> filter = attrFilterFromObject(member);
+    const std::string key = AsicView::computeCreateOnlyKey(member, currentView.m_vidToRid, &filter);
+
+    EXPECT_FALSE(key.empty());
+    EXPECT_NE(key.find(sai_serialize_object_id(SAI_NULL_OBJECT_ID)), std::string::npos);
+}
+
+TEST(AsicViewIdentityIndex, computeNhgMemberKey_MissingNextHopId)
+{
+    AsicView view;
+
+    const auto nhg = deserializePair("oid:0x5000000003a10", "oid:0x5000000000f020");
+
+    addOidObject(view, nhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(view, deserializePair("oid:0x2d000000003a10", "oid:0x2d0000000000f020"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003a10"},
+    });
+
+    EXPECT_TRUE(view.computeNhgMemberKey(nhg.vid, view.m_vidToRid).empty());
+}
+
+TEST(AsicViewIdentityIndex, computeNhgMemberKey_UnresolvedNextHopVid)
+{
+    AsicView view;
+
+    const auto nhg = deserializePair("oid:0x5000000003a20", "oid:0x5000000000f030");
+
+    addOidObject(view, nhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(view, deserializePair("oid:0x2d000000003a20", "oid:0x2d0000000000f030"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003a20"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000a20"},
+    });
+
+    EXPECT_TRUE(view.computeNhgMemberKey(nhg.vid, view.m_vidToRid).empty());
+}
+
+TEST(AsicViewIdentityIndex, computeNhgMemberKey_EmptyMembers)
+{
+    AsicView view;
+
+    const auto nhg = deserializePair("oid:0x5000000003a30", "oid:0x5000000000f040");
+
+    addOidObject(view, nhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    EXPECT_TRUE(view.computeNhgMemberKey(nhg.vid, view.m_vidToRid).empty());
+}
+
+TEST(AsicViewIdentityIndex, getCreateOnlyIndex_SkipsEmptyKey)
+{
+    AsicView currentView;
+
+    const auto tunnelNh = deserializePair("oid:0x4000000000a30", "oid:0x4000000000f050");
+    const auto ipNh = deserializePair("oid:0x4000000000a31", "oid:0x4000000000f051");
+
+    auto tunnelObj = addOidObject(currentView, tunnelNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.210.1"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x1a0000000000ef"},
+    });
+
+    addOidObject(currentView, ipNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.91"},
+    });
+
+    const std::set<sai_attr_id_t> filter = attrFilterFromObject(tunnelObj);
+    const auto *index = currentView.getCreateOnlyIndex(SAI_OBJECT_TYPE_NEXT_HOP, filter);
+
+    ASSERT_NE(index, nullptr);
+    EXPECT_EQ(index->size(), 1u);
+}
+
+TEST(AsicViewIdentityIndex, getNhgMemberIndex_SkipsEmptyKey)
+{
+    AsicView view;
+
+    const auto emptyNhg = deserializePair("oid:0x5000000003a40", "oid:0x5000000000f060");
+    const auto validNhg = deserializePair("oid:0x5000000003a41", "oid:0x5000000000f061");
+    const auto nh = deserializePair("oid:0x4000000000a40", "oid:0x4000000000f070");
+
+    addOidObject(view, emptyNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(view, validNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(view, nh, {});
+
+    addOidObject(view, deserializePair("oid:0x2d000000003a40", "oid:0x2d0000000000f060"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003a40"},
+    });
+
+    addOidObject(view, deserializePair("oid:0x2d000000003a41", "oid:0x2d0000000000f061"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003a41"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000a40"},
+    });
+
+    const auto *index = view.getNhgMemberIndex();
+
+    ASSERT_NE(index, nullptr);
+    EXPECT_EQ(index->size(), 1u);
 }

--- a/unittest/syncd/TestAsicViewIdentityIndex.cpp
+++ b/unittest/syncd/TestAsicViewIdentityIndex.cpp
@@ -1,0 +1,307 @@
+#include "AsicView.h"
+
+#include "meta/sai_serialize.h"
+
+#include "swss/logger.h"
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <vector>
+
+using namespace syncd;
+
+namespace
+{
+    struct TestOidPair
+    {
+        sai_object_id_t vid;
+        sai_object_id_t rid;
+    };
+
+    TestOidPair deserializePair(
+            _In_ const char *vidStr,
+            _In_ const char *ridStr)
+    {
+        SWSS_LOG_ENTER();
+
+        TestOidPair pair;
+
+        sai_deserialize_object_id(vidStr, pair.vid);
+        sai_deserialize_object_id(ridStr, pair.rid);
+
+        return pair;
+    }
+
+    std::shared_ptr<SaiObj> addOidObject(
+            _Inout_ AsicView &view,
+            _In_ const TestOidPair &ids,
+            _In_ const std::vector<std::pair<const char*, const char*>> &attrs)
+    {
+        SWSS_LOG_ENTER();
+
+        auto obj = view.createDummyExistingObject(ids.rid, ids.vid);
+
+        for (const auto &attr: attrs)
+        {
+            obj->setAttr(std::make_shared<SaiAttr>(attr.first, attr.second));
+        }
+
+        return obj;
+    }
+
+    std::set<sai_attr_id_t> attrFilterFromObject(
+            _In_ const std::shared_ptr<SaiObj> &obj)
+    {
+        SWSS_LOG_ENTER();
+
+        std::set<sai_attr_id_t> filter;
+
+        for (const auto &kvp: obj->getAllAttributes())
+        {
+            if (AsicView::isAttrIncludedInIdentityKey(kvp.second->getAttrMetadata()))
+            {
+                filter.insert(kvp.first);
+            }
+        }
+
+        return filter;
+    }
+}
+
+TEST(AsicViewIdentityIndex, computeCreateOnlyKey_ScalarProjectionMatchesAcrossViews)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curIds = deserializePair("oid:0x4000000000905", "oid:0x400000000001");
+    const auto tmpIds = deserializePair("oid:0x4000000000906", "oid:0x400000000001");
+
+    const auto rifCur = deserializePair("oid:0x60000000008f8", "oid:0x600000000001");
+    const auto rifTmp = deserializePair("oid:0x60000000008f9", "oid:0x600000000001");
+
+    addOidObject(currentView, rifCur, {});
+    addOidObject(tempView, rifTmp, {});
+
+    const std::vector<std::pair<const char*, const char*>> sparseAttrs = {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.7"},
+        {"SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID", "oid:0x60000000008f9"},
+    };
+
+    const std::vector<std::pair<const char*, const char*>> richAttrs = {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.7"},
+        {"SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID", "oid:0x60000000008f8"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_VNI", "10100"},
+    };
+
+    auto curNh = addOidObject(currentView, curIds, richAttrs);
+    auto tmpNh = addOidObject(tempView, tmpIds, sparseAttrs);
+
+    tempView.m_vidToRid[rifTmp.vid] = rifCur.rid;
+
+    const std::set<sai_attr_id_t> filter = attrFilterFromObject(tmpNh);
+
+    const std::string curKey = AsicView::computeCreateOnlyKey(curNh, currentView.m_vidToRid, &filter);
+    const std::string tmpKey = AsicView::computeCreateOnlyKey(tmpNh, tempView.m_vidToRid, &filter);
+
+    EXPECT_FALSE(curKey.empty());
+    EXPECT_EQ(curKey, tmpKey);
+}
+
+TEST(AsicViewIdentityIndex, computeCreateOnlyKey_ReturnsEmptyWhenOidUnresolved)
+{
+    AsicView tempView;
+
+    const auto nhIds = deserializePair("oid:0x4000000000907", "oid:0x400000000002");
+
+    auto nh = addOidObject(tempView, nhIds, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.200.1"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x1a000000000099"},
+    });
+
+    const std::set<sai_attr_id_t> filter = attrFilterFromObject(nh);
+    const std::string key = AsicView::computeCreateOnlyKey(nh, tempView.m_vidToRid, &filter);
+
+    EXPECT_TRUE(key.empty());
+}
+
+TEST(AsicViewIdentityIndex, getCreateOnlyIndex_UniqueKeyLookup)
+{
+    AsicView currentView;
+
+    const auto nh1 = deserializePair("oid:0x4000000000908", "oid:0x400000000010");
+    const auto nh2 = deserializePair("oid:0x4000000000909", "oid:0x400000000011");
+
+    auto obj1 = addOidObject(currentView, nh1, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.1"},
+    });
+
+    addOidObject(currentView, nh2, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.2"},
+    });
+
+    const std::set<sai_attr_id_t> filter = attrFilterFromObject(obj1);
+    const auto *index = currentView.getCreateOnlyIndex(SAI_OBJECT_TYPE_NEXT_HOP, filter);
+
+    ASSERT_NE(index, nullptr);
+    EXPECT_EQ(index->size(), 2u);
+
+    const std::string key1 = AsicView::computeCreateOnlyKey(obj1, currentView.m_vidToRid, &filter);
+    const auto it = index->find(key1);
+
+    ASSERT_NE(it, index->end());
+    EXPECT_EQ(it->second->getVid(), nh1.vid);
+}
+
+TEST(AsicViewIdentityIndex, getCreateOnlyIndex_ExcludesDuplicateKeys)
+{
+    AsicView currentView;
+
+    const auto nh1 = deserializePair("oid:0x400000000090a", "oid:0x400000000012");
+    const auto nh2 = deserializePair("oid:0x400000000090b", "oid:0x400000000013");
+
+    auto obj1 = addOidObject(currentView, nh1, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.3"},
+    });
+
+    addOidObject(currentView, nh2, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.3"},
+    });
+
+    const std::set<sai_attr_id_t> filter = attrFilterFromObject(obj1);
+    const auto *index = currentView.getCreateOnlyIndex(SAI_OBJECT_TYPE_NEXT_HOP, filter);
+
+    ASSERT_NE(index, nullptr);
+    EXPECT_EQ(index->size(), 0u);
+
+    const std::string key1 = AsicView::computeCreateOnlyKey(obj1, currentView.m_vidToRid, &filter);
+
+    EXPECT_EQ(index->find(key1), index->end());
+}
+
+TEST(AsicViewIdentityIndex, isAttrIncludedInIdentityKey_SkipsCreateAndSet)
+{
+    AsicView currentView;
+
+    const auto ids = deserializePair("oid:0x400000000090c", "oid:0x400000000014");
+
+    auto nh = addOidObject(currentView, ids, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.4"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_VNI", "10100"},
+    });
+
+    const std::set<sai_attr_id_t> filter = attrFilterFromObject(nh);
+
+    EXPECT_EQ(filter.size(), 2u);
+    EXPECT_NE(filter.find(SAI_NEXT_HOP_ATTR_TYPE), filter.end());
+    EXPECT_NE(filter.find(SAI_NEXT_HOP_ATTR_IP), filter.end());
+    EXPECT_EQ(filter.find(SAI_NEXT_HOP_ATTR_TUNNEL_VNI), filter.end());
+}
+
+TEST(AsicViewIdentityIndex, isAttrIncludedInIdentityKey_IncludesNhgmNextHopId)
+{
+    AsicView currentView;
+
+    const auto nhg = deserializePair("oid:0x5000000002ca0", "oid:0x500000000010");
+    const auto nh = deserializePair("oid:0x400000000090d", "oid:0x400000000015");
+    const auto nhgm = deserializePair("oid:0x2d000000002ca0", "oid:0x2d000000000010");
+
+    addOidObject(currentView, nhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, nh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.5"},
+    });
+
+    auto member = addOidObject(currentView, nhgm, {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002ca0"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x400000000090d"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT", "2"},
+    });
+
+    const std::set<sai_attr_id_t> filter = attrFilterFromObject(member);
+
+    EXPECT_EQ(filter.size(), 2u);
+    EXPECT_NE(filter.find(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID), filter.end());
+    EXPECT_NE(filter.find(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID), filter.end());
+    EXPECT_EQ(filter.find(SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT), filter.end());
+}
+
+TEST(AsicViewIdentityIndex, computeNhgMemberKey_SortedMemberRids)
+{
+    AsicView view;
+
+    const auto nhg = deserializePair("oid:0x5000000002ca2", "oid:0x500000000001");
+    const auto nh1 = deserializePair("oid:0x4000000000910", "oid:0x400000000020");
+    const auto nh2 = deserializePair("oid:0x4000000000911", "oid:0x400000000021");
+
+    addOidObject(view, nhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(view, nh1, {});
+    addOidObject(view, nh2, {});
+
+    addOidObject(view, deserializePair("oid:0x2d000000002ca6", "oid:0x2d000000000001"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002ca2"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000911"},
+    });
+
+    addOidObject(view, deserializePair("oid:0x2d000000002ca7", "oid:0x2d000000000002"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002ca2"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000910"},
+    });
+
+    const std::string key = view.computeNhgMemberKey(nhg.vid, view.m_vidToRid);
+
+    EXPECT_EQ(key,
+            sai_serialize_object_id(nh1.rid) + ";" + sai_serialize_object_id(nh2.rid));
+}
+
+TEST(AsicViewIdentityIndex, getNhgMemberIndex_GroupsInterchangeableNhgs)
+{
+    AsicView view;
+
+    const auto nhg1 = deserializePair("oid:0x5000000002af9", "oid:0x500000000010");
+    const auto nhg2 = deserializePair("oid:0x5000000002afe", "oid:0x500000000011");
+    const auto nh = deserializePair("oid:0x4000000002af8", "oid:0x400000000030");
+
+    addOidObject(view, nhg1, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(view, nhg2, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(view, nh, {});
+
+    addOidObject(view, deserializePair("oid:0x2d000000002afb", "oid:0x2d000000000010"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002af9"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000002af8"},
+    });
+
+    addOidObject(view, deserializePair("oid:0x2d000000002aff", "oid:0x2d000000000011"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002afe"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000002af8"},
+    });
+
+    const auto *index = view.getNhgMemberIndex();
+
+    ASSERT_NE(index, nullptr);
+    ASSERT_EQ(index->size(), 1u);
+
+    const auto &pool = index->begin()->second;
+
+    EXPECT_EQ(pool.size(), 2u);
+}

--- a/unittest/syncd/TestBestCandidateFinderIdentityIndex.cpp
+++ b/unittest/syncd/TestBestCandidateFinderIdentityIndex.cpp
@@ -258,3 +258,517 @@ TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForGenericObject_Nhgm
 
     EXPECT_EQ(match, nullptr);
 }
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchUsingIdentityIndex_SkipsAlreadyProcessed)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curIds = deserializePair("oid:0x4000000000c01", "oid:0x4000000000e050");
+    const auto tmpIds = deserializePair("oid:0x4000000000c02", "oid:0x4000000000e050");
+
+    auto curNh = addOidObject(currentView, curIds, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.80"},
+    });
+
+    auto tmpNh = addOidObject(tempView, tmpIds, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.80"},
+    });
+
+    curNh->setObjectStatus(SAI_OBJECT_STATUS_MATCHED);
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    EXPECT_EQ(bcf.findCurrentBestMatchUsingIdentityIndex(tmpNh), nullptr);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex_TunnelNhFallbackMappedTunnel)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curTunnel = deserializePair("oid:0x2a0000000000ee", "oid:0x2a0000000000e0");
+    const auto tmpTunnel = deserializePair("oid:0x2a0000000000ef", "oid:0x2a0000000000e0");
+    const auto curNh = deserializePair("oid:0x4000000000c10", "oid:0x4000000000e060");
+    const auto tmpNh = deserializePair("oid:0x4000000000c11", "oid:0x4000000000e061");
+    const auto ipNh = deserializePair("oid:0x4000000000c12", "oid:0x4000000000e062");
+    const auto otherTunnel = deserializePair("oid:0x2a0000000000f0", "oid:0x2a0000000000e1");
+    const auto otherNh = deserializePair("oid:0x4000000000c13", "oid:0x4000000000e063");
+    const auto curNhg = deserializePair("oid:0x5000000003c10", "oid:0x5000000000e020");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c11", "oid:0x5000000000e020");
+
+    addOidObject(currentView, curTunnel, {
+        {"SAI_TUNNEL_ATTR_TYPE", "SAI_TUNNEL_TYPE_VXLAN"},
+        {"SAI_TUNNEL_ATTR_PEER_MODE", "SAI_TUNNEL_PEER_MODE_P2MP"},
+        {"SAI_TUNNEL_ATTR_ENCAP_SRC_IP", "10.1.1.1"},
+    });
+
+    addOidObject(currentView, otherTunnel, {
+        {"SAI_TUNNEL_ATTR_TYPE", "SAI_TUNNEL_TYPE_VXLAN"},
+        {"SAI_TUNNEL_ATTR_PEER_MODE", "SAI_TUNNEL_PEER_MODE_P2MP"},
+        {"SAI_TUNNEL_ATTR_ENCAP_SRC_IP", "10.1.1.2"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.200.1"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x2a0000000000ee"},
+    });
+
+    addOidObject(currentView, ipNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.81"},
+    });
+
+    addOidObject(currentView, otherNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.200.9"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x2a0000000000f0"},
+    });
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, deserializePair("oid:0x2d000000003c10", "oid:0x2d0000000000e020"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c10"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c10"},
+    });
+
+    addOidObject(tempView, tmpTunnel, {
+        {"SAI_TUNNEL_ATTR_TYPE", "SAI_TUNNEL_TYPE_VXLAN"},
+        {"SAI_TUNNEL_ATTR_PEER_MODE", "SAI_TUNNEL_PEER_MODE_P2MP"},
+        {"SAI_TUNNEL_ATTR_ENCAP_SRC_IP", "10.1.1.1"},
+    });
+
+    addOidObject(tempView, tmpNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.200.8"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x2a0000000000ef"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(tempView, deserializePair("oid:0x2d000000003c11", "oid:0x2d0000000000e021"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c11"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c11"},
+    });
+
+    tempView.m_vidToRid.erase(tmpNh.vid);
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj);
+
+    ASSERT_NE(match, nullptr);
+    EXPECT_EQ(match->getVid(), curNhg.vid);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex_TunnelNhFallbackViaTunnelIdentity)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curTunnel = deserializePair("oid:0x2a0000000000f1", "oid:0x2a0000000000e2");
+    const auto tmpTunnel = deserializePair("oid:0x2a0000000000f2", "oid:0x2a0000000000e2");
+    const auto curNh = deserializePair("oid:0x4000000000c20", "oid:0x4000000000e070");
+    const auto tmpNh = deserializePair("oid:0x4000000000c21", "oid:0x4000000000e071");
+    const auto curNhg = deserializePair("oid:0x5000000003c20", "oid:0x5000000000e030");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c21", "oid:0x5000000000e030");
+
+    addOidObject(currentView, curTunnel, {
+        {"SAI_TUNNEL_ATTR_TYPE", "SAI_TUNNEL_TYPE_VXLAN"},
+        {"SAI_TUNNEL_ATTR_PEER_MODE", "SAI_TUNNEL_PEER_MODE_P2MP"},
+        {"SAI_TUNNEL_ATTR_ENCAP_SRC_IP", "10.2.2.2"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.201.1"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x2a0000000000f1"},
+    });
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, deserializePair("oid:0x2d000000003c20", "oid:0x2d0000000000e030"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c20"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c20"},
+    });
+
+    addOidObject(tempView, tmpTunnel, {
+        {"SAI_TUNNEL_ATTR_TYPE", "SAI_TUNNEL_TYPE_VXLAN"},
+        {"SAI_TUNNEL_ATTR_PEER_MODE", "SAI_TUNNEL_PEER_MODE_P2MP"},
+        {"SAI_TUNNEL_ATTR_ENCAP_SRC_IP", "10.2.2.2"},
+    });
+
+    addOidObject(tempView, tmpNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.201.8"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x2a0000000000f2"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(tempView, deserializePair("oid:0x2d000000003c21", "oid:0x2d0000000000e031"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c21"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c21"},
+    });
+
+    tempView.m_vidToRid.erase(tmpNh.vid);
+    tempView.m_vidToRid.erase(tmpTunnel.vid);
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj);
+
+    ASSERT_NE(match, nullptr);
+    EXPECT_EQ(match->getVid(), curNhg.vid);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex_TunnelNhFallbackAmbiguous)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curTunnel = deserializePair("oid:0x2a0000000000f3", "oid:0x2a0000000000e3");
+    const auto tmpTunnel = deserializePair("oid:0x2a0000000000f4", "oid:0x2a0000000000e3");
+    const auto curNh1 = deserializePair("oid:0x4000000000c30", "oid:0x4000000000e080");
+    const auto curNh2 = deserializePair("oid:0x4000000000c31", "oid:0x4000000000e081");
+    const auto tmpNh = deserializePair("oid:0x4000000000c32", "oid:0x4000000000e082");
+    const auto curNhg = deserializePair("oid:0x5000000003c30", "oid:0x5000000000e040");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c31", "oid:0x5000000000e040");
+
+    addOidObject(currentView, curTunnel, {
+        {"SAI_TUNNEL_ATTR_TYPE", "SAI_TUNNEL_TYPE_VXLAN"},
+        {"SAI_TUNNEL_ATTR_PEER_MODE", "SAI_TUNNEL_PEER_MODE_P2MP"},
+        {"SAI_TUNNEL_ATTR_ENCAP_SRC_IP", "10.3.3.3"},
+    });
+
+    addOidObject(currentView, curNh1, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.202.1"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x2a0000000000f3"},
+    });
+
+    addOidObject(currentView, curNh2, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.202.2"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x2a0000000000f3"},
+    });
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, deserializePair("oid:0x2d000000003c30", "oid:0x2d0000000000e040"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c30"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c30"},
+    });
+
+    addOidObject(tempView, tmpTunnel, {
+        {"SAI_TUNNEL_ATTR_TYPE", "SAI_TUNNEL_TYPE_VXLAN"},
+        {"SAI_TUNNEL_ATTR_PEER_MODE", "SAI_TUNNEL_PEER_MODE_P2MP"},
+        {"SAI_TUNNEL_ATTR_ENCAP_SRC_IP", "10.3.3.3"},
+    });
+
+    addOidObject(tempView, tmpNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.200.202.9"},
+        {"SAI_NEXT_HOP_ATTR_TUNNEL_ID", "oid:0x2a0000000000f4"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(tempView, deserializePair("oid:0x2d000000003c31", "oid:0x2d0000000000e041"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c31"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c32"},
+    });
+
+    tempView.m_vidToRid.erase(tmpNh.vid);
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    EXPECT_EQ(bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj), nullptr);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex_MemberMissingNextHopId)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000003c40", "oid:0x5000000000e050");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c41", "oid:0x5000000000e050");
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(tempView, deserializePair("oid:0x2d000000003c40", "oid:0x2d0000000000e050"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c41"},
+    });
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    EXPECT_EQ(bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj), nullptr);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex_EmptyMembers)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000003c50", "oid:0x5000000000e060");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c51", "oid:0x5000000000e060");
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    EXPECT_EQ(bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj), nullptr);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex_KeyMiss)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000003c60", "oid:0x5000000000e070");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c61", "oid:0x5000000000e070");
+    const auto curNh = deserializePair("oid:0x4000000000c40", "oid:0x4000000000e090");
+    const auto tmpNh = deserializePair("oid:0x4000000000c41", "oid:0x4000000000e091");
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.82"},
+    });
+
+    addOidObject(currentView, deserializePair("oid:0x2d000000003c60", "oid:0x2d0000000000e070"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c60"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c40"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(tempView, tmpNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.83"},
+    });
+
+    addOidObject(tempView, deserializePair("oid:0x2d000000003c61", "oid:0x2d0000000000e071"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c61"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c41"},
+    });
+
+    tempView.m_vidToRid[tmpNh.vid] = tmpNh.rid;
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    EXPECT_EQ(bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj), nullptr);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex_PoolSizeGreaterThanOne)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg1 = deserializePair("oid:0x5000000003c70", "oid:0x5000000000e080");
+    const auto curNhg2 = deserializePair("oid:0x5000000003c71", "oid:0x5000000000e081");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c72", "oid:0x5000000000e080");
+    const auto curNh = deserializePair("oid:0x4000000000c50", "oid:0x4000000000e0a0");
+    const auto tmpNh = deserializePair("oid:0x4000000000c51", "oid:0x4000000000e0a0");
+
+    addOidObject(currentView, curNhg1, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, curNhg2, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.84"},
+    });
+
+    addOidObject(currentView, deserializePair("oid:0x2d000000003c70", "oid:0x2d0000000000e080"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c70"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c50"},
+    });
+
+    addOidObject(currentView, deserializePair("oid:0x2d000000003c71", "oid:0x2d0000000000e081"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c71"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c50"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(tempView, tmpNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.84"},
+    });
+
+    addOidObject(tempView, deserializePair("oid:0x2d000000003c72", "oid:0x2d0000000000e082"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c72"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c51"},
+    });
+
+    tempView.m_vidToRid[tmpNh.vid] = curNh.rid;
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj);
+
+    ASSERT_NE(match, nullptr);
+    EXPECT_TRUE(match->getVid() == curNhg1.vid || match->getVid() == curNhg2.vid);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex_SkipsAlreadyProcessed)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000003c80", "oid:0x5000000000e090");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c81", "oid:0x5000000000e090");
+    const auto curNh = deserializePair("oid:0x4000000000c60", "oid:0x4000000000e0b0");
+    const auto tmpNh = deserializePair("oid:0x4000000000c61", "oid:0x4000000000e0b0");
+
+    auto curNhgObj = addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.85"},
+    });
+
+    addOidObject(currentView, deserializePair("oid:0x2d000000003c80", "oid:0x2d0000000000e090"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c80"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c60"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(tempView, tmpNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.85"},
+    });
+
+    addOidObject(tempView, deserializePair("oid:0x2d000000003c81", "oid:0x2d0000000000e091"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003c81"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c61"},
+    });
+
+    tempView.m_vidToRid[tmpNh.vid] = curNh.rid;
+
+    currentView.getNhgMemberIndex();
+    curNhgObj->setObjectStatus(SAI_OBJECT_STATUS_MATCHED);
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    EXPECT_EQ(bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj), nullptr);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForGenericObject_EmptyNhgFallsThroughToSlowPath)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000003c90", "oid:0x5000000000e0a0");
+    const auto tmpNhg = deserializePair("oid:0x5000000003c91", "oid:0x5000000000e0a0");
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchForGenericObject(tmpNhgObj);
+
+    ASSERT_NE(match, nullptr);
+    EXPECT_EQ(match->getVid(), curNhg.vid);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForGenericObject_NhgmRidEqualWhenGroupVidUnmapped)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000003ca0", "oid:0x5000000000e0b0");
+    const auto curNh = deserializePair("oid:0x4000000000c70", "oid:0x4000000000e0c0");
+    const auto tmpNh = deserializePair("oid:0x4000000000c71", "oid:0x4000000000e0c0");
+    const auto curNhgm = deserializePair("oid:0x2d000000003ca0", "oid:0x2d0000000000e0b0");
+    const auto tmpNhgm = deserializePair("oid:0x2d000000003ca1", "oid:0x2d0000000000e0b1");
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.86"},
+    });
+
+    addOidObject(currentView, curNhgm, {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003ca0"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c70"},
+    });
+
+    auto tmpNhgmObj = addOidObject(tempView, tmpNhgm, {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000003ca0"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000c71"},
+    });
+
+    tempView.m_vidToRid[tmpNh.vid] = curNh.rid;
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchForGenericObject(tmpNhgmObj);
+
+    ASSERT_NE(match, nullptr);
+    EXPECT_EQ(match->getVid(), curNhgm.vid);
+}

--- a/unittest/syncd/TestBestCandidateFinderIdentityIndex.cpp
+++ b/unittest/syncd/TestBestCandidateFinderIdentityIndex.cpp
@@ -1,0 +1,260 @@
+#include "BestCandidateFinder.h"
+#include "MockableSaiSwitchInterface.h"
+
+#include "meta/sai_serialize.h"
+
+#include "swss/logger.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace syncd;
+using namespace unittests;
+
+namespace
+{
+    struct TestOidPair
+    {
+        sai_object_id_t vid;
+        sai_object_id_t rid;
+    };
+
+    TestOidPair deserializePair(
+            _In_ const char *vidStr,
+            _In_ const char *ridStr)
+    {
+        SWSS_LOG_ENTER();
+
+        TestOidPair pair;
+
+        sai_deserialize_object_id(vidStr, pair.vid);
+        sai_deserialize_object_id(ridStr, pair.rid);
+
+        return pair;
+    }
+
+    std::shared_ptr<SaiObj> addOidObject(
+            _Inout_ AsicView &view,
+            _In_ const TestOidPair &ids,
+            _In_ const std::vector<std::pair<const char*, const char*>> &attrs)
+    {
+        SWSS_LOG_ENTER();
+
+        auto obj = view.createDummyExistingObject(ids.rid, ids.vid);
+
+        for (const auto &attr: attrs)
+        {
+            obj->setAttr(std::make_shared<SaiAttr>(attr.first, attr.second));
+        }
+
+        return obj;
+    }
+}
+
+TEST(BestCandidateFinderIdentityIndex, buildAttrFilterFromObject_SkipsReadOnly)
+{
+    AsicView view;
+
+    const auto ids = deserializePair("oid:0x4000000000912", "oid:0x400000000040");
+
+    auto nh = addOidObject(view, ids, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.9"},
+    });
+
+    const auto filter = BestCandidateFinder::buildAttrFilterFromObject(nh);
+
+    EXPECT_EQ(filter.size(), 2u);
+    EXPECT_NE(filter.find(SAI_NEXT_HOP_ATTR_TYPE), filter.end());
+    EXPECT_NE(filter.find(SAI_NEXT_HOP_ATTR_IP), filter.end());
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchUsingIdentityIndex)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curIds = deserializePair("oid:0x4000000000913", "oid:0x400000000050");
+    const auto tmpIds = deserializePair("oid:0x4000000000914", "oid:0x400000000050");
+
+    addOidObject(currentView, curIds, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.10"},
+    });
+
+    auto tmpNh = addOidObject(tempView, tmpIds, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.10"},
+    });
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchUsingIdentityIndex(tmpNh);
+
+    ASSERT_NE(match, nullptr);
+    EXPECT_EQ(match->getVid(), curIds.vid);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchUsingIdentityIndex_DuplicateAclTableGroupsFallThrough)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto cur1 = deserializePair("oid:0xb000000000001", "oid:0xb000000000010");
+    const auto cur2 = deserializePair("oid:0xb000000000002", "oid:0xb000000000011");
+    const auto tmpIds = deserializePair("oid:0xb000000000003", "oid:0xb000000000012");
+
+    const std::vector<std::pair<const char*, const char*>> atgAttrs = {
+        {"SAI_ACL_TABLE_GROUP_ATTR_ACL_STAGE", "SAI_ACL_STAGE_INGRESS"},
+        {"SAI_ACL_TABLE_GROUP_ATTR_ACL_BIND_POINT_TYPE_LIST", "1:SAI_ACL_BIND_POINT_TYPE_PORT"},
+        {"SAI_ACL_TABLE_GROUP_ATTR_TYPE", "SAI_ACL_TABLE_GROUP_TYPE_PARALLEL"},
+    };
+
+    addOidObject(currentView, cur1, atgAttrs);
+    addOidObject(currentView, cur2, atgAttrs);
+
+    auto tmpAtg = addOidObject(tempView, tmpIds, atgAttrs);
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchUsingIdentityIndex(tmpAtg);
+
+    EXPECT_EQ(match, nullptr);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForNextHopGroupUsingMemberIndex)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000002caf", "oid:0x500000000020");
+    const auto tmpNhg = deserializePair("oid:0x5000000002cb0", "oid:0x500000000020");
+    const auto curNh = deserializePair("oid:0x4000000000915", "oid:0x400000000060");
+    const auto tmpNh = deserializePair("oid:0x4000000000916", "oid:0x400000000060");
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.11"},
+    });
+
+    addOidObject(currentView, deserializePair("oid:0x2d000000002cb0", "oid:0x2d000000000020"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002caf"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000915"},
+    });
+
+    auto tmpNhgObj = addOidObject(tempView, tmpNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(tempView, tmpNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.11"},
+    });
+
+    addOidObject(tempView, deserializePair("oid:0x2d000000002cb1", "oid:0x2d000000000021"), {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002cb0"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000916"},
+    });
+
+    tempView.m_vidToRid[tmpNh.vid] = curNh.rid;
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchForNextHopGroupUsingMemberIndex(tmpNhgObj);
+
+    ASSERT_NE(match, nullptr);
+    EXPECT_EQ(match->getVid(), curNhg.vid);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForGenericObject_NhgmSameRidDifferentVid)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000002cb2", "oid:0x500000000030");
+    const auto tmpNhg = deserializePair("oid:0x5000000002cb3", "oid:0x500000000030");
+    const auto curNh = deserializePair("oid:0x4000000000917", "oid:0x400000000070");
+    const auto tmpNh = deserializePair("oid:0x4000000000918", "oid:0x400000000070");
+    const auto curNhgm = deserializePair("oid:0x2d000000002cb2", "oid:0x2d000000000030");
+    const auto tmpNhgm = deserializePair("oid:0x2d000000002cb3", "oid:0x2d000000000031");
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.12"},
+    });
+
+    addOidObject(currentView, curNhgm, {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002cb2"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000917"},
+    });
+
+    auto tmpNhgmObj = addOidObject(tempView, tmpNhgm, {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002cb3"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000918"},
+    });
+
+    tempView.m_vidToRid[tmpNhg.vid] = curNhg.rid;
+    tempView.m_vidToRid[tmpNh.vid] = curNh.rid;
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchForGenericObject(tmpNhgmObj);
+
+    ASSERT_NE(match, nullptr);
+    EXPECT_EQ(match->getVid(), curNhgm.vid);
+}
+
+TEST(BestCandidateFinderIdentityIndex, findCurrentBestMatchForGenericObject_NhgmDifferentRidRejected)
+{
+    AsicView currentView;
+    AsicView tempView;
+
+    const auto curNhg = deserializePair("oid:0x5000000002cb4", "oid:0x500000000040");
+    const auto tmpNhg = deserializePair("oid:0x5000000002cb5", "oid:0x500000000040");
+    const auto curNh = deserializePair("oid:0x4000000000919", "oid:0x400000000080");
+    const auto tmpNh = deserializePair("oid:0x400000000091a", "oid:0x400000000081");
+    const auto curNhgm = deserializePair("oid:0x2d000000002cb4", "oid:0x2d000000000040");
+    const auto tmpNhgm = deserializePair("oid:0x2d000000002cb5", "oid:0x2d000000000041");
+
+    addOidObject(currentView, curNhg, {
+        {"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"},
+    });
+
+    addOidObject(currentView, curNh, {
+        {"SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP"},
+        {"SAI_NEXT_HOP_ATTR_IP", "10.0.0.13"},
+    });
+
+    addOidObject(currentView, curNhgm, {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002cb4"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x4000000000919"},
+    });
+
+    auto tmpNhgmObj = addOidObject(tempView, tmpNhgm, {
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0x5000000002cb5"},
+        {"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x400000000091a"},
+    });
+
+    tempView.m_vidToRid[tmpNhg.vid] = curNhg.rid;
+    tempView.m_vidToRid[tmpNh.vid] = tmpNh.rid;
+
+    auto sw = std::make_shared<MockableSaiSwitchInterface>(0, 0);
+    BestCandidateFinder bcf(currentView, tempView, sw);
+
+    auto match = bcf.findCurrentBestMatchForGenericObject(tmpNhgmObj);
+
+    EXPECT_EQ(match, nullptr);
+}


### PR DESCRIPTION
### Description of PR

Summary:
The APPLY_VIEW phase matches temporary (post-restart) SAI objects to current
(pre-restart) ASIC objects. The existing algorithm is O(n²) per object type,
which becomes prohibitively slow at scale (e.g. ~15K next-hops, ~60K NHG
members, ~3.7K NHGs in an EVPN-MH leaf).

This change introduces three additive fast-path optimizations that reduce
the hot path to O(n) for the most expensive object types, while preserving
full backward compatibility by falling through to the existing slow path
on any resolution failure.

### Type of change

- [ ] New feature

### Approach

#### What is the motivation for this PR?

At scale (EVPN-MH leaf with ~15K next-hops, ~60K NHG members, ~3.7K NHGs,
~30K routes), the `findCurrentBestMatchForGenericObject` slow path performs
O(n²) comparisons per object type. For next-hops alone, that is ~225 million
comparisons; for NHG members it exceeds 3.6 billion. This makes warm restart
reconciliation unacceptably slow.

#### How did you do it?

Three additive fast-path optimizations:

**1. Identity Index (general OID objects — `AsicView::getCreateOnlyIndex`)**

For each object type, builds a hash map keyed by a fingerprint string of the
object's CREATE_ONLY attributes (with OID references resolved to RIDs via the
VID→RID map). Temporary objects compute the same fingerprint and perform a
single O(1) hash-map lookup. The index is built lazily on first access and
cached for reuse across objects of the same type.

**2. NHG Member Index (`AsicView::getNhgMemberIndex`)**

Matches next-hop groups by their member composition — a sorted, semicolon-
delimited list of the member next-hop RIDs. This is semantically stronger than
generic attribute matching because it captures the group's actual forwarding
identity (which next-hops it contains), regardless of internal VID assignment.

**3. NHGM RID-based comparison (slow-path enhancement)**

When comparing `NEXT_HOP_GROUP_MEMBER` objects in the existing slow path, the
`NEXT_HOP_ID` attribute VIDs are resolved to RIDs before comparison. This
ensures members pointing to the same physical next-hop are correctly matched
even though their VIDs differ across restarts.

All fast paths fall through to the existing slow path on any resolution failure
(unresolved OID, empty key, ambiguous match), so **no existing behavior is
changed**.

#### How did you verify/test it?

- Unit tests for identity index building, key computation, and deduplication
  (`TestAsicViewIdentityIndex.cpp`)
- Unit tests for fast-path matching, NHG member index, and NHGM RID-based
  comparison (`TestBestCandidateFinderIdentityIndex.cpp`)
- Verified on EVPN-MH topology with ~15K next-hops and ~3.7K NHGs

### Fixes:

https://github.com/sonic-net/sonic-buildimage/issues/28787

#### Any platform specific information?

No platform-specific changes. All optimizations operate on the generic SAI
object model.

### Documentation

New file:
- `syncd/BestCandidateFinderIdentityIndex.cpp` — implements all three fast-path
  lookup functions

Modified files:
- `syncd/AsicView.cpp/.h` — identity index and NHG member index data structures
- `syncd/BestCandidateFinder.cpp/.h` — wiring: try fast paths before slow path
- `syncd/Makefile.am`, `unittest/syncd/Makefile.am` — build integration
