### PR TITLE
vpp: interface registry to consolidate scattered interface maps

### DIFF
--- a/vslib/Makefile.am
+++ b/vslib/Makefile.am
@@ -79,6 +79,7 @@ if USE_VPP
 libSaiVS_a_SOURCES +=\
 					  vpp/CRMTracker.cpp \
 					  vpp/SaiObjectDB.cpp \
+					  vpp/VppInterfaceRegistry.cpp \
 					  vpp/SwitchVpp.cpp \
 					  vpp/SwitchVppAcl.cpp \
 					  vpp/SwitchVppNexthop.cpp \

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -750,148 +750,6 @@ sai_status_t SwitchVpp::warm_update_queues()
     return SAI_STATUS_SUCCESS;
 }
 
-bool SwitchVpp::port_to_hostif_list(
-        _In_ sai_object_id_t port_id,
-        _Inout_ std::string& if_name)
-{
-    SWSS_LOG_ENTER();
-
-    // TODO to be removed and inlined
-
-    //sai_object_id_t switch_id = switchIdQuery(port_id);
-    //if (switch_id == SAI_NULL_OBJECT_ID) {
-    //return false;
-    //}
-    //auto it = m_switchStateMap.find(switch_id);
-    //if (it == m_switchStateMap.end()) {
-    //return false;
-    //}
-    //auto sw = it->second;
-    //if (sw == nullptr) {
-    //return false;
-    //}
-    //return(
-    return getTapNameFromPortId(port_id, if_name);
-}
-
-bool SwitchVpp::getTapNameFromPortOrLagId(
-        _In_ sai_object_id_t obj_id,
-        _Out_ std::string& if_name)
-{
-    SWSS_LOG_ENTER();
-
-    /*
-     * Answers uniformly for PORT and LAG, and answers only when a host netdev
-     * really exists: hasTapName() is false until the hostif is created for a
-     * port, or until vpp_ensure_lag_lcp() creates the be<N> pair for a bond.
-     */
-    auto rec = m_ifaceRegistry.findByOid(obj_id);
-
-    if (rec && rec->hasTapName())
-    {
-        if_name = rec->getTapName();
-
-        return true;
-    }
-
-    sai_object_type_t ot = objectTypeQuery(obj_id);
-
-    bool resolved = false;
-
-    if (ot == SAI_OBJECT_TYPE_PORT)
-    {
-        resolved = getTapNameFromPortId(obj_id, if_name);
-    }
-    else if (ot == SAI_OBJECT_TYPE_LAG)
-    {
-        platform_bond_info_t bond_info;
-        sai_status_t status = get_lag_bond_info(obj_id, bond_info);
-
-        if (status == SAI_STATUS_SUCCESS)
-        {
-            std::ostringstream tap_stream;
-            tap_stream << BOND_TAP_PREFIX << bond_info.id;
-            if_name = tap_stream.str();
-
-            resolved = true;
-        }
-    }
-
-    if (resolved)
-    {
-        SWSS_LOG_WARN("registry has no tap for %s, legacy path resolved %s",
-                sai_serialize_object_id(obj_id).c_str(), if_name.c_str());
-    }
-
-    return resolved;
-}
-
-/*
- * Host OS interface name of a port or LAG, i.e. the netdev SONiC itself
- * provisions and that shows up in `ip link`: "Ethernet<n>" for a port,
- * "PortChannel<id>" for a LAG.
- *
- * This is deliberately NOT the same as getTapNameFromPortOrLagId(): a LAG has
- * two host netdevs, the teamd-owned PortChannel<id> returned here and the
- * linux-cp tap be<id> returned there. They coincide for a physical port.
- * Use this one for anything keyed on the SONiC name -- `ip link show`, VRF
- * enslavement lookups, and osif_name_to_hwif_name().
- */
-bool SwitchVpp::getOsIfFromPortOrLagId(
-        _In_ sai_object_id_t obj_id,
-        _Out_ std::string& if_name)
-{
-    SWSS_LOG_ENTER();
-
-    sai_object_type_t ot = objectTypeQuery(obj_id);
-
-    if (ot == SAI_OBJECT_TYPE_PORT)
-    {
-        return getTapNameFromPortId(obj_id, if_name);
-    }
-
-    if (ot == SAI_OBJECT_TYPE_LAG)
-    {
-        platform_bond_info_t bond_info;
-        sai_status_t status = get_lag_bond_info(obj_id, bond_info);
-
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            return false;
-        }
-
-        if_name = std::string(PORTCHANNEL_PREFIX) + std::to_string(bond_info.id);
-
-        return true;
-    }
-
-    return false;
-}
-
-bool SwitchVpp::port_to_hwifname(
-        _In_ sai_object_id_t port_id,
-        _Inout_ std::string& if_name)
-{
-    SWSS_LOG_ENTER();
-
-    // TODO to be removed and inlined
-
-    // sai_object_id_t switch_id = switchIdQuery(port_id);
-    // if (switch_id == SAI_NULL_OBJECT_ID) {
-    // return false;
-    // }
-    // auto it = m_switchStateMap.find(switch_id);
-    // if (it == m_switchStateMap.end()) {
-    // return false;
-    // }
-    // auto sw = it->second;
-    // if (sw == nullptr) {
-    // return false;
-    // }
-
-    return vpp_get_hwif_name(port_id, 0, if_name);
-}
-
 void SwitchVpp::setPortStats(
         _In_ sai_object_id_t oid)
 {
@@ -899,9 +757,9 @@ void SwitchVpp::setPortStats(
 
     std::map<sai_stat_id_t, uint64_t> stats;
 
-    std::string if_name;
+    std::string if_name = m_ifaceRegistry.resolveHwIfName(oid, 0);
 
-    if (!port_to_hwifname(oid, if_name))
+    if (if_name.empty())
     {
         return;
     }
@@ -1357,29 +1215,18 @@ void SwitchVpp::processFdbEntriesForAging()
          */
         auto rec = m_ifaceRegistry.findBySwIfIndex(ev.sw_if_index);
 
-        uint32_t bd_id;
-
-        if (rec && rec->hasBdId()) {
-            bd_id = rec->getBdId();
-        } else {
-            auto bd_it = m_swif_to_bdid.find(ev.sw_if_index);
-
-            if (bd_it == m_swif_to_bdid.end()) {
-                SWSS_LOG_WARN("FDB: dropping MAC event for untracked sw_if_index %u "
-                              "(action %u, MAC %02x:%02x:%02x:%02x:%02x:%02x); "
-                              "VPP L2FIB will desync from ASIC_DB/STATE_DB",
-                              ev.sw_if_index, ev.action,
-                              ev.mac[0], ev.mac[1], ev.mac[2],
-                              ev.mac[3], ev.mac[4], ev.mac[5]);
-                events.pop();
-                continue;
-            }
-
-            bd_id = bd_it->second;
-
-            SWSS_LOG_WARN("FDB: registry has no bd_id for sw_if_index %u, legacy map says bd %u",
-                          ev.sw_if_index, bd_id);
+        if (!rec || !rec->hasBdId()) {
+            SWSS_LOG_WARN("FDB: dropping MAC event for untracked sw_if_index %u "
+                          "(action %u, MAC %02x:%02x:%02x:%02x:%02x:%02x); "
+                          "VPP L2FIB will desync from ASIC_DB/STATE_DB",
+                          ev.sw_if_index, ev.action,
+                          ev.mac[0], ev.mac[1], ev.mac[2],
+                          ev.mac[3], ev.mac[4], ev.mac[5]);
+            events.pop();
+            continue;
         }
+
+        uint32_t bd_id = rec->getBdId();
 
         VppFdbKey key;
         memcpy(key.mac, ev.mac, 6);
@@ -3057,10 +2904,10 @@ sai_status_t SwitchVpp::refresh_port_oper_speed(
     }
     else
     {
-        std::string hwif_name;
+        std::string hwif_name = m_ifaceRegistry.resolveHwIfName(port_id, 0);
         uint32_t vpp_speed_kbps = 0;
 
-        if (vpp_get_hwif_name(port_id, 0, hwif_name) &&
+        if (!hwif_name.empty() &&
             vpp_get_interface_speed(hwif_name.c_str(), &vpp_speed_kbps) == 0 &&
             vpp_speed_kbps > 0)
         {
@@ -3085,50 +2932,4 @@ sai_status_t SwitchVpp::refresh_port_oper_speed(
     CHECK_STATUS(set(SAI_OBJECT_TYPE_PORT, port_id, &attr));
 
     return SAI_STATUS_SUCCESS;
-}
-
-/*
- * Resolve a VPP sw_if_index to a SAI port OID via the 3-step lookup chain:
- * sw_if_index -> VPP hw interface name -> Linux tap/SONiC port name -> SAI port OID.
- * Returns SAI_NULL_OBJECT_ID on any lookup failure.
- */
-sai_object_id_t SwitchVpp::getPortIdFromSwIfIndex(uint32_t sw_if_index)
-{
-    SWSS_LOG_ENTER();
-
-    /*
-     * The registry indexes sw_if_index directly, so it answers in one step what
-     * the chain below needs three for -- and without depending on the interface
-     * having a host tap at all, which a LAG never has.
-     */
-    auto rec = m_ifaceRegistry.findBySwIfIndex(sw_if_index);
-
-    if (rec && rec->hasOid())
-    {
-        return rec->getOid();
-    }
-
-    const char *hwifname = vpp_get_swif_name(sw_if_index);
-    if (!hwifname)
-    {
-        SWSS_LOG_WARN("FDB: cannot get hwif name for sw_if_index %u", sw_if_index);
-        return SAI_NULL_OBJECT_ID;
-    }
-
-    const char *tapname = hwif_to_osif_name(hwifname);
-    if (!tapname)
-    {
-        SWSS_LOG_WARN("FDB: cannot get tap name for hwif %s", hwifname);
-        return SAI_NULL_OBJECT_ID;
-    }
-
-    sai_object_id_t port_id = getPortIdFromIfName(std::string(tapname));
-
-    if (port_id != SAI_NULL_OBJECT_ID)
-    {
-        SWSS_LOG_WARN("FDB: registry has no oid for sw_if_index %u, legacy chain resolved %s via %s/%s",
-                sw_if_index, sai_serialize_object_id(port_id).c_str(), hwifname, tapname);
-    }
-
-    return port_id;
 }

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -1714,6 +1714,32 @@ sai_status_t SwitchVpp::createPort(
     return create_port_dependencies(object_id, attr_count, attr_list);
 }
 
+sai_status_t SwitchVpp::removePort(
+        _In_ sai_object_id_t objectId)
+{
+    SWSS_LOG_ENTER();
+
+    /*
+     * Deregister only after the base removal has succeeded: it can refuse with
+     * SAI_STATUS_OBJECT_IN_USE while the port still has active dependencies,
+     * and dropping the record for a port that is still present would break
+     * resolveHwIfName() and resolveTapName() for it.
+     */
+    CHECK_STATUS(SwitchStateBase::removePort(objectId));
+
+    /*
+     * Cascades to any sub-interfaces parented on this port -- tagged VLAN
+     * members and SUB_PORT RIFs -- mirroring VPP, which deletes them with their
+     * parent. Zero is the normal answer for a port that never had its lane list
+     * set, since that is what registers it in the first place.
+     */
+    auto removed = m_ifaceRegistry.removeByOid(objectId);
+
+    SWSS_LOG_INFO("removed port %s from interface registry (%zu records)",
+            sai_serialize_object_id(objectId).c_str(), removed);
+
+    return SAI_STATUS_SUCCESS;
+}
 
 sai_status_t SwitchVpp::remove(
         _In_ sai_object_type_t object_type,

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -780,6 +780,69 @@ bool SwitchVpp::getTapNameFromPortOrLagId(
 {
     SWSS_LOG_ENTER();
 
+    /*
+     * Answers uniformly for PORT and LAG, and answers only when a host netdev
+     * really exists: hasTapName() is false until the hostif is created for a
+     * port, or until vpp_ensure_lag_lcp() creates the be<N> pair for a bond.
+     */
+    auto rec = m_ifaceRegistry.findByOid(obj_id);
+
+    if (rec && rec->hasTapName())
+    {
+        if_name = rec->getTapName();
+
+        return true;
+    }
+
+    sai_object_type_t ot = objectTypeQuery(obj_id);
+
+    bool resolved = false;
+
+    if (ot == SAI_OBJECT_TYPE_PORT)
+    {
+        resolved = getTapNameFromPortId(obj_id, if_name);
+    }
+    else if (ot == SAI_OBJECT_TYPE_LAG)
+    {
+        platform_bond_info_t bond_info;
+        sai_status_t status = get_lag_bond_info(obj_id, bond_info);
+
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            std::ostringstream tap_stream;
+            tap_stream << BOND_TAP_PREFIX << bond_info.id;
+            if_name = tap_stream.str();
+
+            resolved = true;
+        }
+    }
+
+    if (resolved)
+    {
+        SWSS_LOG_WARN("registry has no tap for %s, legacy path resolved %s",
+                sai_serialize_object_id(obj_id).c_str(), if_name.c_str());
+    }
+
+    return resolved;
+}
+
+/*
+ * Host OS interface name of a port or LAG, i.e. the netdev SONiC itself
+ * provisions and that shows up in `ip link`: "Ethernet<n>" for a port,
+ * "PortChannel<id>" for a LAG.
+ *
+ * This is deliberately NOT the same as getTapNameFromPortOrLagId(): a LAG has
+ * two host netdevs, the teamd-owned PortChannel<id> returned here and the
+ * linux-cp tap be<id> returned there. They coincide for a physical port.
+ * Use this one for anything keyed on the SONiC name -- `ip link show`, VRF
+ * enslavement lookups, and osif_name_to_hwif_name().
+ */
+bool SwitchVpp::getOsIfFromPortOrLagId(
+        _In_ sai_object_id_t obj_id,
+        _Out_ std::string& if_name)
+{
+    SWSS_LOG_ENTER();
+
     sai_object_type_t ot = objectTypeQuery(obj_id);
 
     if (ot == SAI_OBJECT_TYPE_PORT)
@@ -797,9 +860,7 @@ bool SwitchVpp::getTapNameFromPortOrLagId(
             return false;
         }
 
-        std::ostringstream tap_stream;
-        tap_stream << "be" << bond_info.id;
-        if_name = tap_stream.str();
+        if_name = std::string(PORTCHANNEL_PREFIX) + std::to_string(bond_info.id);
 
         return true;
     }
@@ -1285,21 +1346,44 @@ void SwitchVpp::processFdbEntriesForAging()
     while (!events.empty()) {
         const VppMacEvent &ev = events.front();
 
-        auto bd_it = m_swif_to_bdid.find(ev.sw_if_index);
-        if (bd_it == m_swif_to_bdid.end()) {
-            SWSS_LOG_WARN("FDB: dropping MAC event for untracked sw_if_index %u "
-                          "(action %u, MAC %02x:%02x:%02x:%02x:%02x:%02x); "
-                          "VPP L2FIB will desync from ASIC_DB/STATE_DB",
-                          ev.sw_if_index, ev.action,
-                          ev.mac[0], ev.mac[1], ev.mac[2],
-                          ev.mac[3], ev.mac[4], ev.mac[5]);
-            events.pop();
-            continue;
+        /*
+         * Bridge-domain membership is the drop gate: an event from an interface
+         * that is not in a BD is not a bridged MAC and must not reach ASIC_DB.
+         *
+         * Test hasBdId(), NEVER record existence. Every interface now has a
+         * permanent registry record from the moment it is created, so existence
+         * says nothing about BD membership -- gating on it would admit events
+         * for L3 interfaces that the old map deliberately rejected.
+         */
+        auto rec = m_ifaceRegistry.findBySwIfIndex(ev.sw_if_index);
+
+        uint32_t bd_id;
+
+        if (rec && rec->hasBdId()) {
+            bd_id = rec->getBdId();
+        } else {
+            auto bd_it = m_swif_to_bdid.find(ev.sw_if_index);
+
+            if (bd_it == m_swif_to_bdid.end()) {
+                SWSS_LOG_WARN("FDB: dropping MAC event for untracked sw_if_index %u "
+                              "(action %u, MAC %02x:%02x:%02x:%02x:%02x:%02x); "
+                              "VPP L2FIB will desync from ASIC_DB/STATE_DB",
+                              ev.sw_if_index, ev.action,
+                              ev.mac[0], ev.mac[1], ev.mac[2],
+                              ev.mac[3], ev.mac[4], ev.mac[5]);
+                events.pop();
+                continue;
+            }
+
+            bd_id = bd_it->second;
+
+            SWSS_LOG_WARN("FDB: registry has no bd_id for sw_if_index %u, legacy map says bd %u",
+                          ev.sw_if_index, bd_id);
         }
 
         VppFdbKey key;
         memcpy(key.mac, ev.mac, 6);
-        key.bd_id = bd_it->second;
+        key.bd_id = bd_id;
 
         switch (ev.action) {
         case VPP_MAC_ACTION_ADD:
@@ -3011,6 +3095,19 @@ sai_status_t SwitchVpp::refresh_port_oper_speed(
 sai_object_id_t SwitchVpp::getPortIdFromSwIfIndex(uint32_t sw_if_index)
 {
     SWSS_LOG_ENTER();
+
+    /*
+     * The registry indexes sw_if_index directly, so it answers in one step what
+     * the chain below needs three for -- and without depending on the interface
+     * having a host tap at all, which a LAG never has.
+     */
+    auto rec = m_ifaceRegistry.findBySwIfIndex(sw_if_index);
+
+    if (rec && rec->hasOid())
+    {
+        return rec->getOid();
+    }
+
     const char *hwifname = vpp_get_swif_name(sw_if_index);
     if (!hwifname)
     {
@@ -3018,12 +3115,20 @@ sai_object_id_t SwitchVpp::getPortIdFromSwIfIndex(uint32_t sw_if_index)
         return SAI_NULL_OBJECT_ID;
     }
 
-    const char *tapname = hwif_to_tap_name(hwifname);
+    const char *tapname = hwif_to_osif_name(hwifname);
     if (!tapname)
     {
         SWSS_LOG_WARN("FDB: cannot get tap name for hwif %s", hwifname);
         return SAI_NULL_OBJECT_ID;
     }
 
-    return getPortIdFromIfName(std::string(tapname));
+    sai_object_id_t port_id = getPortIdFromIfName(std::string(tapname));
+
+    if (port_id != SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_WARN("FDB: registry has no oid for sw_if_index %u, legacy chain resolved %s via %s/%s",
+                sw_if_index, sai_serialize_object_id(port_id).c_str(), hwifname, tapname);
+    }
+
+    return port_id;
 }

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -2,6 +2,8 @@
 
 #include "SwitchStateBase.h"
 
+#include "swss/logger.h"
+
 #include "IpVrfInfo.h"
 #include "SaiObjectDB.h"
 #include "BitResourcePool.h"
@@ -1289,6 +1291,7 @@ namespace saivs
 
             const VppInterfaceRegistry& getInterfaceRegistry() const
             {
+                                SWSS_LOG_ENTER();
                 return m_ifaceRegistry;
             }
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -280,6 +280,17 @@ namespace saivs
                     _In_ uint32_t attr_count,
                     _In_ const sai_attribute_t *attr_list);
 
+            /*
+             * Overridden purely to deregister the port from m_ifaceRegistry.
+             * The base class knows nothing about the registry, so without this
+             * a removed physical port would leave its record behind -- and
+             * because addPhysicalPort() refuses a hwif that is already
+             * registered, a later re-add of the same hwif would silently get no
+             * record at all. LAG and sub-port teardown already do this.
+             */
+            virtual sai_status_t removePort(
+                    _In_ sai_object_id_t objectId) override;
+
             virtual sai_status_t setPort(
                     _In_ sai_object_id_t portId,
                     _In_ const sai_attribute_t* attr) override;

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -182,14 +182,6 @@ namespace saivs
             void removeRouteCounterBinding(
                     _In_ const std::string &serializedObjectId);
 
-            bool port_to_hostif_list(
-                    _In_ sai_object_id_t oid,
-                    _Inout_ std::string& if_name);
-
-            bool port_to_hwifname(
-                    _In_ sai_object_id_t oid,
-                    _Inout_ std::string& if_name);
-
         public: // from VirtualSwitchSaiInterface changed functions
 
             virtual sai_status_t queryAttributeCapability(
@@ -1272,12 +1264,33 @@ namespace saivs
                     _Out_ uint32_t *vpp_rule_base_index,
                     _Out_ uint32_t *num_rules);
 
-            bool vpp_get_hwif_name (
+            /*
+             * VPP interface name of a PORT, on the port create/update path.
+             *
+             * Registry first, falling back to the hardware lane list, which is
+             * also what registers the port: create_ports() makes ports with no
+             * attributes at all and only later sets SAI_PORT_ATTR_HW_LANE_LIST,
+             * so this is the first moment a front panel port has a derivable
+             * name. That makes this the only entry point that can name a port
+             * which is not in the registry yet, and the reason it takes the
+             * attribute list -- during a set, the new lane list is in attr_list
+             * and not yet in the object store.
+             *
+             * Everywhere else the interface is necessarily already known, and
+             * the plain index lookup, VppInterfaceRegistry::resolveHwIfName(),
+             * is what should be used.
+             */
+            bool vppGetHwIfNameForPort (
                     _In_ sai_object_id_t object_id,
                     _In_ uint32_t vlan_id,
                     _Out_ std::string& ifname,
                     _In_ uint32_t attr_count = 0,
                     _In_ const sai_attribute_t *attr_list = nullptr);
+
+            const VppInterfaceRegistry& getInterfaceRegistry() const
+            {
+                return m_ifaceRegistry;
+            }
 
         public:
 
@@ -1290,14 +1303,6 @@ namespace saivs
             void deinitFdbEventHandling() override;
 
         protected: // VPP
-            typedef struct platform_bond_info_ {
-                uint32_t sw_if_index;
-                uint32_t id;
-                bool lcp_created;
-            } platform_bond_info_t;
-
-            void populate_if_mapping();
-
             bool getPortHwifNameFromLane(
                     _In_ sai_object_id_t port_id,
                     _Out_ std::string& if_name);
@@ -1307,33 +1312,8 @@ namespace saivs
                     _In_ uint32_t attr_count,
                     _In_ const sai_attribute_t *attr_list,
                     _Out_ std::string& if_name);
-            bool getTapNameFromPortOrLagId(
-                    _In_ sai_object_id_t obj_id,
-                    _Out_ std::string& if_name);
-
-            bool getOsIfFromPortOrLagId(
-                    _In_ sai_object_id_t obj_id,
-                    _Out_ std::string& if_name);
-
-            /*
-             * Resolve a host OS interface name ("Ethernet0", "PortChannel1",
-             * "PortChannel1.100", "Vlan200") to the VPP hardware interface
-             * name. The input is the SONiC-side netdev name as produced by
-             * getOsIfFromPortOrLagId(); a bond LCP tap name ("be1") is not
-             * accepted. Returns nullptr when the name cannot be resolved.
-             *
-             * Callers MUST check for nullptr: the result is routinely passed
-             * straight to a VPP call or a "%s" format, so an unchecked miss is
-             * a null dereference rather than, as before, a VPP call against the
-             * literal string "Unknown" that failed somewhere further down.
-             */
-            const char *osif_name_to_hwif_name(const char *name);
-
-            const char *hwif_to_osif_name(const char *name);
 
             uint32_t find_new_bond_id();
-            sai_status_t get_lag_bond_info(const sai_object_id_t lag_id, platform_bond_info_t &bond_info);
-            int remove_lag_to_bond_entry (const sai_object_id_t lag_id);
 
             void vppProcessEvents ();
 
@@ -1358,24 +1338,19 @@ namespace saivs
             /*
              * Single owner of interface identity: hwif name, SONiC name, host
              * tap, PORT/LAG oid, sw_if_index and bridge domain, for every kind
-             * of VPP interface. Being filled in alongside the older per-fact
-             * maps below; those are read from until the migration is complete.
+             * of VPP interface.
              */
             VppInterfaceRegistry m_ifaceRegistry;
 
-            std::map<std::string, std::string> m_osif_to_hwif_map;
-            std::map<std::string, std::string> m_hwif_to_osif_map;
-            int mapping_init = 0;
             bool m_run_vpp_events_thread = true;
             std::atomic<bool> m_operResyncDue { false };
             bool VppEventsThreadStarted = false;
             std::shared_ptr<std::thread> m_vpp_thread;
 
         private: // VPP
-	    // m_lag_bond_map and m_egress_disabled_lag_member_ports are only accessed on
-	    // the LAG create/set/remove path, which the VS layer serializes through a
-	    // single queue, so they require no additional locking.
-	    std::map<sai_object_id_t, platform_bond_info_t> m_lag_bond_map;
+	    // m_egress_disabled_lag_member_ports is only accessed on the LAG
+	    // create/set/remove path, which the VS layer serializes through a
+	    // single queue, so it requires no additional locking.
 	    std::set<sai_object_id_t> m_egress_disabled_lag_member_ports;
 
             static int currentMaxInstance;
@@ -1392,17 +1367,6 @@ namespace saivs
             // Kept in sync with MAC events from VPP to support flush operations
             // and de-duplication of events.
             std::map<VppFdbKey, uint32_t> m_vpp_fdb_entries;
-
-            // Cache: VPP sw_if_index -> SAI port OID, built from FDB learn events.
-            // Avoids per-entry VPP API calls in vpp_fdb_entries_invalidate_by_port().
-            // Invalidated per sw_if_index on port-leave via swif_bdid_untrack(),
-            // since VPP recycles sw_if_index values after an interface is deleted.
-            std::unordered_map<uint32_t, sai_object_id_t> m_swif_to_port_id;
-
-            // Maps VPP sw_if_index -> bridge domain ID.
-            // Maintained when ports are added/removed from bridge domains.
-            // Required because l2_macs_event carries sw_if_index but not bd_id.
-            std::map<uint32_t, uint32_t> m_swif_to_bdid;
 
             // MAC event queue — thread boundary between VPP and saivpp.
             //
@@ -1437,20 +1401,15 @@ namespace saivs
 
             bool generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type);
             bool generateFdbAgedEvent(const VppFdbKey &key);
-            sai_object_id_t getPortIdFromSwIfIndex(uint32_t sw_if_index);
-
-            // Cache-first resolution of sw_if_index -> SAI port OID.
-            // On a cache miss, falls back to the VPP API lookup and memoizes the result.
-            // Defined inline in SwitchVppFdb.cpp (its only translation unit).
-            sai_object_id_t resolvePortIdFromSwIfIndex(uint32_t sw_if_index);
 
             void vpp_fdb_entries_invalidate_all();
             void vpp_fdb_entries_invalidate_by_bd(uint32_t bd_id);
             void vpp_fdb_entries_invalidate_by_port(sai_object_id_t port_id);
 
-            // Track/untrack sw_if_index→bd_id when ports join/leave bridge domains.
-            // Untrack also invalidates the m_swif_to_port_id cache for that
-            // sw_if_index, since both per-swif caches share the same lifecycle.
+            // Track/untrack bd_id on the interface record when ports join/leave
+            // bridge domains. Having a bd_id is the gate that admits an FDB
+            // event: every interface has a record, so record existence alone
+            // does not imply bridge domain membership.
             void swif_bdid_track(const char *hwif_name, uint32_t bd_id);
             void swif_bdid_untrack(const char *hwif_name);
 

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -10,6 +10,7 @@
 #include "SwitchVppAcl.h"
 #include "CRMTracker.h"
 #include "PortConfigMap.h"
+#include "VppInterfaceRegistry.h"
 
 #include "vppxlate/SaiVppXlate.h"
 #include "vppxlate/SaiRouteStats.h"
@@ -704,14 +705,6 @@ namespace saivs
             sai_status_t vpp_remove_router_interface(
                     _In_ sai_object_id_t objectId);
 
-            sai_status_t vpp_router_interface_remove_vrf(
-                    _In_ sai_object_id_t obj_id);
-
-            sai_status_t vpp_add_del_intf_ip_addr (
-                    _In_ sai_ip_prefix_t& ip_prefix,
-                    _In_ sai_object_id_t nexthop_oid,
-                    _In_ bool is_add);
-
             sai_status_t vpp_add_del_intf_ip_addr_norif (
                     _In_ const std::string& ip_prefix_key,
                     _In_ sai_route_entry_t& route_entry,
@@ -732,11 +725,6 @@ namespace saivs
 
             sai_status_t vpp_del_lpb_intf_ip_addr (
                     _In_ const std::string &serializedObjectId);
-
-            sai_status_t vpp_get_router_intf_name (
-                    _In_ sai_ip_prefix_t& ip_prefix,
-                    _In_ sai_object_id_t rif_id,
-                    std::string& nexthop_ifname);
 
             int getNextLoopbackInstance();
 
@@ -1322,9 +1310,26 @@ namespace saivs
             bool getTapNameFromPortOrLagId(
                     _In_ sai_object_id_t obj_id,
                     _Out_ std::string& if_name);
-            const char *tap_to_hwif_name(const char *name);
 
-            const char *hwif_to_tap_name(const char *name);
+            bool getOsIfFromPortOrLagId(
+                    _In_ sai_object_id_t obj_id,
+                    _Out_ std::string& if_name);
+
+            /*
+             * Resolve a host OS interface name ("Ethernet0", "PortChannel1",
+             * "PortChannel1.100", "Vlan200") to the VPP hardware interface
+             * name. The input is the SONiC-side netdev name as produced by
+             * getOsIfFromPortOrLagId(); a bond LCP tap name ("be1") is not
+             * accepted. Returns nullptr when the name cannot be resolved.
+             *
+             * Callers MUST check for nullptr: the result is routinely passed
+             * straight to a VPP call or a "%s" format, so an unchecked miss is
+             * a null dereference rather than, as before, a VPP call against the
+             * literal string "Unknown" that failed somewhere further down.
+             */
+            const char *osif_name_to_hwif_name(const char *name);
+
+            const char *hwif_to_osif_name(const char *name);
 
             uint32_t find_new_bond_id();
             sai_status_t get_lag_bond_info(const sai_object_id_t lag_id, platform_bond_info_t &bond_info);
@@ -1350,8 +1355,16 @@ namespace saivs
 
             std::shared_ptr<PortConfigMap> m_portConfigMap;
 
-            std::map<std::string, std::string> m_hostif_hwif_map;
-            std::map<std::string, std::string> m_hwif_hostif_map;
+            /*
+             * Single owner of interface identity: hwif name, SONiC name, host
+             * tap, PORT/LAG oid, sw_if_index and bridge domain, for every kind
+             * of VPP interface. Being filled in alongside the older per-fact
+             * maps below; those are read from until the migration is complete.
+             */
+            VppInterfaceRegistry m_ifaceRegistry;
+
+            std::map<std::string, std::string> m_osif_to_hwif_map;
+            std::map<std::string, std::string> m_hwif_to_osif_map;
             int mapping_init = 0;
             bool m_run_vpp_events_thread = true;
             std::atomic<bool> m_operResyncDue { false };

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -539,8 +539,8 @@ sai_status_t SwitchVpp::tunterm_set_action_redirect(
         vlan_id = attr.value.u16;
     }
 
-    std::string hwif_name;
-    if (!vpp_get_hwif_name(port_oid, vlan_id, hwif_name)) {
+    std::string hwif_name = m_ifaceRegistry.resolveHwIfName(port_oid, vlan_id);
+    if (hwif_name.empty()) {
         SWSS_LOG_WARN("VS hwif name not found for port %s", sai_serialize_object_id(port_oid).c_str());
         return SAI_STATUS_SUCCESS;
     }
@@ -2015,9 +2015,9 @@ sai_status_t SwitchVpp::aclBindUnbindPort(
         return SAI_STATUS_SUCCESS;
     }
 
-    std::string hwif_name;
+    std::string hwif_name = m_ifaceRegistry.resolveHwIfName(port_oid, 0);
 
-    if (!vpp_get_hwif_name(port_oid, 0, hwif_name)) {
+    if (hwif_name.empty()) {
         SWSS_LOG_WARN("VS hwif name not found for port %s", sai_serialize_object_id(port_oid).c_str());
         return SAI_STATUS_FAILURE;
     }
@@ -2179,7 +2179,9 @@ sai_status_t SwitchVpp::aclBindUnbindPorts(
 
     for (auto port_oid: member_list) {
 
-        if (!vpp_get_hwif_name(port_oid, 0, hwif_name)) {
+        hwif_name = m_ifaceRegistry.resolveHwIfName(port_oid, 0);
+
+        if (hwif_name.empty()) {
             SWSS_LOG_WARN("VS hwif name not found for port %s", sai_serialize_object_id(port_oid).c_str());
             continue;
         }

--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -1161,9 +1161,8 @@ sai_status_t SwitchVpp::acl_entry_in_ports_get(
 
     for (uint32_t i = 0; i < attr.value.aclfield.data.objlist.count; i++) {
 
-        std::string hwif_name;
-
-        if (!vpp_get_hwif_name(ports[i], 0, hwif_name)) {
+        std::string hwif_name = m_ifaceRegistry.resolveHwIfName(ports[i], 0);
+        if (hwif_name.empty()) {
             SWSS_LOG_WARN("No VPP interface for port %s named by IN_PORTS of ACL entry %s",
                           sai_serialize_object_id(ports[i]).c_str(),
                           sai_serialize_object_id(ace_oid).c_str());

--- a/vslib/vpp/SwitchVppBfd.cpp
+++ b/vslib/vpp/SwitchVppBfd.cpp
@@ -193,7 +193,21 @@ sai_status_t SwitchVpp::vpp_bfd_session_add(
             SWSS_LOG_INFO("Port attribute not passed as parameter: get if name from ip address");
             if (vpp_get_ifname_from_ip_address(local_addr, ifname) == true)
             {
-                hwif_name = tap_to_hwif_name(ifname.c_str());
+                /*
+                 * ifname comes from "ip addr show", so it is a kernel netdev
+                 * name: "Ethernet0", but equally "PortChannel102" or "Vlan200".
+                 * Resolving it is not optional -- an unresolved name used to
+                 * reach bfd_udp_add() as the literal "Unknown".
+                 */
+                hwif_name = osif_name_to_hwif_name(ifname.c_str());
+
+                if (hwif_name == nullptr)
+                {
+                    SWSS_LOG_ERROR("BFD session create request FAILED, no hwif for interface %s",
+                            ifname.c_str());
+                    return SAI_STATUS_FAILURE;
+                }
+
                 SWSS_LOG_INFO("interface name for BFD session create is %s", hwif_name);
             }
             else
@@ -347,7 +361,15 @@ sai_status_t SwitchVpp::vpp_bfd_session_del(
             */
             std::string ifname = "";
             if (vpp_get_ifname_from_ip_address(local_addr, ifname) == true) {
-                hwif_name = tap_to_hwif_name(ifname.c_str());
+                hwif_name = osif_name_to_hwif_name(ifname.c_str());
+
+                if (hwif_name == nullptr)
+                {
+                    SWSS_LOG_ERROR("BFD session delete request FAILED, no hwif for interface %s",
+                            ifname.c_str());
+                    return SAI_STATUS_FAILURE;
+                }
+
                 SWSS_LOG_NOTICE("interface name for BFD session delete is %s", hwif_name);
             }
             else

--- a/vslib/vpp/SwitchVppBfd.cpp
+++ b/vslib/vpp/SwitchVppBfd.cpp
@@ -183,7 +183,11 @@ sai_status_t SwitchVpp::vpp_bfd_session_add(
         tos = attr->value.u8;
     }
 
-    const char *hwif_name = NULL;
+    /*
+     * By value, not a const char*: this outlives the block below, and the
+     * strings it used to point into did not.
+     */
+    std::string hwif_name;
     if (!multihop) {
         /* Attribute#7 */
         std::string ifname = "";
@@ -199,16 +203,16 @@ sai_status_t SwitchVpp::vpp_bfd_session_add(
                  * Resolving it is not optional -- an unresolved name used to
                  * reach bfd_udp_add() as the literal "Unknown".
                  */
-                hwif_name = osif_name_to_hwif_name(ifname.c_str());
+                hwif_name = m_ifaceRegistry.resolveHwIfByOsIf(ifname);
 
-                if (hwif_name == nullptr)
+                if (hwif_name.empty())
                 {
                     SWSS_LOG_ERROR("BFD session create request FAILED, no hwif for interface %s",
                             ifname.c_str());
                     return SAI_STATUS_FAILURE;
                 }
 
-                SWSS_LOG_INFO("interface name for BFD session create is %s", hwif_name);
+                SWSS_LOG_INFO("interface name for BFD session create is %s", hwif_name.c_str());
             }
             else
             {
@@ -227,11 +231,9 @@ sai_status_t SwitchVpp::vpp_bfd_session_add(
                         sai_serialize_object_type(obj_type).c_str());
                 return SAI_STATUS_FAILURE;
             }
-            if (vpp_get_hwif_name(port_id, 0, ifname) == true)
-            {
-                hwif_name = ifname.c_str();
-            }
-            else
+            hwif_name = m_ifaceRegistry.resolveHwIfName(port_id, 0);
+
+            if (hwif_name.empty())
             {
                 SWSS_LOG_ERROR("BFD session create request FAILED due to invalid hwif name");
 
@@ -240,8 +242,8 @@ sai_status_t SwitchVpp::vpp_bfd_session_add(
         }
     }
 
-    if (multihop || hwif_name) {
-        SWSS_LOG_NOTICE("BFD session create request sent to VS, hwif: %s, multihop: %d, oid: %ld",  hwif_name, multihop, bfd_oid);
+    if (multihop || !hwif_name.empty()) {
+        SWSS_LOG_NOTICE("BFD session create request sent to VS, hwif: %s, multihop: %d, oid: %ld",  hwif_name.c_str(), multihop, bfd_oid);
         /* VPP exposes only a global BFD TOS; sync it before adding a
          * session that disagrees with the last-programmed value. Warn
          * (but proceed) when active sessions had a different TOS --
@@ -266,7 +268,7 @@ sai_status_t SwitchVpp::vpp_bfd_session_add(
             }
         }
         /*vpp call to add bfd session*/
-        ret = bfd_udp_add(multihop, hwif_name, &vpp_local_addr, &vpp_peer_addr, detect_mult, required_min_tx, required_min_rx);
+        ret = bfd_udp_add(multihop, hwif_name.empty() ? nullptr : hwif_name.c_str(), &vpp_local_addr, &vpp_peer_addr, detect_mult, required_min_tx, required_min_rx);
         if (ret >= 0)
         {
             BFD_MUTEX;
@@ -332,7 +334,11 @@ sai_status_t SwitchVpp::vpp_bfd_session_del(
         multihop = attr.value.booldata;
     }
 
-    const char *hwif_name = NULL;
+    /*
+     * By value, not a const char*: this outlives the block below, and the
+     * strings it used to point into did not.
+     */
+    std::string hwif_name;
     if (!multihop) {
         /* Attribute#4 */
         attr.id = SAI_BFD_SESSION_ATTR_PORT;
@@ -346,11 +352,9 @@ sai_status_t SwitchVpp::vpp_bfd_session_del(
                         sai_serialize_object_type(obj_type).c_str());
                 return SAI_STATUS_FAILURE;
             }
-            std::string ifname = "";
-            if (vpp_get_hwif_name(port_id, 0, ifname) == true) {
-                hwif_name = ifname.c_str();
-            }
-            else
+            hwif_name = m_ifaceRegistry.resolveHwIfName(port_id, 0);
+
+            if (hwif_name.empty())
             {
                 SWSS_LOG_ERROR("BFD session delete request FAILED due to invalid hwif name");
                 return SAI_STATUS_FAILURE;
@@ -361,16 +365,16 @@ sai_status_t SwitchVpp::vpp_bfd_session_del(
             */
             std::string ifname = "";
             if (vpp_get_ifname_from_ip_address(local_addr, ifname) == true) {
-                hwif_name = osif_name_to_hwif_name(ifname.c_str());
+                hwif_name = m_ifaceRegistry.resolveHwIfByOsIf(ifname);
 
-                if (hwif_name == nullptr)
+                if (hwif_name.empty())
                 {
                     SWSS_LOG_ERROR("BFD session delete request FAILED, no hwif for interface %s",
                             ifname.c_str());
                     return SAI_STATUS_FAILURE;
                 }
 
-                SWSS_LOG_NOTICE("interface name for BFD session delete is %s", hwif_name);
+                SWSS_LOG_NOTICE("interface name for BFD session delete is %s", hwif_name.c_str());
             }
             else
             {
@@ -380,10 +384,10 @@ sai_status_t SwitchVpp::vpp_bfd_session_del(
         }
     }
 
-    if (multihop || hwif_name) {
-        SWSS_LOG_NOTICE("BFD session delete request sent to VS, hwif: %s, multihop: %d, oid: %ld",  hwif_name, multihop, bfd_oid);
+    if (multihop || !hwif_name.empty()) {
+        SWSS_LOG_NOTICE("BFD session delete request sent to VS, hwif: %s, multihop: %d, oid: %ld",  hwif_name.c_str(), multihop, bfd_oid);
         /*vpp call to add bfd session*/
-        ret = bfd_udp_del(multihop, hwif_name, &vpp_local_addr, &vpp_peer_addr);
+        ret = bfd_udp_del(multihop, hwif_name.empty() ? nullptr : hwif_name.c_str(), &vpp_local_addr, &vpp_peer_addr);
         if (ret >= 0)
         {
             BFD_MUTEX;

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -818,7 +818,9 @@ sai_status_t SwitchVpp::vpp_create_vlan_member(
         return SAI_STATUS_FAILURE;
     }
 
-    if (!vpp_get_hwif_name(port_id, 0, hwif_str))
+    hwif_str = m_ifaceRegistry.resolveHwIfName(port_id, 0);
+
+    if (hwif_str.empty())
     {
         SWSS_LOG_NOTICE("No VPP interface found for bridge port id :%s",
                 sai_serialize_object_id(br_port_id).c_str());
@@ -1076,7 +1078,9 @@ sai_status_t SwitchVpp::vpp_remove_vlan_member(
         return SAI_STATUS_FAILURE;
     }
 
-    if (!vpp_get_hwif_name(port_id, 0, hwif_str))
+    hwif_str = m_ifaceRegistry.resolveHwIfName(port_id, 0);
+
+    if (hwif_str.empty())
     {
         SWSS_LOG_NOTICE("No VPP interface found for bridge port id :%s",
                 sai_serialize_object_id(br_port_oid).c_str());
@@ -1252,9 +1256,9 @@ bool SwitchVpp::vlan_member_hwif(
         return false;
     }
 
-    std::string hwif_str;
+    std::string hwif_str = m_ifaceRegistry.resolveHwIfName(port_id, 0);
 
-    if (!vpp_get_hwif_name(port_id, 0, hwif_str))
+    if (hwif_str.empty())
     {
         SWSS_LOG_WARN("No VPP interface for vlan member %s",
                 vlan_member.get_id().c_str());
@@ -1551,7 +1555,7 @@ sai_status_t SwitchVpp::vpp_create_bvi_interface(
          * recorded explicitly: it exists only once the LCP pair above has been
          * created, and hasTapName() is what tells a reader that.
          */
-        auto bvi_rec = m_ifaceRegistry.addBvi(static_cast<uint16_t>(vlan_id));
+        auto bvi_rec = m_ifaceRegistry.addBvi(static_cast<uint16_t>(vlan_id), vlan_oid);
 
         if (bvi_rec)
         {
@@ -1741,59 +1745,6 @@ sai_status_t SwitchVpp::vpp_delete_bvi_interface(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t SwitchVpp::get_lag_bond_info(const sai_object_id_t lag_id, platform_bond_info_t &bond_info)
-{
-    SWSS_LOG_ENTER();
-
-    /*
-     * Registry first: addLag() takes the bond id, the sw_if_index and the oid in
-     * one call, so a registered LAG always has all three -- the map below only
-     * has them because the same creation path writes both.
-     */
-    auto rec = m_ifaceRegistry.findByOid(lag_id);
-
-    if (rec && rec->getType() == VppInterfaceType::LAG && rec->hasSwIfIndex())
-    {
-        const VppBondInterface *bond = rec->asBond();
-
-        bond_info.sw_if_index = rec->getSwIfIndex();
-        bond_info.id = bond->getBondId();
-        bond_info.lcp_created = bond->isLcpCreated();
-
-        return SAI_STATUS_SUCCESS;
-    }
-
-    auto it = m_lag_bond_map.find(lag_id);
-    if (it == m_lag_bond_map.end())
-    {
-        SWSS_LOG_ERROR("failed to find bond info for lag id: %s", sai_serialize_object_id(lag_id).c_str());
-        return SAI_STATUS_ITEM_NOT_FOUND;
-    }
-
-    SWSS_LOG_WARN("registry miss for lag %s, bond map resolved bond %u",
-            sai_serialize_object_id(lag_id).c_str(), it->second.id);
-
-    bond_info = it->second;
-    return SAI_STATUS_SUCCESS;
-}
-
-int SwitchVpp::remove_lag_to_bond_entry(const sai_object_id_t lag_oid)
-{
-    SWSS_LOG_ENTER();
-
-    auto it = m_lag_bond_map.find(lag_oid);
-
-    if (it == m_lag_bond_map.end())
-    {
-        SWSS_LOG_ERROR("failed to find lag swif index for : %s", sai_serialize_object_id(lag_oid).c_str());
-        return ~0;
-    }
-
-    SWSS_LOG_NOTICE("Removing lag object swif index: %s", sai_serialize_object_id(lag_oid).c_str());
-    m_lag_bond_map.erase(it);
-    return 0;
-}
-
 sai_status_t SwitchVpp::createLag(
         _In_ sai_object_id_t object_id,
         _In_ sai_object_id_t switch_id,
@@ -1811,7 +1762,11 @@ sai_status_t SwitchVpp::createLag(
 /*
  * This function determines the ID of a newly created PortChannel.
  * It does this by querying the list of PortChannels using the ip command and
- * comparing it to the existing LAG interfaces in m_lag_bond_map.
+ * comparing it to the bond ids already claimed by a registered LAG.
+ *
+ * The kernel netdev name is the only source of the number: SAI passes no name
+ * with a LAG object, and a bond record's "PortChannel<N>" is built FROM its id,
+ * so the registry can supply the already-used set but never a new id.
  *
  * This function is necessary due to the way IP addresses are set on interfaces in Sonic-VPP,
  * which requires mapping between the PortChannel interface and the BondEthernet in VPP.
@@ -1843,10 +1798,7 @@ uint32_t SwitchVpp::find_new_bond_id()
 
     SWSS_LOG_DEBUG("Output of ip command: %s", res.c_str());
 
-    std::unordered_set<uint32_t> existing_bond_ids;
-    for (const auto& entry : m_lag_bond_map) {
-        existing_bond_ids.insert(entry.second.id);
-    }
+    std::unordered_set<uint32_t> existing_bond_ids = m_ifaceRegistry.collectBondIds();
 
     std::istringstream iss(res);
     std::string line;
@@ -1907,9 +1859,6 @@ sai_status_t SwitchVpp::vpp_create_lag(
     }
 
     // Update the lag to bond map
-    platform_bond_info_t bond_info = {swif_idx, bond_id, false};
-    m_lag_bond_map[lag_id] = bond_info;
-
     /*
      * A bond is fully identified the moment it is created: the oid came in as a
      * parameter, the bond id was just allocated and the sw_if_index came back
@@ -1945,10 +1894,16 @@ sai_status_t SwitchVpp::vpp_remove_lag(
     SWSS_LOG_ENTER();
 
     int ret;
-    platform_bond_info_t bond_info;
 
-    CHECK_STATUS(get_lag_bond_info(lag_oid, bond_info));
-    uint32_t lag_swif_idx = bond_info.sw_if_index;
+    auto lag_rec = m_ifaceRegistry.findLag(lag_oid);
+
+    if (!lag_rec)
+    {
+        SWSS_LOG_ERROR("no bond record for lag id: %s", sai_serialize_object_id(lag_oid).c_str());
+        return SAI_STATUS_ITEM_NOT_FOUND;
+    }
+
+    uint32_t lag_swif_idx = lag_rec->getSwIfIndex();
     auto lag_ifname =  vpp_get_swif_name(lag_swif_idx);
     SWSS_LOG_NOTICE("lag swif idx :%d swif_name:%s",lag_swif_idx, lag_ifname);
     if (lag_ifname == NULL)
@@ -1964,7 +1919,6 @@ sai_status_t SwitchVpp::vpp_remove_lag(
         SWSS_LOG_ERROR("failed to delete bond interface in VPP for %s", sai_serialize_object_id(lag_oid).c_str());
         return SAI_STATUS_FAILURE;
     }
-    remove_lag_to_bond_entry(lag_oid);
 
     /*
      * delete_bond_interface() also tears down the LCP pair and any
@@ -2035,9 +1989,15 @@ sai_status_t SwitchVpp::vpp_create_lag_member(
         return SAI_STATUS_FAILURE;
     }
 
-    platform_bond_info_t bond_info;
-    CHECK_STATUS(get_lag_bond_info(lag_oid, bond_info));
-    bond_if_idx = bond_info.sw_if_index;
+    auto bond_rec = m_ifaceRegistry.findLag(lag_oid);
+
+    if (!bond_rec)
+    {
+        SWSS_LOG_ERROR("no bond record for lag id: %s", sai_serialize_object_id(lag_oid).c_str());
+        return SAI_STATUS_ITEM_NOT_FOUND;
+    }
+
+    bond_if_idx = bond_rec->getSwIfIndex();
     SWSS_LOG_NOTICE("bond if index is %d\n", bond_if_idx);
 
     attr_type = sai_metadata_get_attr_by_id(SAI_LAG_MEMBER_ATTR_PORT_ID, attr_count, attr_list);
@@ -2059,9 +2019,9 @@ sai_status_t SwitchVpp::vpp_create_lag_member(
         return SAI_STATUS_FAILURE;
     }
 
-    std::string hwif_str;
+    std::string hwif_str = m_ifaceRegistry.resolveHwIfName(lag_port_oid, 0);
 
-    if (!vpp_get_hwif_name(lag_port_oid, 0, hwif_str))
+    if (hwif_str.empty())
     {
         SWSS_LOG_NOTICE("No VPP interface found for lag port id :%s",
                 sai_serialize_object_id(lag_port_oid).c_str());
@@ -2110,9 +2070,9 @@ void SwitchVpp::vpp_set_lag_member_ip6(
     // Best effort, the caller must still complete the LAG member add/remove because
     // the VPP bond membership change already happened and failing here would leave
     // the object model inconsistent.
-    std::string hwif_str;
+    std::string hwif_str = m_ifaceRegistry.resolveHwIfName(port_oid, 0);
 
-    if (!vpp_get_hwif_name(port_oid, 0, hwif_str))
+    if (hwif_str.empty())
     {
         SWSS_LOG_ERROR("no hwif found for port %s, IPv6 not %s",
                 sai_serialize_object_id(port_oid).c_str(),
@@ -2138,20 +2098,24 @@ sai_status_t SwitchVpp::vpp_ensure_lag_lcp(
 {
     SWSS_LOG_ENTER();
 
-    platform_bond_info_t bond_info;
-    CHECK_STATUS(get_lag_bond_info(lag_oid, bond_info));
+    auto lag_rec = m_ifaceRegistry.findLag(lag_oid);
 
-    if (bond_info.lcp_created)
+    if (!lag_rec)
+    {
+        SWSS_LOG_ERROR("no bond record for lag id: %s", sai_serialize_object_id(lag_oid).c_str());
+        return SAI_STATUS_ITEM_NOT_FOUND;
+    }
+
+    VppBondInterface *bond = lag_rec->asBond();
+
+    if (bond->isLcpCreated())
     {
         return SAI_STATUS_SUCCESS;
     }
 
-    uint32_t bond_id = bond_info.id;
-    std::ostringstream tap_stream;
-    tap_stream << "be" << bond_id;
-    std::string tap = tap_stream.str();
+    std::string tap = VppBondInterface::tapNameFor(bond->getBondId());
 
-    const char *hw_ifname = vpp_get_swif_name(bond_info.sw_if_index);
+    const char *hw_ifname = vpp_get_swif_name(lag_rec->getSwIfIndex());
     if (hw_ifname == NULL)
     {
         SWSS_LOG_ERROR("failed to get VPP bond interface name for %s", sai_serialize_object_id(lag_oid).c_str());
@@ -2167,8 +2131,6 @@ sai_status_t SwitchVpp::vpp_ensure_lag_lcp(
      * be<id> -> PortChannel<id> tc mirred redirect is no longer needed and is
      * intentionally not installed (SONiC PR #2440 §5.3).
      */
-    bond_info.lcp_created = true;
-    m_lag_bond_map[lag_oid] = bond_info;
 
     /*
      * A LAG has no SAI hostif, so this is the ONLY point at which its host
@@ -2184,12 +2146,7 @@ sai_status_t SwitchVpp::vpp_ensure_lag_lcp(
      */
     m_ifaceRegistry.setTapName(hw_ifname, tap);
 
-    auto lag_rec = m_ifaceRegistry.findByOid(lag_oid);
-
-    if (lag_rec && lag_rec->getType() == VppInterfaceType::LAG)
-    {
-        lag_rec->asBond()->setLcpCreated(true);
-    }
+    bond->setLcpCreated(true);
 
     SWSS_LOG_NOTICE("Created LCP for LAG %s", sai_serialize_object_id(lag_oid).c_str());
 
@@ -2327,9 +2284,15 @@ sai_status_t SwitchVpp::get_lag_member_bond_index(
         return SAI_STATUS_FAILURE;
     }
 
-    platform_bond_info_t bond_info;
-    CHECK_STATUS(get_lag_bond_info(lag_oid, bond_info));
-    bond_sw_if_index = bond_info.sw_if_index;
+    auto bond_rec = m_ifaceRegistry.findLag(lag_oid);
+
+    if (!bond_rec)
+    {
+        SWSS_LOG_ERROR("no bond record for lag id: %s", sai_serialize_object_id(lag_oid).c_str());
+        return SAI_STATUS_ITEM_NOT_FOUND;
+    }
+
+    bond_sw_if_index = bond_rec->getSwIfIndex();
 
     return SAI_STATUS_SUCCESS;
 }
@@ -2350,8 +2313,9 @@ sai_status_t SwitchVpp::vpp_set_lag_member_egress_disable(
     sai_object_id_t port_oid;
     CHECK_STATUS(get_lag_member_port(lag_member_oid, port_oid));
 
-    std::string hwif_str;
-    if (!vpp_get_hwif_name(port_oid, 0, hwif_str))
+    std::string hwif_str = m_ifaceRegistry.resolveHwIfName(port_oid, 0);
+
+    if (hwif_str.empty())
     {
         SWSS_LOG_ERROR("No hwif found for lag member port id: %s", sai_serialize_object_id(port_oid).c_str());
         return SAI_STATUS_FAILURE;
@@ -2455,9 +2419,9 @@ sai_status_t SwitchVpp::restorePortTapMac(
 {
     SWSS_LOG_ENTER();
 
-    std::string if_name;
+    const std::string if_name = m_ifaceRegistry.resolveTapName(port_oid);
 
-    if (getTapNameFromPortId(port_oid, if_name) == false)
+    if (if_name.empty())
     {
         SWSS_LOG_ERROR("no tap found for port %s, switch MAC not restored",
                 sai_serialize_object_id(port_oid).c_str());
@@ -2545,9 +2509,9 @@ sai_status_t SwitchVpp::vpp_remove_lag_member(
         return SAI_STATUS_FAILURE;
     }
 
-    std::string hwif_str;
+    std::string hwif_str = m_ifaceRegistry.resolveHwIfName(port_oid, 0);
 
-    if (!vpp_get_hwif_name(port_oid, 0, hwif_str))
+    if (hwif_str.empty())
     {
         SWSS_LOG_NOTICE("No VPP interface found for lag port id :%s",
                 sai_serialize_object_id(port_oid).c_str());
@@ -2686,8 +2650,9 @@ sai_status_t SwitchVpp::vpp_fdbentry_add(
 
     uint32_t bd_id = attr.value.u16; /* bd_id is same as VLAN ID for .1Q bridge */
 
-    std::string ifname;
-    if (vpp_get_hwif_name(port_id, 0, ifname) == true)
+    std::string ifname = m_ifaceRegistry.resolveHwIfName(port_id, 0);
+
+    if (!ifname.empty())
     {
         const char *hwif_name = ifname.c_str();
         auto ret = l2fib_add_del(hwif_name, fdb_entry.mac_address, bd_id, is_add, is_static);
@@ -2823,9 +2788,9 @@ sai_status_t SwitchVpp::vpp_fdbentry_del(
                 sai_serialize_mac(fdb_entry.mac_address).c_str(), bd_id);
     }
 
-    std::string ifname;
+    std::string ifname = m_ifaceRegistry.resolveHwIfName(port_id, 0);
 
-    if (vpp_get_hwif_name(port_id, 0, ifname) == true)
+    if (!ifname.empty())
     {
         const char *hwif_name = ifname.c_str();
         auto ret = l2fib_add_del(hwif_name, fdb_entry.mac_address, bd_id, is_add, is_static);
@@ -2939,8 +2904,9 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
                             sai_serialize_object_type(obj_type).c_str());
                     return SAI_STATUS_FAILURE;
                 }
-                std::string ifname = "";
-                if (vpp_get_hwif_name(port_id, 0, ifname) == true)
+                std::string ifname = m_ifaceRegistry.resolveHwIfName(port_id, 0);
+
+                if (!ifname.empty())
                 {
                     const char *hwif_name = ifname.c_str();
                     auto ret = l2fib_flush_int(hwif_name);
@@ -2985,69 +2951,21 @@ sai_status_t SwitchVpp::vpp_fdbentry_flush(
     return SAI_STATUS_SUCCESS;
 }
 
-inline sai_object_id_t SwitchVpp::resolvePortIdFromSwIfIndex(uint32_t sw_if_index)
-{
-    SWSS_LOG_ENTER();
-
-    auto it = m_swif_to_port_id.find(sw_if_index);
-    if (it != m_swif_to_port_id.end())
-        return it->second;
-
-    /*
-     * The only lookup that can resolve a SUB-INTERFACE index. VPP reports the
-     * sub-interface sw_if_index in FDB learn events, and resolvePortOid() walks
-     * from the sub-interface record up to its parent's PORT/LAG oid -- which is
-     * what SAI_BRIDGE_PORT_ATTR_PORT_ID carries and what
-     * findBridgeVlanForPortVlan() matches on. Neither the name chain below nor
-     * the bond scan can answer that: the former dead-ends on a name the ifmap
-     * has never heard of, the latter compares the BOND index, not the sub-if's.
-     */
-    sai_object_id_t port_id = m_ifaceRegistry.resolvePortOid(sw_if_index);
-
-    if (port_id == SAI_NULL_OBJECT_ID)
-    {
-        port_id = getPortIdFromSwIfIndex(sw_if_index);
-    }
-
-    if (port_id == SAI_NULL_OBJECT_ID)
-    {
-        /*
-         * A LAG (BondEthernet<N>) is created directly via create_bond_interface()
-         * and has no SAI hostif tap, so it is absent from the hwif->hostif ifmap
-         * that getPortIdFromSwIfIndex() relies on. Resolve it from the bond map
-         * instead: SAI_BRIDGE_PORT_ATTR_PORT_ID of a PortChannel bridge port is
-         * the LAG OID, which is exactly what findBridgeVlanForPortVlan() matches
-         * on. Without this, every MAC learned on a PortChannel is dropped and
-         * never reaches ASIC_DB/STATE_DB (invisible to fdbshow).
-         */
-        for (const auto &kv : m_lag_bond_map)
-        {
-            if (kv.second.sw_if_index == sw_if_index)
-            {
-                port_id = kv.first;
-                SWSS_LOG_WARN("FDB: registry could not resolve sw_if_index %u, bond map resolved LAG %s (bond %u)",
-                                sw_if_index, sai_serialize_object_id(port_id).c_str(),
-                                kv.second.id);
-                break;
-            }
-        }
-    }
-
-    if (port_id != SAI_NULL_OBJECT_ID)
-    {
-        m_swif_to_port_id[sw_if_index] = port_id;
-    }
-
-    return port_id;
-}
-
 bool SwitchVpp::generateFdbLearnedOrMoveEvent(const VppFdbKey &key, uint32_t sw_if_index, sai_fdb_event_t event_type)
 {
     SWSS_LOG_ENTER();
 
     bool is_move = (event_type == SAI_FDB_EVENT_MOVE);
 
-    sai_object_id_t port_id = resolvePortIdFromSwIfIndex(sw_if_index);
+    /*
+     * resolveIfOid() is the only lookup that can resolve a SUB-INTERFACE index.
+     * VPP reports the sub-interface sw_if_index in FDB learn events and it
+     * walks from the sub-interface record up to its parent's PORT/LAG oid --
+     * which is what SAI_BRIDGE_PORT_ATTR_PORT_ID carries and what
+     * findBridgeVlanForPortVlan() matches on below. A BVI never sources an FDB
+     * event, so a VLAN oid cannot come back here.
+     */
+    sai_object_id_t port_id = m_ifaceRegistry.resolveIfOid(sw_if_index);
     if (port_id == SAI_NULL_OBJECT_ID)
     {
         SWSS_LOG_ERROR("FDB: cannot resolve port OID for sw_if_index %u", sw_if_index);
@@ -3184,12 +3102,9 @@ void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)
     uint32_t swif = vpp_get_swif_idx_by_name(hwif_name);
     if (swif != (uint32_t)~0u)
     {
-        m_swif_to_bdid[swif] = bd_id;
-
         /*
-         * Same two facts, in the record rather than in a side map. bd_id is the
-         * FDB drop gate, so it has to be attached to the interface it describes
-         * and torn down with it.
+         * bd_id is the FDB drop gate, so it has to be attached to the interface
+         * it describes and torn down with it.
          */
          //@todo: can this be moved to when the subif is created, add to the bd?
         m_ifaceRegistry.bindSwIfIndex(hwif_name, swif);
@@ -3203,7 +3118,7 @@ void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)
         // vpp_get_swif_idx_by_name() resolves against a locally cached
         // interface table populated by sw_interface_dump. A miss here means
         // every MAC learn/age event VPP reports for this interface will be
-        // dropped (its sw_if_index never enters m_swif_to_bdid), silently
+        // dropped (its sw_if_index carries no bd_id), silently
         // desyncing the VPP L2FIB from ASIC_DB/STATE_DB.
         SWSS_LOG_ERROR("FDB: cannot resolve sw_if_index for %s (bd %u); "
                        "MAC events for this interface will be dropped",
@@ -3214,22 +3129,11 @@ void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)
 void SwitchVpp::swif_bdid_untrack(const char *hwif_name)
 {
     SWSS_LOG_ENTER();
-    uint32_t swif = vpp_get_swif_idx_by_name(hwif_name);
-    if (swif != (uint32_t)~0u)
-    {
-        m_swif_to_bdid.erase(swif);
-
-        // Invalidate the sw_if_index -> SAI port OID memoization as well.
-        // VPP recycles sw_if_index values after an interface is deleted, so a
-        // stale entry would mis-attribute FDB learn/move/age notifications (and
-        // vpp_fdb_entries_invalidate_by_port matches) to the previous port OID.
-        m_swif_to_port_id.erase(swif);
-    }
 
     /*
-     * Keyed by name, so this still works when the sw_if_index lookup above
-     * misses -- which is exactly the leak the old code had, since it derived
-     * the index from the name at teardown and silently did nothing on a miss.
+     * Keyed by name, so this still works when a sw_if_index lookup would miss --
+     * which is exactly the leak the old code had, since it derived the index
+     * from the name at teardown and silently did nothing on a miss.
      * The record survives: leaving a bridge domain is not the end of the
      * interface.
      */
@@ -3264,7 +3168,7 @@ void SwitchVpp::vpp_fdb_entries_invalidate_by_port(sai_object_id_t port_id)
     size_t before = m_vpp_fdb_entries.size();
     for (auto it = m_vpp_fdb_entries.begin(); it != m_vpp_fdb_entries.end(); )
     {
-        if (resolvePortIdFromSwIfIndex(it->second) == port_id)
+        if (m_ifaceRegistry.resolveIfOid(it->second) == port_id)
             it = m_vpp_fdb_entries.erase(it);
         else
             ++it;

--- a/vslib/vpp/SwitchVppFdb.cpp
+++ b/vslib/vpp/SwitchVppFdb.cpp
@@ -799,8 +799,7 @@ sai_status_t SwitchVpp::vpp_create_vlan_member(
         return SAI_STATUS_SUCCESS;
     }
 
-    const char *hwifname = nullptr;
-    uint32_t lag_swif_idx;
+    std::string hwif_str;
 
     sai_object_id_t port_id;
 
@@ -819,29 +818,14 @@ sai_status_t SwitchVpp::vpp_create_vlan_member(
         return SAI_STATUS_FAILURE;
     }
 
-    if (obj_type == SAI_OBJECT_TYPE_PORT)
+    if (!vpp_get_hwif_name(port_id, 0, hwif_str))
     {
-        std::string if_name;
-        bool found = getTapNameFromPortId(port_id, if_name);
-        if (found == true)
-        {
-            hwifname = tap_to_hwif_name(if_name.c_str());
-        }else {
-            SWSS_LOG_NOTICE("No ports found for bridge port id :%s",sai_serialize_object_id(br_port_id).c_str());
-            return SAI_STATUS_FAILURE;
-        }
-    } else if (obj_type == SAI_OBJECT_TYPE_LAG) {
-        platform_bond_info_t bond_info;
-        CHECK_STATUS(get_lag_bond_info(port_id, bond_info));
-        lag_swif_idx = bond_info.sw_if_index;
-        SWSS_LOG_NOTICE("lag swif idx :%d",lag_swif_idx);
-	    hwifname =  vpp_get_swif_name(lag_swif_idx);
-        SWSS_LOG_NOTICE("lag swif idx :%d swif_name:%s",lag_swif_idx, hwifname);
-	    if (hwifname == NULL) {
-            SWSS_LOG_NOTICE("LAG is not found for bridge port id :%s",sai_serialize_object_id(br_port_id).c_str());
-            return SAI_STATUS_FAILURE;
-	    }
+        SWSS_LOG_NOTICE("No VPP interface found for bridge port id :%s",
+                sai_serialize_object_id(br_port_id).c_str());
+        return SAI_STATUS_FAILURE;
     }
+
+    const char *hwifname = hwif_str.c_str();
 
     auto attr_vlan_member = sai_metadata_get_attr_by_id(SAI_VLAN_MEMBER_ATTR_VLAN_ID, attr_count, attr_list);
 
@@ -896,6 +880,16 @@ sai_status_t SwitchVpp::vpp_create_vlan_member(
 
         /* lcp-auto-subint creates the host tap automatically */
         create_sub_interface(hwifname, vlan_id, vlan_id);
+
+        {
+            auto parent_rec = m_ifaceRegistry.findByHwif(hwifname);
+
+            if (parent_rec)
+            {
+                m_ifaceRegistry.addSubInterface(parent_rec, vlan_id,
+                        static_cast<uint16_t>(vlan_id));
+            }
+        }
 
         hw_ifname = host_subifname;
 
@@ -1063,7 +1057,7 @@ sai_status_t SwitchVpp::vpp_remove_vlan_member(
         return SAI_STATUS_SUCCESS;
     }
 
-    const char *hw_ifname = nullptr;
+    std::string hwif_str;
 
     sai_object_id_t port_id;
 
@@ -1082,29 +1076,14 @@ sai_status_t SwitchVpp::vpp_remove_vlan_member(
         return SAI_STATUS_FAILURE;
     }
 
-    if (obj_type == SAI_OBJECT_TYPE_PORT)
+    if (!vpp_get_hwif_name(port_id, 0, hwif_str))
     {
-        std::string if_name;
-        bool found = getTapNameFromPortId(port_id, if_name);
-        if (found == true)
-        {
-            hw_ifname = tap_to_hwif_name(if_name.c_str());
-        }else {
-            SWSS_LOG_NOTICE("No ports found for bridge port id :%s",sai_serialize_object_id(br_port_oid).c_str());
-            return SAI_STATUS_FAILURE;
-        }
-    } else if (obj_type == SAI_OBJECT_TYPE_LAG) {
-        platform_bond_info_t bond_info;
-        CHECK_STATUS(get_lag_bond_info(port_id, bond_info));
-        uint32_t lag_swif_idx = bond_info.sw_if_index;
-        SWSS_LOG_NOTICE("lag swif idx :%d",lag_swif_idx);
-	    hw_ifname =  vpp_get_swif_name(lag_swif_idx);
-        SWSS_LOG_NOTICE("lag swif idx :%d swif_name:%s",lag_swif_idx, hw_ifname);
-	    if (hw_ifname == NULL) {
-            SWSS_LOG_NOTICE("LAG port is not found for bridge port id :%s",sai_serialize_object_id(port_id).c_str());
-            return SAI_STATUS_FAILURE;
-	    }
+        SWSS_LOG_NOTICE("No VPP interface found for bridge port id :%s",
+                sai_serialize_object_id(br_port_oid).c_str());
+        return SAI_STATUS_FAILURE;
     }
+
+    const char *hw_ifname = hwif_str.c_str();
 
     attr.id = SAI_VLAN_MEMBER_ATTR_VLAN_TAGGING_MODE;
     status = get(SAI_OBJECT_TYPE_VLAN_MEMBER, vlan_member_oid, 1, &attr);
@@ -1156,6 +1135,8 @@ sai_status_t SwitchVpp::vpp_remove_vlan_member(
 
         // delete subinterface (lcp-auto-subint removes host tap automatically)
         delete_sub_interface(parent_hwif, vlan_id);
+
+        m_ifaceRegistry.remove(hw_ifname);
     }
     else {
 
@@ -1266,44 +1247,21 @@ bool SwitchVpp::vlan_member_hwif(
 
     sai_object_type_t obj_type = objectTypeQuery(port_id);
 
-    const char *hwifname = nullptr;
-
-    if (obj_type == SAI_OBJECT_TYPE_PORT)
-    {
-        std::string if_name;
-
-        if (!getTapNameFromPortId(port_id, if_name))
-        {
-            return false;
-        }
-
-        hwifname = tap_to_hwif_name(if_name.c_str());
-    }
-    else if (obj_type == SAI_OBJECT_TYPE_LAG)
-    {
-        platform_bond_info_t bond_info;
-
-        if (get_lag_bond_info(port_id, bond_info) != SAI_STATUS_SUCCESS)
-        {
-            return false;
-        }
-
-        hwifname = vpp_get_swif_name(bond_info.sw_if_index);
-    }
-    else
+    if (obj_type != SAI_OBJECT_TYPE_PORT && obj_type != SAI_OBJECT_TYPE_LAG)
     {
         return false;
     }
 
-    /* tap_to_hwif_name() reports a lookup miss by returning the literal
-     * "Unknown" rather than NULL, so both have to be rejected -- otherwise we
-     * would try to bind classify tables to an interface named "Unknown". */
-    if (hwifname == NULL || strcmp(hwifname, "Unknown") == 0)
+    std::string hwif_str;
+
+    if (!vpp_get_hwif_name(port_id, 0, hwif_str))
     {
         SWSS_LOG_WARN("No VPP interface for vlan member %s",
                 vlan_member.get_id().c_str());
         return false;
     }
+
+    const char *hwifname = hwif_str.c_str();
 
     sai_attribute_t attr;
 
@@ -1586,6 +1544,19 @@ sai_status_t SwitchVpp::vpp_create_bvi_interface(
 
         refresh_interfaces_list();
         interface_set_state(tap_name.c_str(), true);
+
+        /*
+         * The BVI is the only interface kind whose three names are all
+         * derivable (bvi<id> / Vlan<id> / tap_Vlan<id>), but the tap is still
+         * recorded explicitly: it exists only once the LCP pair above has been
+         * created, and hasTapName() is what tells a reader that.
+         */
+        auto bvi_rec = m_ifaceRegistry.addBvi(static_cast<uint16_t>(vlan_id));
+
+        if (bvi_rec)
+        {
+            m_ifaceRegistry.setTapName(bvi_rec->getHwifName(), tap_name);
+        }
     }
 
     return SAI_STATUS_SUCCESS;
@@ -1762,6 +1733,8 @@ sai_status_t SwitchVpp::vpp_delete_bvi_interface(
     //Remove the bvi interface
     delete_bvi_interface(hw_ifname);
 
+    m_ifaceRegistry.remove(hw_ifname);
+
     // refresh interfaces from VS
     refresh_interfaces_list();
 
@@ -1772,12 +1745,34 @@ sai_status_t SwitchVpp::get_lag_bond_info(const sai_object_id_t lag_id, platform
 {
     SWSS_LOG_ENTER();
 
+    /*
+     * Registry first: addLag() takes the bond id, the sw_if_index and the oid in
+     * one call, so a registered LAG always has all three -- the map below only
+     * has them because the same creation path writes both.
+     */
+    auto rec = m_ifaceRegistry.findByOid(lag_id);
+
+    if (rec && rec->getType() == VppInterfaceType::LAG && rec->hasSwIfIndex())
+    {
+        const VppBondInterface *bond = rec->asBond();
+
+        bond_info.sw_if_index = rec->getSwIfIndex();
+        bond_info.id = bond->getBondId();
+        bond_info.lcp_created = bond->isLcpCreated();
+
+        return SAI_STATUS_SUCCESS;
+    }
+
     auto it = m_lag_bond_map.find(lag_id);
     if (it == m_lag_bond_map.end())
     {
         SWSS_LOG_ERROR("failed to find bond info for lag id: %s", sai_serialize_object_id(lag_id).c_str());
         return SAI_STATUS_ITEM_NOT_FOUND;
     }
+
+    SWSS_LOG_WARN("registry miss for lag %s, bond map resolved bond %u",
+            sai_serialize_object_id(lag_id).c_str(), it->second.id);
+
     bond_info = it->second;
     return SAI_STATUS_SUCCESS;
 }
@@ -1914,6 +1909,15 @@ sai_status_t SwitchVpp::vpp_create_lag(
     // Update the lag to bond map
     platform_bond_info_t bond_info = {swif_idx, bond_id, false};
     m_lag_bond_map[lag_id] = bond_info;
+
+    /*
+     * A bond is fully identified the moment it is created: the oid came in as a
+     * parameter, the bond id was just allocated and the sw_if_index came back
+     * from VPP. The tap ("be<N>") is not bound here -- it only exists once the
+     * LCP pair is created.
+     */
+    m_ifaceRegistry.addLag(bond_id, swif_idx, lag_id);
+
     SWSS_LOG_NOTICE("vpp bond interface created for lag_id:%s, swif index:%d, bond_id:%d\n", sai_serialize_object_id(lag_id).c_str(), swif_idx, bond_id);
     refresh_interfaces_list();
 
@@ -1961,6 +1965,14 @@ sai_status_t SwitchVpp::vpp_remove_lag(
         return SAI_STATUS_FAILURE;
     }
     remove_lag_to_bond_entry(lag_oid);
+
+    /*
+     * delete_bond_interface() also tears down the LCP pair and any
+     * sub-interfaces, so drop the whole subtree. Doing this by oid rather than
+     * by name avoids depending on lag_ifname, which VPP may already have freed.
+     */
+    m_ifaceRegistry.removeByOid(lag_oid);
+
     refresh_interfaces_list();
 
     return SAI_STATUS_SUCCESS;
@@ -2047,17 +2059,18 @@ sai_status_t SwitchVpp::vpp_create_lag_member(
         return SAI_STATUS_FAILURE;
     }
 
-    std::string if_name;
-    bool found = getTapNameFromPortId(lag_port_oid, if_name);
-    const char *hwifname;
-    if (found == true)
+    std::string hwif_str;
+
+    if (!vpp_get_hwif_name(lag_port_oid, 0, hwif_str))
     {
-        hwifname = tap_to_hwif_name(if_name.c_str());
-        SWSS_LOG_NOTICE("hwif name for port is %s",hwifname);
-    }else {
-        SWSS_LOG_NOTICE("No ports found for lag port id :%s",sai_serialize_object_id(lag_port_oid).c_str());
+        SWSS_LOG_NOTICE("No VPP interface found for lag port id :%s",
+                sai_serialize_object_id(lag_port_oid).c_str());
         return SAI_STATUS_FAILURE;
     }
+
+    const char *hwifname = hwif_str.c_str();
+
+    SWSS_LOG_NOTICE("hwif name for port is %s", hwifname);
 
     ret = create_bond_member(bond_if_idx, hwifname, is_passive, is_long_timeout);
     if (ret != 0)
@@ -2097,25 +2110,17 @@ void SwitchVpp::vpp_set_lag_member_ip6(
     // Best effort, the caller must still complete the LAG member add/remove because
     // the VPP bond membership change already happened and failing here would leave
     // the object model inconsistent.
-    std::string if_name;
+    std::string hwif_str;
 
-    if (getTapNameFromPortId(port_oid, if_name) == false)
+    if (!vpp_get_hwif_name(port_oid, 0, hwif_str))
     {
-        SWSS_LOG_ERROR("no tap found for port %s, IPv6 not %s",
+        SWSS_LOG_ERROR("no hwif found for port %s, IPv6 not %s",
                 sai_serialize_object_id(port_oid).c_str(),
                 enable ? "enabled" : "disabled");
         return;
     }
 
-    const char *hwif_name = tap_to_hwif_name(if_name.c_str());
-
-    if (hwif_name == nullptr)
-    {
-        SWSS_LOG_ERROR("no hwif found for tap %s, IPv6 not %s",
-                if_name.c_str(),
-                enable ? "enabled" : "disabled");
-        return;
-    }
+    const char *hwif_name = hwif_str.c_str();
 
     if (sw_interface_ip6_enable_disable(hwif_name, enable) < 0)
     {
@@ -2164,6 +2169,27 @@ sai_status_t SwitchVpp::vpp_ensure_lag_lcp(
      */
     bond_info.lcp_created = true;
     m_lag_bond_map[lag_oid] = bond_info;
+
+    /*
+     * A LAG has no SAI hostif, so this is the ONLY point at which its host
+     * netdev comes into existence. Without recording it here the registry
+     * record for BondEthernet<N> would never gain a tap name, and every
+     * registry-backed tap lookup for a port channel would silently fall
+     * through to the legacy path.
+     *
+     * The tap is "be<N>", deliberately NOT "PortChannel<N>": the latter is the
+     * kernel bond/team netdev owned by SONiC, and naming the LCP tap after it
+     * would collide with that device (same reason a port-channel sub-port uses
+     * be<N>.<vlan> rather than PortChannel<N>.<vlan>).
+     */
+    m_ifaceRegistry.setTapName(hw_ifname, tap);
+
+    auto lag_rec = m_ifaceRegistry.findByOid(lag_oid);
+
+    if (lag_rec && lag_rec->getType() == VppInterfaceType::LAG)
+    {
+        lag_rec->asBond()->setLcpCreated(true);
+    }
 
     SWSS_LOG_NOTICE("Created LCP for LAG %s", sai_serialize_object_id(lag_oid).c_str());
 
@@ -2324,14 +2350,14 @@ sai_status_t SwitchVpp::vpp_set_lag_member_egress_disable(
     sai_object_id_t port_oid;
     CHECK_STATUS(get_lag_member_port(lag_member_oid, port_oid));
 
-    std::string if_name;
-    if (!getTapNameFromPortId(port_oid, if_name))
+    std::string hwif_str;
+    if (!vpp_get_hwif_name(port_oid, 0, hwif_str))
     {
-        SWSS_LOG_ERROR("No port found for lag member port id: %s", sai_serialize_object_id(port_oid).c_str());
+        SWSS_LOG_ERROR("No hwif found for lag member port id: %s", sai_serialize_object_id(port_oid).c_str());
         return SAI_STATUS_FAILURE;
     }
 
-    const char *hwif_name = tap_to_hwif_name(if_name.c_str());
+    const char *hwif_name = hwif_str.c_str();
 
     int ret;
     if (egress_disable)
@@ -2519,17 +2545,18 @@ sai_status_t SwitchVpp::vpp_remove_lag_member(
         return SAI_STATUS_FAILURE;
     }
 
-    std::string if_name;
-    bool found = getTapNameFromPortId(port_oid, if_name);
-    const char *lag_member_ifname;
-    if (found == true)
+    std::string hwif_str;
+
+    if (!vpp_get_hwif_name(port_oid, 0, hwif_str))
     {
-        lag_member_ifname = tap_to_hwif_name(if_name.c_str());
-	SWSS_LOG_NOTICE("hwif name for port is %s",lag_member_ifname);
-    } else {
-        SWSS_LOG_NOTICE("No ports found for lag port id :%s",sai_serialize_object_id(port_oid).c_str());
+        SWSS_LOG_NOTICE("No VPP interface found for lag port id :%s",
+                sai_serialize_object_id(port_oid).c_str());
         return SAI_STATUS_FAILURE;
     }
+
+    const char *lag_member_ifname = hwif_str.c_str();
+
+    SWSS_LOG_NOTICE("hwif name for port is %s", lag_member_ifname);
 
     ret = delete_bond_member(lag_member_ifname);
     if (ret != 0)
@@ -2966,7 +2993,21 @@ inline sai_object_id_t SwitchVpp::resolvePortIdFromSwIfIndex(uint32_t sw_if_inde
     if (it != m_swif_to_port_id.end())
         return it->second;
 
-    sai_object_id_t port_id = getPortIdFromSwIfIndex(sw_if_index);
+    /*
+     * The only lookup that can resolve a SUB-INTERFACE index. VPP reports the
+     * sub-interface sw_if_index in FDB learn events, and resolvePortOid() walks
+     * from the sub-interface record up to its parent's PORT/LAG oid -- which is
+     * what SAI_BRIDGE_PORT_ATTR_PORT_ID carries and what
+     * findBridgeVlanForPortVlan() matches on. Neither the name chain below nor
+     * the bond scan can answer that: the former dead-ends on a name the ifmap
+     * has never heard of, the latter compares the BOND index, not the sub-if's.
+     */
+    sai_object_id_t port_id = m_ifaceRegistry.resolvePortOid(sw_if_index);
+
+    if (port_id == SAI_NULL_OBJECT_ID)
+    {
+        port_id = getPortIdFromSwIfIndex(sw_if_index);
+    }
 
     if (port_id == SAI_NULL_OBJECT_ID)
     {
@@ -2984,7 +3025,7 @@ inline sai_object_id_t SwitchVpp::resolvePortIdFromSwIfIndex(uint32_t sw_if_inde
             if (kv.second.sw_if_index == sw_if_index)
             {
                 port_id = kv.first;
-                SWSS_LOG_NOTICE("FDB: resolved sw_if_index %u to LAG %s (bond %u)",
+                SWSS_LOG_WARN("FDB: registry could not resolve sw_if_index %u, bond map resolved LAG %s (bond %u)",
                                 sw_if_index, sai_serialize_object_id(port_id).c_str(),
                                 kv.second.id);
                 break;
@@ -2993,7 +3034,9 @@ inline sai_object_id_t SwitchVpp::resolvePortIdFromSwIfIndex(uint32_t sw_if_inde
     }
 
     if (port_id != SAI_NULL_OBJECT_ID)
+    {
         m_swif_to_port_id[sw_if_index] = port_id;
+    }
 
     return port_id;
 }
@@ -3142,6 +3185,16 @@ void SwitchVpp::swif_bdid_track(const char *hwif_name, uint32_t bd_id)
     if (swif != (uint32_t)~0u)
     {
         m_swif_to_bdid[swif] = bd_id;
+
+        /*
+         * Same two facts, in the record rather than in a side map. bd_id is the
+         * FDB drop gate, so it has to be attached to the interface it describes
+         * and torn down with it.
+         */
+         //@todo: can this be moved to when the subif is created, add to the bd?
+        m_ifaceRegistry.bindSwIfIndex(hwif_name, swif);
+        m_ifaceRegistry.setBdId(hwif_name, bd_id);
+
         SWSS_LOG_NOTICE("FDB: tracking sw_if_index %u -> bd %u for %s",
                         swif, bd_id, hwif_name);
     }
@@ -3172,6 +3225,15 @@ void SwitchVpp::swif_bdid_untrack(const char *hwif_name)
         // vpp_fdb_entries_invalidate_by_port matches) to the previous port OID.
         m_swif_to_port_id.erase(swif);
     }
+
+    /*
+     * Keyed by name, so this still works when the sw_if_index lookup above
+     * misses -- which is exactly the leak the old code had, since it derived
+     * the index from the name at teardown and silently did nothing on a miss.
+     * The record survives: leaving a bridge domain is not the end of the
+     * interface.
+     */
+    m_ifaceRegistry.clearBdId(hwif_name);
 }
 
 void SwitchVpp::vpp_fdb_entries_invalidate_all()

--- a/vslib/vpp/SwitchVppHostif.cpp
+++ b/vslib/vpp/SwitchVppHostif.cpp
@@ -410,7 +410,22 @@ sai_status_t SwitchVpp::vs_create_hostif_tap_interface(
 
     SWSS_LOG_NOTICE("created TAP device for %s, fd: %d", name.c_str(), tapfd);
     const char *dev = name.c_str();
-    const char *hwif_name = tap_to_hwif_name(dev);
+    const char *hwif_name = osif_name_to_hwif_name(dev);
+
+    if (hwif_name == nullptr)
+    {
+        /*
+         * Every use of hwif_name below either calls into VPP or formats it with
+         * "%s", so there is nothing useful to do without it. This used to run on
+         * with the literal "Unknown" and fail later at sw_interface_set_mac();
+         * failing here reports the actual cause.
+         */
+        SWSS_LOG_ERROR("no hwif mapping for hostif %s, cannot attach it to VPP", dev);
+
+        close(tapfd);
+
+        return SAI_STATUS_FAILURE;
+    }
 
     configure_lcp_interface(hwif_name, dev, true);
     interface_set_promiscuous(hwif_name, true);
@@ -512,6 +527,25 @@ sai_status_t SwitchVpp::vs_create_hostif_tap_interface(
 
     setIfNameToPortId(name, obj_id);
     setPortIdToTapName(obj_id, name);
+
+    /*
+     * The port record is created by the lane based resolution, which may not
+     * have run yet for this port -- so force it once here before attaching the
+     * tap. VPP is definitely up at this point, we have just been calling it.
+     */
+    std::string reg_hwif_name = hwif_name;
+    //@todo: can we use lane to report hwif_name?
+    if (!m_ifaceRegistry.findByHwif(reg_hwif_name))
+    {
+        std::string resolved;
+
+        if (getPortHwifNameFromLane(obj_id, resolved))
+        {
+            reg_hwif_name = resolved;
+        }
+    }
+
+    m_ifaceRegistry.setTapName(reg_hwif_name, name);
 
     SWSS_LOG_INFO("created tap interface %s", name.c_str());
 
@@ -625,12 +659,19 @@ sai_status_t SwitchVpp::vs_remove_hostif_tap_interface(
      * test to avoid. Both calls are idempotent (vpp_normalize_ret tolerates
      * NO_SUCH_ENTRY on delete), so removing a partially-created hostif is safe.
      */
-    const char *hwif_name = tap_to_hwif_name(name.c_str());
+    const char *hwif_name = osif_name_to_hwif_name(name.c_str());
 
     if (hwif_name != nullptr)
     {
         sw_interface_ip6_enable_disable(hwif_name, false);
         configure_lcp_interface(hwif_name, name.c_str(), false);
+
+        /*
+         * Only the tap goes away. The port itself still exists in VPP and is
+         * still reachable through the lane based lookup, so the record must
+         * survive -- clearTapName(), never remove().
+         */
+        m_ifaceRegistry.clearTapName(hwif_name);
     }
 
     removeIfNameToPortId(name);
@@ -671,6 +712,19 @@ bool SwitchVpp::hasIfIndex(
 // TODO to config
 static const char *sonic_vpp_ifmap = "/usr/share/sonic/hwsku/sonic_vpp_ifmap.ini";
 
+/*
+ * sonic_vpp_ifmap.ini maps the host OS interface name ("osif") to the VPP
+ * hardware interface name, e.g. "Ethernet0" -> "TenGigabitEthernet0/0/0". The
+ * osif name is whatever the NOS above SAI calls the port -- under SONiC it is
+ * the port_config.ini name, but nothing here depends on that.
+ * Only physical ports appear in the file -- every logical interface is derived
+ * by rule in derive_logical_hwif() below.
+ *
+ * Note that for a physical port the osif name, the LCP tap name and the SAI
+ * hostif name are all the same string, which is why this map has historically
+ * been described as a "tap" map. It is not: for a bond the osif name is
+ * "PortChannel<N>" while the tap is "be<N>", and the two must not be confused.
+ */
 void SwitchVpp::populate_if_mapping()
 {
     SWSS_LOG_ENTER();
@@ -681,7 +735,7 @@ void SwitchVpp::populate_if_mapping()
     }
 
     FILE *fp;
-    char sonic_name[64], vpp_name[64];
+    char osif_name[64], vpp_name[64];
 
     fp = fopen(sonic_vpp_ifmap, "r");
 
@@ -690,15 +744,15 @@ void SwitchVpp::populate_if_mapping()
         return;
     }
 
-    while (fscanf(fp, "%s %s", sonic_name, vpp_name) != EOF)
+    while (fscanf(fp, "%s %s", osif_name, vpp_name) != EOF)
     {
-        std::string tap_name, hwif_name;
+        std::string ifname, hwif_name;
 
-        tap_name = std::string(sonic_name);
+        ifname = std::string(osif_name);
         hwif_name = std::string(vpp_name);
 
-        m_hostif_hwif_map[tap_name] = hwif_name;
-        m_hwif_hostif_map[hwif_name] = tap_name;
+        m_osif_to_hwif_map[ifname] = hwif_name;
+        m_hwif_to_osif_map[hwif_name] = ifname;
     }
 
     mapping_init = 1;
@@ -706,83 +760,203 @@ void SwitchVpp::populate_if_mapping()
     fclose(fp);
 }
 
-static bool bond_tap_to_hwif_name(
-        _In_ const char *name,
-        _Out_ std::string &bond_hwif)
+/*
+ * Split a trailing ".<vlan>" sub-interface suffix off an interface name.
+ * Returns false if there is a '.' that is not followed by digits only, which
+ * means the name is not something this switch ever creates.
+ */
+static bool split_subif_suffix(
+        _In_ const std::string &name,
+        _Out_ std::string &base,
+        _Out_ std::string &suffix)
 {
-    SWSS_LOG_ENTER();
+    auto dot = name.find('.');
 
-    if (name[0] != 'b' || name[1] != 'e' || name[2] == '\0')
+    if (dot == std::string::npos)
+    {
+        base = name;
+        suffix.clear();
+
+        return true;
+    }
+
+    base = name.substr(0, dot);
+    suffix = name.substr(dot);
+
+    if (suffix.size() < 2)
     {
         return false;
     }
 
-    for (const char *p = name + 2; *p != '\0'; p++)
+    for (size_t i = 1; i < suffix.size(); i++)
     {
-        if (!isdigit(static_cast<unsigned char>(*p)))
+        if (!isdigit(static_cast<unsigned char>(suffix[i])))
         {
             return false;
         }
     }
 
-    bond_hwif = std::string(BONDETHERNET_PREFIX) + (name + 2);
+    return true;
+}
+
+/*
+ * Derive the VPP hardware interface name of a logical interface. These are
+ * hard invariants of the way this switch creates VPP interfaces:
+ *
+ *   PortChannel<N> -> BondEthernet<N>   vpp_create_lag(); find_new_bond_id()
+ *                                       takes the bond id straight from the
+ *                                       PortChannel kernel netdev name
+ *   Vlan<N>        -> bvi<N>            vpp_create_bvi_interface()
+ *
+ * Only SONiC-side names are accepted. The bond's linux-cp tap name be<N> is
+ * deliberately not resolved here: it is a VPP-side artefact, and accepting it
+ * would let a caller that wants the SONiC netdev (`ip link show`, VRF
+ * enslavement) silently get away with the wrong name.
+ *
+ * Physical ports are not handled here: their hwif name is platform specific
+ * and only sonic_vpp_ifmap.ini knows it.
+ */
+static bool derive_logical_hwif(
+        _In_ const std::string &base,
+        _Out_ std::string &hwif)
+{
+    SWSS_LOG_ENTER();
+
+    const char *prefix;
+    const char *hwif_prefix;
+
+    if (base.compare(0, strlen(PORTCHANNEL_PREFIX), PORTCHANNEL_PREFIX) == 0)
+    {
+        prefix = PORTCHANNEL_PREFIX;
+        hwif_prefix = BONDETHERNET_PREFIX;
+    }
+    else if (base.compare(0, strlen(VLAN_PREFIX), VLAN_PREFIX) == 0)
+    {
+        prefix = VLAN_PREFIX;
+        hwif_prefix = BVI_PREFIX;
+    }
+    else
+    {
+        return false;
+    }
+
+    std::string id = base.substr(strlen(prefix));
+
+    if (id.empty())
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < id.size(); i++)
+    {
+        if (!isdigit(static_cast<unsigned char>(id[i])))
+        {
+            return false;
+        }
+    }
+
+    hwif = std::string(hwif_prefix) + id;
 
     return true;
 }
 
-const char* SwitchVpp::tap_to_hwif_name(
+const char* SwitchVpp::osif_name_to_hwif_name(
         _In_ const char *name)
 {
     SWSS_LOG_ENTER();
 
     populate_if_mapping();
 
-    std::string tap_name = std::string(name);
+    std::string ifname = std::string(name);
 
-    auto it = m_hostif_hwif_map.find(tap_name);
+    auto it = m_osif_to_hwif_map.find(ifname);
 
-    if (it == m_hostif_hwif_map.end())
+    if (it != m_osif_to_hwif_map.end())
     {
-        static thread_local std::string bond_hwif;
+        SWSS_LOG_DEBUG("Found hwif %s info entry for interface: %s", it->second.c_str(), name);
 
-        if (bond_tap_to_hwif_name(name, bond_hwif))
+        return it->second.c_str();
+    }
+
+    static thread_local std::string derived_hwif;
+
+    std::string base, suffix;
+
+    if (split_subif_suffix(ifname, base, suffix))
+    {
+        /*
+         * A sub-interface carries the ".<vlan>" suffix over unchanged, so
+         * "Ethernet0.100" -> "TenGigabitEthernet0/0/0.100" and
+         * "PortChannel1.100" -> "BondEthernet1.100".
+         */
+        auto base_it = m_osif_to_hwif_map.find(base);
+
+        if (base_it != m_osif_to_hwif_map.end())
         {
-            SWSS_LOG_DEBUG("Mapped bond tap %s to hwif %s", name, bond_hwif.c_str());
+            derived_hwif = base_it->second + suffix;
 
-            return bond_hwif.c_str();
+            SWSS_LOG_DEBUG("Derived hwif %s for interface: %s", derived_hwif.c_str(), name);
+
+            return derived_hwif.c_str();
         }
 
-        SWSS_LOG_ERROR("failed to find hwif info entry for hostif device: %s", tap_name.c_str());
+        if (derive_logical_hwif(base, derived_hwif))
+        {
+            derived_hwif += suffix;
 
-        return "Unknown";
+            SWSS_LOG_DEBUG("Derived hwif %s for interface: %s", derived_hwif.c_str(), name);
+
+            return derived_hwif.c_str();
+        }
     }
 
-    SWSS_LOG_DEBUG("Found hwif %s info entry for hostif device: %s", it->second.c_str(), tap_name.c_str());
+    SWSS_LOG_ERROR("failed to find hwif info entry for interface: %s", name);
 
-    return it->second.c_str();
+    return nullptr;
 }
 
-const char* SwitchVpp::hwif_to_tap_name(
+const char* SwitchVpp::hwif_to_osif_name(
         _In_ const char *name)
 {
     SWSS_LOG_ENTER();
 
     populate_if_mapping();
 
-    std::string tap_name = std::string(name);
+    std::string hwif_name = std::string(name);
 
-    auto it = m_hwif_hostif_map.find(tap_name);
+    /*
+     * Registry first. sonic_vpp_ifmap.ini lists ONLY physical ports, so the map
+     * below structurally cannot answer for BondEthernet<N>, bvi<N> or a
+     * sub-interface -- those are exactly the "Unknown" returns this function has
+     * always produced. The registry knows all of them because every kind records
+     * its SONiC name at registration.
+     *
+     * getSonicName() returns a reference into a registry-owned record, so the
+     * c_str() handed back stays valid as long as the interface exists.
+     */
+    auto rec = m_ifaceRegistry.findByHwif(hwif_name);
 
-    if (it == m_hwif_hostif_map.end())
+    if (rec && rec->hasSonicName())
     {
-        // not all hwif are mapped to hostif, e.g. vxlan tunnel interface, bvi interface,
-        // and BondEthernet<N> (LAG) which has no SAI hostif tap.
-        SWSS_LOG_NOTICE("failed to find hostif info entry for hwif device: %s", tap_name.c_str());
+        SWSS_LOG_DEBUG("Registry resolved hwif %s to interface %s", name, rec->getSonicName().c_str());
+
+        return rec->getSonicName().c_str();
+    }
+
+    auto it = m_hwif_to_osif_map.find(hwif_name);
+
+    if (it == m_hwif_to_osif_map.end())
+    {
+        // not all hwif have an entry in the ifmap, e.g. vxlan tunnel interface,
+        // bvi interface, and BondEthernet<N> (LAG) which is not a physical port.
+        SWSS_LOG_NOTICE("failed to find interface name entry for hwif device: %s", name);
 
         return "Unknown";
     }
 
-    SWSS_LOG_DEBUG("Found  hostif %s info entry for hwif device: %s", it->second.c_str(), tap_name.c_str());
+    SWSS_LOG_WARN("registry miss for hwif %s, ifmap resolved it to %s", name, it->second.c_str());
+
+    SWSS_LOG_DEBUG("Found interface %s entry for hwif device: %s", it->second.c_str(), name);
 
     return it->second.c_str();
 }

--- a/vslib/vpp/SwitchVppHostif.cpp
+++ b/vslib/vpp/SwitchVppHostif.cpp
@@ -410,9 +410,9 @@ sai_status_t SwitchVpp::vs_create_hostif_tap_interface(
 
     SWSS_LOG_NOTICE("created TAP device for %s, fd: %d", name.c_str(), tapfd);
     const char *dev = name.c_str();
-    const char *hwif_name = osif_name_to_hwif_name(dev);
+    const std::string hwif = m_ifaceRegistry.resolveHwIfByOsIf(name);
 
-    if (hwif_name == nullptr)
+    if (hwif.empty())
     {
         /*
          * Every use of hwif_name below either calls into VPP or formats it with
@@ -426,6 +426,8 @@ sai_status_t SwitchVpp::vs_create_hostif_tap_interface(
 
         return SAI_STATUS_FAILURE;
     }
+
+    const char *hwif_name = hwif.c_str();
 
     configure_lcp_interface(hwif_name, dev, true);
     interface_set_promiscuous(hwif_name, true);
@@ -525,6 +527,13 @@ sai_status_t SwitchVpp::vs_create_hostif_tap_interface(
         return SAI_STATUS_FAILURE;
     }
 
+    /*
+     * Write-only from the VPP backend's point of view: nothing under vslib/vpp/
+     * reads these two maps any more, every VPP lookup goes through
+     * m_ifaceRegistry instead. They are kept in step purely so the inherited
+     * SwitchState/SwitchStateBase paths that still consult them -- getPortStat()
+     * being the one VPP actually reaches -- see the same state they always did.
+     */
     setIfNameToPortId(name, obj_id);
     setPortIdToTapName(obj_id, name);
 
@@ -618,28 +627,15 @@ sai_status_t SwitchVpp::vs_remove_hostif_tap_interface(
     std::string name = std::string(attr.value.chardata);
 
     /*
-       auto it = m_hostif_info_map.find(name);
+     * Only needed to undo the compatibility writes in
+     * vs_create_hostif_tap_interface(). Resolved through the registry rather
+     * than getPortIdFromIfName(), and taken before clearTapName() below drops
+     * the tap index.
+     */
+    auto rec = m_ifaceRegistry.findByTap(name);
 
-       if (it == m_hostif_info_map.end())
-       {
-       SWSS_LOG_ERROR("failed to find host info entry for tap device: %s", name.c_str());
+    sai_object_id_t port_id = rec ? rec->getOid() : SAI_NULL_OBJECT_ID;
 
-       return SAI_STATUS_FAILURE;
-       }
-
-       SWSS_LOG_NOTICE("attempting to remove tap device: %s", name.c_str());
-
-       auto info = it->second; // destructor will stop threads
-       */
-    // remove host info entry from map
-
-    // m_hostif_info_map.erase(it);
-
-    // remove interface mapping
-
-    // std::string vname = vpp_get_veth_name(name, info->m_portId);
-
-    sai_object_id_t port_id = getPortIdFromIfName(name);
     auto it = m_hostif_info_map.find(name);
 
     if (it != m_hostif_info_map.end())
@@ -659,12 +655,12 @@ sai_status_t SwitchVpp::vs_remove_hostif_tap_interface(
      * test to avoid. Both calls are idempotent (vpp_normalize_ret tolerates
      * NO_SUCH_ENTRY on delete), so removing a partially-created hostif is safe.
      */
-    const char *hwif_name = osif_name_to_hwif_name(name.c_str());
+    const std::string hwif_name = m_ifaceRegistry.resolveHwIfByOsIf(name);
 
-    if (hwif_name != nullptr)
+    if (!hwif_name.empty())
     {
-        sw_interface_ip6_enable_disable(hwif_name, false);
-        configure_lcp_interface(hwif_name, name.c_str(), false);
+        sw_interface_ip6_enable_disable(hwif_name.c_str(), false);
+        configure_lcp_interface(hwif_name.c_str(), name.c_str(), false);
 
         /*
          * Only the tap goes away. The port itself still exists in VPP and is
@@ -674,6 +670,7 @@ sai_status_t SwitchVpp::vs_remove_hostif_tap_interface(
         m_ifaceRegistry.clearTapName(hwif_name);
     }
 
+    /* Compatibility only, see vs_create_hostif_tap_interface(). */
     removeIfNameToPortId(name);
 
     if (port_id != SAI_NULL_OBJECT_ID)
@@ -709,254 +706,3 @@ bool SwitchVpp::hasIfIndex(
 
 // VPP
 
-// TODO to config
-static const char *sonic_vpp_ifmap = "/usr/share/sonic/hwsku/sonic_vpp_ifmap.ini";
-
-/*
- * sonic_vpp_ifmap.ini maps the host OS interface name ("osif") to the VPP
- * hardware interface name, e.g. "Ethernet0" -> "TenGigabitEthernet0/0/0". The
- * osif name is whatever the NOS above SAI calls the port -- under SONiC it is
- * the port_config.ini name, but nothing here depends on that.
- * Only physical ports appear in the file -- every logical interface is derived
- * by rule in derive_logical_hwif() below.
- *
- * Note that for a physical port the osif name, the LCP tap name and the SAI
- * hostif name are all the same string, which is why this map has historically
- * been described as a "tap" map. It is not: for a bond the osif name is
- * "PortChannel<N>" while the tap is "be<N>", and the two must not be confused.
- */
-void SwitchVpp::populate_if_mapping()
-{
-    SWSS_LOG_ENTER();
-
-    if (mapping_init)
-    {
-        return;
-    }
-
-    FILE *fp;
-    char osif_name[64], vpp_name[64];
-
-    fp = fopen(sonic_vpp_ifmap, "r");
-
-    if (!fp)
-    {
-        return;
-    }
-
-    while (fscanf(fp, "%s %s", osif_name, vpp_name) != EOF)
-    {
-        std::string ifname, hwif_name;
-
-        ifname = std::string(osif_name);
-        hwif_name = std::string(vpp_name);
-
-        m_osif_to_hwif_map[ifname] = hwif_name;
-        m_hwif_to_osif_map[hwif_name] = ifname;
-    }
-
-    mapping_init = 1;
-
-    fclose(fp);
-}
-
-/*
- * Split a trailing ".<vlan>" sub-interface suffix off an interface name.
- * Returns false if there is a '.' that is not followed by digits only, which
- * means the name is not something this switch ever creates.
- */
-static bool split_subif_suffix(
-        _In_ const std::string &name,
-        _Out_ std::string &base,
-        _Out_ std::string &suffix)
-{
-    auto dot = name.find('.');
-
-    if (dot == std::string::npos)
-    {
-        base = name;
-        suffix.clear();
-
-        return true;
-    }
-
-    base = name.substr(0, dot);
-    suffix = name.substr(dot);
-
-    if (suffix.size() < 2)
-    {
-        return false;
-    }
-
-    for (size_t i = 1; i < suffix.size(); i++)
-    {
-        if (!isdigit(static_cast<unsigned char>(suffix[i])))
-        {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/*
- * Derive the VPP hardware interface name of a logical interface. These are
- * hard invariants of the way this switch creates VPP interfaces:
- *
- *   PortChannel<N> -> BondEthernet<N>   vpp_create_lag(); find_new_bond_id()
- *                                       takes the bond id straight from the
- *                                       PortChannel kernel netdev name
- *   Vlan<N>        -> bvi<N>            vpp_create_bvi_interface()
- *
- * Only SONiC-side names are accepted. The bond's linux-cp tap name be<N> is
- * deliberately not resolved here: it is a VPP-side artefact, and accepting it
- * would let a caller that wants the SONiC netdev (`ip link show`, VRF
- * enslavement) silently get away with the wrong name.
- *
- * Physical ports are not handled here: their hwif name is platform specific
- * and only sonic_vpp_ifmap.ini knows it.
- */
-static bool derive_logical_hwif(
-        _In_ const std::string &base,
-        _Out_ std::string &hwif)
-{
-    SWSS_LOG_ENTER();
-
-    const char *prefix;
-    const char *hwif_prefix;
-
-    if (base.compare(0, strlen(PORTCHANNEL_PREFIX), PORTCHANNEL_PREFIX) == 0)
-    {
-        prefix = PORTCHANNEL_PREFIX;
-        hwif_prefix = BONDETHERNET_PREFIX;
-    }
-    else if (base.compare(0, strlen(VLAN_PREFIX), VLAN_PREFIX) == 0)
-    {
-        prefix = VLAN_PREFIX;
-        hwif_prefix = BVI_PREFIX;
-    }
-    else
-    {
-        return false;
-    }
-
-    std::string id = base.substr(strlen(prefix));
-
-    if (id.empty())
-    {
-        return false;
-    }
-
-    for (size_t i = 0; i < id.size(); i++)
-    {
-        if (!isdigit(static_cast<unsigned char>(id[i])))
-        {
-            return false;
-        }
-    }
-
-    hwif = std::string(hwif_prefix) + id;
-
-    return true;
-}
-
-const char* SwitchVpp::osif_name_to_hwif_name(
-        _In_ const char *name)
-{
-    SWSS_LOG_ENTER();
-
-    populate_if_mapping();
-
-    std::string ifname = std::string(name);
-
-    auto it = m_osif_to_hwif_map.find(ifname);
-
-    if (it != m_osif_to_hwif_map.end())
-    {
-        SWSS_LOG_DEBUG("Found hwif %s info entry for interface: %s", it->second.c_str(), name);
-
-        return it->second.c_str();
-    }
-
-    static thread_local std::string derived_hwif;
-
-    std::string base, suffix;
-
-    if (split_subif_suffix(ifname, base, suffix))
-    {
-        /*
-         * A sub-interface carries the ".<vlan>" suffix over unchanged, so
-         * "Ethernet0.100" -> "TenGigabitEthernet0/0/0.100" and
-         * "PortChannel1.100" -> "BondEthernet1.100".
-         */
-        auto base_it = m_osif_to_hwif_map.find(base);
-
-        if (base_it != m_osif_to_hwif_map.end())
-        {
-            derived_hwif = base_it->second + suffix;
-
-            SWSS_LOG_DEBUG("Derived hwif %s for interface: %s", derived_hwif.c_str(), name);
-
-            return derived_hwif.c_str();
-        }
-
-        if (derive_logical_hwif(base, derived_hwif))
-        {
-            derived_hwif += suffix;
-
-            SWSS_LOG_DEBUG("Derived hwif %s for interface: %s", derived_hwif.c_str(), name);
-
-            return derived_hwif.c_str();
-        }
-    }
-
-    SWSS_LOG_ERROR("failed to find hwif info entry for interface: %s", name);
-
-    return nullptr;
-}
-
-const char* SwitchVpp::hwif_to_osif_name(
-        _In_ const char *name)
-{
-    SWSS_LOG_ENTER();
-
-    populate_if_mapping();
-
-    std::string hwif_name = std::string(name);
-
-    /*
-     * Registry first. sonic_vpp_ifmap.ini lists ONLY physical ports, so the map
-     * below structurally cannot answer for BondEthernet<N>, bvi<N> or a
-     * sub-interface -- those are exactly the "Unknown" returns this function has
-     * always produced. The registry knows all of them because every kind records
-     * its SONiC name at registration.
-     *
-     * getSonicName() returns a reference into a registry-owned record, so the
-     * c_str() handed back stays valid as long as the interface exists.
-     */
-    auto rec = m_ifaceRegistry.findByHwif(hwif_name);
-
-    if (rec && rec->hasSonicName())
-    {
-        SWSS_LOG_DEBUG("Registry resolved hwif %s to interface %s", name, rec->getSonicName().c_str());
-
-        return rec->getSonicName().c_str();
-    }
-
-    auto it = m_hwif_to_osif_map.find(hwif_name);
-
-    if (it == m_hwif_to_osif_map.end())
-    {
-        // not all hwif have an entry in the ifmap, e.g. vxlan tunnel interface,
-        // bvi interface, and BondEthernet<N> (LAG) which is not a physical port.
-        SWSS_LOG_NOTICE("failed to find interface name entry for hwif device: %s", name);
-
-        return "Unknown";
-    }
-
-    SWSS_LOG_WARN("registry miss for hwif %s, ifmap resolved it to %s", name, it->second.c_str());
-
-    SWSS_LOG_DEBUG("Found interface %s entry for hwif device: %s", it->second.c_str(), name);
-
-    return it->second.c_str();
-}

--- a/vslib/vpp/SwitchVppMirror.cpp
+++ b/vslib/vpp/SwitchVppMirror.cpp
@@ -32,8 +32,8 @@ sai_status_t SwitchVpp::createMirrorSession(
         CHECK_STATUS(find_attrib_in_list(attr_count, attr_list, SAI_MIRROR_SESSION_ATTR_MONITOR_PORT, &value, &attr_index));
         sai_object_id_t monitor_port = value->oid;
 
-        std::string hwif_name;
-        if(!vpp_get_hwif_name(monitor_port, 0, hwif_name)) {
+        std::string hwif_name = m_ifaceRegistry.resolveHwIfName(monitor_port, 0);
+        if(hwif_name.empty()) {
             SWSS_LOG_ERROR("Failed to get hwif name for monitor port %s", sai_serialize_object_id(monitor_port).c_str());
             return SAI_STATUS_FAILURE;
         }
@@ -92,8 +92,8 @@ sai_status_t SwitchVpp::removeMirrorSession(
         sai_object_id_t portId = pmb_it->first;
         auto port_sid = sai_serialize_object_id(portId);
 
-        std::string src_hwif;
-        if(!vpp_get_hwif_name(portId, 0, src_hwif)) {
+        std::string src_hwif = m_ifaceRegistry.resolveHwIfName(portId, 0);
+        if(src_hwif.empty()) {
             SWSS_LOG_WARN("Failed to get hwif name for port %s while removing mirror session %s; skipping VPP SPAN unprogramming",
                 port_sid.c_str(), sai_serialize_object_id(object_id).c_str());
         } else {
@@ -131,8 +131,8 @@ sai_status_t SwitchVpp::bindMirrorPort(
 
     auto sid = sai_serialize_object_id(portId);
 
-    std::string src_hwif;
-    if(!vpp_get_hwif_name(portId, 0, src_hwif)) {
+    std::string src_hwif = m_ifaceRegistry.resolveHwIfName(portId, 0);
+    if(src_hwif.empty()) {
         SWSS_LOG_ERROR("Failed to get hwif name for port %s", sid.c_str());
         return SAI_STATUS_FAILURE;
     } else {

--- a/vslib/vpp/SwitchVppMpls.cpp
+++ b/vslib/vpp/SwitchVppMpls.cpp
@@ -243,8 +243,10 @@ sai_status_t SwitchVpp::mplsRouteAddRemove(
             sai_object_id_t rif_id = rif_attr.value.oid;
             sai_attribute_t port_attr;
             port_attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
-            if (get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &port_attr) == SAI_STATUS_SUCCESS &&
-                vpp_get_hwif_name(port_attr.value.oid, 0, egress_hwif)) {
+            if (get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &port_attr) == SAI_STATUS_SUCCESS) {
+                egress_hwif = m_ifaceRegistry.resolveHwIfName(port_attr.value.oid, 0);
+            }
+            if (!egress_hwif.empty()) {
                 route->nexthop[0].hwif_name = egress_hwif.c_str();
             }
         }

--- a/vslib/vpp/SwitchVppNbr.cpp
+++ b/vslib/vpp/SwitchVppNbr.cpp
@@ -165,7 +165,9 @@ sai_status_t SwitchVpp::addRemoveIpNbr(
             vlan_id = attr.value.u16;
         }
 
-        if (vpp_get_hwif_name(port_oid, vlan_id, hwif_name) == false)
+        hwif_name = m_ifaceRegistry.resolveHwIfName(port_oid, vlan_id);
+
+        if (hwif_name.empty())
         {
             SWSS_LOG_ERROR("hw interface for port/lag id %s not found", serializedObjectId.c_str());
             return SAI_STATUS_FAILURE;

--- a/vslib/vpp/SwitchVppNexthop.cpp
+++ b/vslib/vpp/SwitchVppNexthop.cpp
@@ -248,8 +248,10 @@ SwitchVpp::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_object_id_t
             sai_attribute_t port_attr;
             port_attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
             if (rif_obj &&
-                rif_obj->get_attr(port_attr) == SAI_STATUS_SUCCESS &&
-                vpp_get_hwif_name(port_attr.value.oid, 0, mpls_hwif)) {
+                rif_obj->get_attr(port_attr) == SAI_STATUS_SUCCESS) {
+                mpls_hwif = m_ifaceRegistry.resolveHwIfName(port_attr.value.oid, 0);
+            }
+            if (!mpls_hwif.empty()) {
                 int idx = get_sw_if_idx(mpls_hwif.c_str());
                 if (idx >= 0) {
                     nxt_grp_member->sw_if_index = (uint32_t)idx;

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -434,8 +434,8 @@ bool SwitchVpp::getPortHwifNameFromLane(
         return false;
     }
 
-    const char *mapped_hwifname = tap_to_hwif_name(port_name.c_str());
-    if (mapped_hwifname == nullptr || strcmp(mapped_hwifname, "Unknown") == 0)
+    const char *mapped_hwifname = osif_name_to_hwif_name(port_name.c_str());
+    if (mapped_hwifname == nullptr)
     {
         SWSS_LOG_ERROR("port %s has no VPP mapping", port_name.c_str());
         return false;
@@ -452,6 +452,22 @@ bool SwitchVpp::getPortHwifNameFromLane(
     SWSS_LOG_INFO("resolved port %s lane set to %s/%s",
             sai_serialize_object_id(port_id).c_str(), port_name.c_str(),
             if_name.c_str());
+
+    /*
+     * The one place that holds all three parts of a physical port's identity at
+     * once -- the oid, the SONiC name from the lane set, and the hwif name from
+     * sonic_vpp_ifmap.ini -- and that has just confirmed the VPP interface
+     * really exists. Registering here rather than in createPort() is deliberate:
+     * create_ports() creates ports with no attributes at all and only later sets
+     * SAI_PORT_ATTR_HW_LANE_LIST, so a port has no derivable name inside
+     * createPort() and attempting it there would fail for every front panel
+     * port.
+     */
+    if (!m_ifaceRegistry.findByOid(port_id))
+    {
+        m_ifaceRegistry.addPhysicalPort(mapped_hwifname, port_name, port_id);
+    }
+
     return true;
 }
 
@@ -464,9 +480,32 @@ bool SwitchVpp::vpp_get_hwif_name (
 {
     SWSS_LOG_ENTER();
 
-    std::string tap_name;
+    std::string osif_name;
     std::string hwifname;
-    if (objectTypeQuery(object_id) == SAI_OBJECT_TYPE_PORT &&
+
+    sai_object_type_t ot = objectTypeQuery(object_id);
+
+    if (ot == SAI_OBJECT_TYPE_VLAN)
+    {
+        /*
+         * A VLAN is represented in VPP by its BVI, which is named after the
+         * VLAN id and has no host interface behind it, so it never goes
+         * through the osif name path below.
+         */
+        sai_attribute_t vlan_attr;
+
+        vlan_attr.id = SAI_VLAN_ATTR_VLAN_ID;
+
+        if (get(SAI_OBJECT_TYPE_VLAN, object_id, 1, &vlan_attr) != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("SAI_VLAN_ATTR_VLAN_ID not found for %s",
+                    sai_serialize_object_id(object_id).c_str());
+            return false;
+        }
+
+        hwifname = std::string(BVI_PREFIX) + std::to_string(vlan_attr.value.u16);
+    }
+    else if (ot == SAI_OBJECT_TYPE_PORT &&
                 getPortHwifNameFromLane(object_id, attr_count, attr_list, hwifname))
     {
         SWSS_LOG_DEBUG("using lane-based VPP interface %s for port %s",
@@ -474,21 +513,53 @@ bool SwitchVpp::vpp_get_hwif_name (
     }
     else
     {
-        if (getTapNameFromPortOrLagId(object_id, tap_name) == false)
+        /*
+         * Registry first. Both kinds that reach here record their oid at the
+         * moment they acquire an identity -- addPhysicalPort() from the lane
+         * path above, addLag() from vpp_create_lag() -- so the registry answers
+         * straight from the oid without going through a name at all, and
+         * without needing get_lag_bond_info() to rebuild "PortChannel<id>"
+         * only for osif_name_to_hwif_name() to take it apart again.
+         */
+        auto rec = m_ifaceRegistry.findByOid(object_id);
+
+        if (rec)
         {
-            SWSS_LOG_ERROR("host interface for port/lag id %s not found",
-                    sai_serialize_object_id(object_id).c_str());
-            return false;
+            hwifname = rec->getHwifName();
         }
-
-        const char *mapped_hwifname = tap_to_hwif_name(tap_name.c_str());
-
-        if (mapped_hwifname == NULL || strcmp(mapped_hwifname, "Unknown") == 0)
+        else
         {
-            return false;
-        }
+            /*
+             * Legacy fallback, deliberately still here: the registry is
+             * in-memory and only populated by the create paths, so anything it
+             * has not seen must still resolve exactly as before. The WARN is
+             * the parity harness -- a VS run that never logs it is the signal
+             * that Phase 5 may delete this arm.
+             *
+             * osif_name_to_hwif_name() is keyed on the SONiC netdev name, so
+             * the LAG must be resolved to PortChannel<id> and not to its
+             * linux-cp tap be<id>.
+             */
+            if (getOsIfFromPortOrLagId(object_id, osif_name) == false)
+            {
+                SWSS_LOG_ERROR("host interface for port/lag id %s not found",
+                        sai_serialize_object_id(object_id).c_str());
+                return false;
+            }
 
-        hwifname = mapped_hwifname;
+            const char *mapped_hwifname = osif_name_to_hwif_name(osif_name.c_str());
+
+            if (mapped_hwifname == nullptr)
+            {
+                return false;
+            }
+
+            hwifname = mapped_hwifname;
+
+            SWSS_LOG_WARN("registry miss for %s, legacy path resolved %s to %s",
+                    sai_serialize_object_id(object_id).c_str(),
+                    osif_name.c_str(), hwifname.c_str());
+        }
     }
     if (vlan_id) {
         ifname = hwifname + "." + std::to_string(vlan_id);
@@ -514,7 +585,12 @@ void SwitchVpp::resyncPortOperStatus()
         }
 
         const char* dev = tapname.c_str();
-        const char* hwif_name = tap_to_hwif_name(dev);
+        const char* hwif_name = osif_name_to_hwif_name(dev);
+
+        if (hwif_name == nullptr)
+        {
+            continue;
+        }
 
         bool link_up = false;
 
@@ -690,7 +766,7 @@ sai_status_t SwitchVpp::asyncIntfStateUpdate(const char *hwif_name, bool link_up
     std::string tap_str;
     const char *tap;
 
-    tap = hwif_to_tap_name(hwif_name);
+    tap = hwif_to_osif_name(hwif_name);
     auto port_oid = getPortIdFromIfName(std::string(tap));
 
     if (port_oid == SAI_NULL_OBJECT_ID) {
@@ -933,193 +1009,6 @@ sai_status_t SwitchVpp::UpdatePort(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr (
-    _In_ sai_ip_prefix_t& ip_prefix,
-    _In_ sai_object_id_t rif_id,
-    _In_ bool is_add)
-{
-    SWSS_LOG_ENTER();
-
-    sai_attribute_t attr;
-    int32_t rif_type;
-
-    attr.id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
-    sai_status_t status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &attr);
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("attr SAI_ROUTER_INTERFACE_ATTR_TYPE was not passed");
-
-        return SAI_STATUS_FAILURE;
-    }
-    rif_type = attr.value.s32;
-
-    attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
-    status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &attr);
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("attr SAI_ROUTER_INTERFACE_ATTR_PORT_ID was not passed");
-
-        return SAI_STATUS_FAILURE;
-    }
-
-    sai_object_id_t obj_id = attr.value.oid;
-
-    sai_object_type_t ot = objectTypeQuery(obj_id);
-
-    if (ot == SAI_OBJECT_TYPE_VLAN)
-    {
-        SWSS_LOG_DEBUG("Skipping object type VLAN");
-        return SAI_STATUS_SUCCESS;
-    }
-
-    std::string if_name;
-
-    if (ot != SAI_OBJECT_TYPE_PORT && ot != SAI_OBJECT_TYPE_LAG)
-    {
-        SWSS_LOG_ERROR("SAI_ROUTER_INTERFACE_ATTR_PORT_ID=%s expected to be PORT or LAG but is: %s",
-                sai_serialize_object_id(obj_id).c_str(),
-                sai_serialize_object_type(ot).c_str());
-
-        return SAI_STATUS_FAILURE;
-    }
-
-    if (getTapNameFromPortOrLagId(obj_id, if_name) == false)
-    {
-        SWSS_LOG_ERROR("host interface for port/lag id %s not found",
-                sai_serialize_object_id(obj_id).c_str());
-        return SAI_STATUS_FAILURE;
-    }
-
-    if (rif_type != SAI_ROUTER_INTERFACE_TYPE_SUB_PORT &&
-        rif_type != SAI_ROUTER_INTERFACE_TYPE_PORT &&
-        rif_type != SAI_ROUTER_INTERFACE_TYPE_LOOPBACK)
-    {
-        return SAI_STATUS_SUCCESS;
-    }
-
-    attr.id = SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID;
-    status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &attr);
-
-    uint16_t vlan_id = 0;
-    if (status == SAI_STATUS_SUCCESS)
-    {
-        vlan_id = attr.value.u16;
-    }
-
-    swss::IpPrefix intf_ip_prefix;
-    char host_subifname[32];
-    const char *linux_ifname;
-    bool is_v6 = false;
-
-    is_v6 = (ip_prefix.addr_family == SAI_IP_ADDR_FAMILY_IPV6) ? true : false;
-
-    if (vlan_id) {
-        snprintf(host_subifname, sizeof(host_subifname), "%s.%u", if_name.c_str(), vlan_id);
-        linux_ifname = host_subifname;
-    } else {
-        linux_ifname= if_name.c_str();
-    }
-    std::string ip_prefix_key;
-    std::string addr_family = ((is_v6) ? "v6" : "v4");
-
-    ip_prefix_key = linux_ifname + addr_family + sai_serialize_ip_prefix(ip_prefix);
-
-    if (is_add)
-    {
-        std::string ip_prefix_str;
-
-        bool ret = vpp_get_intf_ip_address(linux_ifname, ip_prefix, is_v6, ip_prefix_str);
-        if (ret == false)
-        {
-            SWSS_LOG_DEBUG("No ip address to add on router interface %s", linux_ifname);
-            return SAI_STATUS_SUCCESS;
-        }
-        SWSS_LOG_NOTICE("Adding ip address on router interface %s", linux_ifname);
-
-        intf_ip_prefix = swss::IpPrefix(ip_prefix_str.c_str());
-
-        sai_ip_prefix_t saiIpPrefix;
-
-        copy(saiIpPrefix, intf_ip_prefix);
-
-        m_intf_prefix_map[ip_prefix_key] = sai_serialize_ip_prefix(saiIpPrefix);
-    } else {
-        sai_ip_prefix_t saiIpPrefix;
-
-        std::string ip_prefix_str;
-
-        if (vpp_intf_get_prefix_entry(ip_prefix_key, ip_prefix_str) == false)
-        {
-            SWSS_LOG_DEBUG("No ip address to remove on router interface %s", linux_ifname);
-            return SAI_STATUS_SUCCESS;
-        }
-              SWSS_LOG_NOTICE("Removing ip address on router interface %s", linux_ifname);
-
-        sai_deserialize_ip_prefix(ip_prefix_str, saiIpPrefix);
-
-        intf_ip_prefix = getIpPrefixFromSaiPrefix(saiIpPrefix);
-
-        vpp_intf_remove_prefix_entry(ip_prefix_key);
-    }
-    vpp_ip_route_t vpp_ip_prefix;
-    swss::IpAddress m_ip = intf_ip_prefix.getIp();
-
-    vpp_ip_prefix.prefix_len = intf_ip_prefix.getMaskLength();
-
-    switch (m_ip.getIp().family)
-    {
-        case AF_INET:
-        {
-            struct sockaddr_in *sin =  &vpp_ip_prefix.prefix_addr.addr.ip4;
-
-            vpp_ip_prefix.prefix_addr.sa_family = AF_INET;
-            sin->sin_addr.s_addr = m_ip.getV4Addr();
-            break;
-        }
-        case AF_INET6:
-        {
-            const uint8_t *prefix = m_ip.getV6Addr();
-            struct sockaddr_in6 *sin6 =  &vpp_ip_prefix.prefix_addr.addr.ip6;
-
-            vpp_ip_prefix.prefix_addr.sa_family = AF_INET6;
-            memcpy(sin6->sin6_addr.s6_addr, prefix, sizeof(sin6->sin6_addr.s6_addr));
-            break;
-        }
-        default:
-        {
-            throw std::logic_error("Invalid family");
-        }
-    }
-
-    const char *hw_ifname;
-    char hw_subifname[32];
-    const char *hwifname = tap_to_hwif_name(if_name.c_str());
-
-    if (hwifname == NULL || strcmp(hwifname, "Unknown") == 0)
-    {
-        return SAI_STATUS_FAILURE;
-    }
-
-    if (vlan_id) {
-        snprintf(hw_subifname, sizeof(hw_subifname), "%s.%u", hwifname, vlan_id);
-        hw_ifname = hw_subifname;
-    } else {
-        hw_ifname = hwifname;
-    }
-
-    int ret = interface_ip_address_add_del(hw_ifname, &vpp_ip_prefix, is_add);
-
-    if (ret == 0)
-    {
-        return SAI_STATUS_SUCCESS;
-    }
-    else {
-        return SAI_STATUS_FAILURE;
-    }
-}
-
 static void get_intf_vlanid (std::string& sub_ifname, int *vlan_id, std::string& if_name)
 {
     SWSS_LOG_ENTER();
@@ -1308,39 +1197,24 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
         }
     }
 
-    const char *hwifname;
-    char hw_subifname[32];
-    char hw_bviifname[32];
-    char hw_bondifname[32];
-    const char *hw_ifname;
-    if (full_if_name.compare(0, vlan_prefix.length(), vlan_prefix) == 0)
+    /*
+     * full_if_name is the kernel netdev that owns the prefix, i.e. a host OS
+     * interface name: "Ethernet0[.<vlan>]", "PortChannel<N>[.<vlan>]" or
+     * "Vlan<N>". osif_name_to_hwif_name() resolves every one of those forms,
+     * sub-interface suffix included, so no per-family string surgery is needed
+     * here. It also replaces a std::stoi() on the PortChannel name that used to
+     * silently parse "102.20" as 102 and program the address onto the bond main
+     * interface instead of the sub-interface.
+     */
+    const char *hw_ifname = osif_name_to_hwif_name(full_if_name.c_str());
+
+    if (hw_ifname == nullptr)
     {
-       snprintf(hw_bviifname, sizeof(hw_bviifname), "%s%d","bvi",vlan_id);
-       hw_ifname = hw_bviifname;
-    } else if (full_if_name.compare(0, strlen(PORTCHANNEL_PREFIX), PORTCHANNEL_PREFIX) == 0) {
-        /* full_if_name is PortChannel<id>[.<vlan>]; get_intf_vlanid() above
-         * already split it into if_name / vlan_id.  Parse the id from the
-         * name *without* the VLAN suffix: std::stoi("1.20") stops at the
-         * '.' and silently yields 1, which used to drop the sub-interface
-         * and program the address onto the bond main interface. */
-        uint32_t bond_id = std::stoi(if_name.substr(strlen(PORTCHANNEL_PREFIX)));
-        if (vlan_id) {
-            snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%u.%u",
-                     BONDETHERNET_PREFIX, bond_id, vlan_id);
-        } else {
-            snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%u",
-                     BONDETHERNET_PREFIX, bond_id);
-        }
-        hw_ifname = hw_bondifname;
-    } else {
-       hwifname = tap_to_hwif_name(if_name.c_str());
-       if (vlan_id) {
-           snprintf(hw_subifname, sizeof(hw_subifname), "%s.%u", hwifname, vlan_id);
-           hw_ifname = hw_subifname;
-       } else {
-           hw_ifname = hwifname;
-       }
+        SWSS_LOG_ERROR("no hwif found for interface %s", full_if_name.c_str());
+
+        return SAI_STATUS_FAILURE;
     }
+
     SWSS_LOG_NOTICE("Setting ip on hw_ifname %s", hw_ifname);
 
     if (is_add)
@@ -1639,98 +1513,6 @@ sai_status_t SwitchVpp::vpp_del_lpb_intf_ip_addr (
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t SwitchVpp::vpp_get_router_intf_name (
-    _In_ sai_ip_prefix_t& ip_prefix,
-    _In_ sai_object_id_t rif_id,
-    std::string& nexthop_ifname)
-{
-    SWSS_LOG_ENTER();
-
-    sai_attribute_t attr;
-    int32_t rif_type;
-
-    attr.id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
-    sai_status_t status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &attr);
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("attr SAI_ROUTER_INTERFACE_ATTR_TYPE was not passed");
-
-        return SAI_STATUS_FAILURE;
-    }
-    rif_type = attr.value.s32;
-
-    attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
-    status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &attr);
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("attr SAI_ROUTER_INTERFACE_ATTR_PORT_ID was not passed");
-
-        return SAI_STATUS_FAILURE;
-    }
-
-    sai_object_id_t obj_id = attr.value.oid;
-
-    sai_object_type_t ot = objectTypeQuery(obj_id);
-
-    if (ot == SAI_OBJECT_TYPE_VLAN)
-    {
-        SWSS_LOG_DEBUG("Skipping object type VLAN");
-        return SAI_STATUS_SUCCESS;
-    }
-
-    if (ot != SAI_OBJECT_TYPE_PORT)
-    {
-        SWSS_LOG_ERROR("SAI_ROUTER_INTERFACE_ATTR_PORT_ID=%s expected to be PORT but is: %s",
-                sai_serialize_object_id(obj_id).c_str(),
-                sai_serialize_object_type(ot).c_str());
-
-        return SAI_STATUS_FAILURE;
-    }
-
-    if (rif_type != SAI_ROUTER_INTERFACE_TYPE_SUB_PORT &&
-        rif_type != SAI_ROUTER_INTERFACE_TYPE_PORT &&
-    rif_type != SAI_ROUTER_INTERFACE_TYPE_LOOPBACK)
-    {
-        return SAI_STATUS_SUCCESS;
-    }
-
-    attr.id = SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID;
-    status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &attr);
-
-    uint16_t vlan_id = 0;
-    if (status == SAI_STATUS_SUCCESS)
-    {
-        vlan_id = attr.value.u16;
-    }
-
-    std::string if_name;
-    bool found = getTapNameFromPortId(obj_id, if_name);
-    if (found == false)
-    {
-        SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(obj_id).c_str());
-        return SAI_STATUS_FAILURE;
-    }
-
-    const char *hwifname = tap_to_hwif_name(if_name.c_str());
-    char hw_subifname[32];
-    const char *hw_ifname;
-
-    if (vlan_id) {
-        snprintf(hw_subifname, sizeof(hw_subifname), "%s.%u", hwifname, vlan_id);
-        hw_ifname = hw_subifname;
-    } else {
-        hw_ifname = hwifname;
-    }
-
-    nexthop_ifname = std::string(hw_ifname);
-
-    SWSS_LOG_NOTICE("Configuring ip address on router interface %s", nexthop_ifname.c_str());
-
-    return SAI_STATUS_SUCCESS;
-}
-
 int SwitchVpp::vpp_add_ip_vrf (_In_ sai_object_id_t objectId, uint32_t vrf_id)
 {
     SWSS_LOG_ENTER();
@@ -1907,51 +1689,56 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
         vlan_id = attr_vlan_id->value.u16;
     }
 
-    std::string if_name;
-    bool found = false;
-    platform_bond_info_t bond_info;
-    if (ot == SAI_OBJECT_TYPE_LAG) {
-        CHECK_STATUS(get_lag_bond_info(obj_id, bond_info));
-        if_name = std::string(PORTCHANNEL_PREFIX) + std::to_string(bond_info.id);
-        found = true;
-    } else {
-        found = getTapNameFromPortId(obj_id, if_name);
-    }
+    /*
+     * Three names are needed below and each has exactly one source:
+     *   osif_name   SONiC netdev, for `ip link` / VRF enslavement lookups;
+     *               gains the ".<vlan>" suffix for a sub-port
+     *   parent_hwif VPP interface, for the VPP API calls
+     *   tap_name    linux-cp tap, only for the SUB_PORT LCP pair
+     * They differ for a LAG (PortChannel<id> / BondEthernet<id> / be<id>) and
+     * coincide for a physical port.
+     */
+    std::string osif_name;
 
-    if (found == false)
+    if (!getOsIfFromPortOrLagId(obj_id, osif_name))
     {
         SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(obj_id).c_str());
         return SAI_STATUS_FAILURE;
     }
 
-    const char *dev = if_name.c_str();
-    const char *linux_ifname;
-    char host_subifname[32];
+    std::string parent_hwif;
+
+    if (!vpp_get_hwif_name(obj_id, 0, parent_hwif))
+    {
+        SWSS_LOG_ERROR("No VPP interface found for %s", sai_serialize_object_id(obj_id).c_str());
+        return SAI_STATUS_FAILURE;
+    }
 
     if (attr_type->value.s32 == SAI_ROUTER_INTERFACE_TYPE_SUB_PORT)
     {
-        snprintf(host_subifname, sizeof(host_subifname), "%s.%u", dev, vlan_id);
+        const std::string suffix = "." + std::to_string(vlan_id);
 
-        const char *parent_hwif;
-        char hw_subif_parent[32];
-        char lcp_host_subif[64];
-        if (ot == SAI_OBJECT_TYPE_LAG) {
-            snprintf(hw_subif_parent, sizeof(hw_subif_parent), "%s%u", BONDETHERNET_PREFIX, bond_info.id);
-            parent_hwif = hw_subif_parent;
-            /*
-             * For a port-channel sub-port the LCP host tap must be be<id>.<vlan>
-             * (a VLAN netdev on the be<id> bond tap), NOT PortChannel<id>.<vlan>:
-             * that name collides with the kernel 8021q netdev owned by the Linux
-             * bond/team stack. linux-cp-punt-xc lands on be<id>.<vlan> and the
-             * sonic_ext aggr-tap-redirect steers the punted copy to the
-             * originating member tap (SONiC PR #2440 §5.3).
-             */
-            snprintf(lcp_host_subif, sizeof(lcp_host_subif), "be%u.%u", bond_info.id, vlan_id);
-        } else {
-            parent_hwif = tap_to_hwif_name(dev);
-            snprintf(lcp_host_subif, sizeof(lcp_host_subif), "%s", host_subifname);
+        /*
+         * For a port-channel sub-port the LCP host tap must be be<id>.<vlan>
+         * (a VLAN netdev on the be<id> bond tap), NOT PortChannel<id>.<vlan>:
+         * that name collides with the kernel 8021q netdev owned by the Linux
+         * bond/team stack. linux-cp-punt-xc lands on be<id>.<vlan> and the
+         * sonic_ext aggr-tap-redirect steers the punted copy to the
+         * originating member tap (SONiC PR #2440 §5.3). For a plain port the
+         * tap name is the SONiC name, so this is just Ethernet<n>.<vlan>.
+         */
+        std::string tap_name;
+
+        if (!getTapNameFromPortOrLagId(obj_id, tap_name))
+        {
+            SWSS_LOG_ERROR("host tap for port/lag id %s not found",
+                    sai_serialize_object_id(obj_id).c_str());
+            return SAI_STATUS_FAILURE;
         }
-        create_sub_interface(parent_hwif, vlan_id, vlan_id);
+
+        const std::string subif_tap = tap_name + suffix;
+
+        create_sub_interface(parent_hwif.c_str(), vlan_id, vlan_id);
 
         /*
          * lcp-auto-subint is disabled in VPP startup config (vlan-bvi HLD §3.6),
@@ -1961,9 +1748,29 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
          * port-channel). Without this the sub-interface will not show up in
          * `vppctl show lcp` and host punt will not work for the SUB_PORT RIF.
          */
-        char vpp_subif_name[64];
-        snprintf(vpp_subif_name, sizeof(vpp_subif_name), "%s.%u", parent_hwif, vlan_id);
-        configure_lcp_interface(vpp_subif_name, lcp_host_subif, true);
+        const std::string sub_hwif = parent_hwif + suffix;
+
+        configure_lcp_interface(sub_hwif.c_str(), subif_tap.c_str(), true);
+
+        {
+            auto parent_rec = m_ifaceRegistry.findByHwif(parent_hwif);
+
+            if (parent_rec)
+            {
+                auto sub_rec = m_ifaceRegistry.addSubInterface(parent_rec, vlan_id,
+                        static_cast<uint16_t>(vlan_id));
+
+                if (sub_rec)
+                {
+                    /*
+                     * For a bond parent this is "be<id>.<vlan>", which is NOT
+                     * the SONiC name "PortChannel<id>.<vlan>" -- the tap has to
+                     * be recorded, it cannot be derived from the SONiC name.
+                     */
+                    m_ifaceRegistry.setTapName(sub_hwif, subif_tap);
+                }
+            }
+        }
 
         /*
          * lcp-auto-subint is disabled and linux-cp lcp-sync is off, so nothing
@@ -1973,19 +1780,17 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
          * SUB_PORT datapath silently breaks. Explicitly bring the host tap UP
          * here (SAI-driven, consistent with the no-lcp-sync design).
          */
-        if (vs_set_dev_admin_up(lcp_host_subif, true) < 0)
+        if (vs_set_dev_admin_up(subif_tap.c_str(), true) < 0)
         {
             SWSS_LOG_ERROR("Failed to bring host sub-interface %s admin up; "
                            "for-us traffic punted to this SUB_PORT RIF will be dropped",
-                           lcp_host_subif);
+                           subif_tap.c_str());
         }
 
         /* Get new list of physical interfaces from VS */
         refresh_interfaces_list();
 
-        linux_ifname = host_subifname;
-    } else {
-        linux_ifname = dev;
+        osif_name += suffix;
     }
 
     sai_object_id_t vrf_obj_id = 0;
@@ -2002,20 +1807,12 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
     }
 
     uint32_t vrf_id;
-    int ret = vpp_get_vrf_id(linux_ifname, &vrf_id);
+    int ret = vpp_get_vrf_id(osif_name.c_str(), &vrf_id);
 
     vpp_add_ip_vrf(vrf_obj_id, vrf_id);
     if (ret == 0 && vrf_id != 0) {
-	const char *hwif_name;
-	char hw_bondifname[32];
-	if (ot == SAI_OBJECT_TYPE_LAG) {
-	    snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
-	    hwif_name = hw_bondifname;
-	} else {
-	    hwif_name = tap_to_hwif_name(dev);
-	}
-	SWSS_LOG_NOTICE("Setting interface vrf on hwif_name %s", hwif_name);
-	set_interface_vrf(hwif_name, vlan_id, vrf_id, false);
+        SWSS_LOG_NOTICE("Setting interface vrf on hwif_name %s", parent_hwif.c_str());
+        set_interface_vrf(parent_hwif.c_str(), vlan_id, vrf_id, false);
     }
     auto attr_type_mtu = sai_metadata_get_attr_by_id(SAI_ROUTER_INTERFACE_ATTR_MTU, attr_count, attr_list);
 
@@ -2193,54 +1990,6 @@ sai_status_t SwitchVpp::vpp_update_router_interface(
     }
 }
 
-sai_status_t SwitchVpp::vpp_router_interface_remove_vrf(
-     _In_ sai_object_id_t obj_id)
-{
-    SWSS_LOG_ENTER();
-
-    std::string if_name;
-    bool found = false;
-    platform_bond_info_t bond_info;
-    if (objectTypeQuery(obj_id) == SAI_OBJECT_TYPE_LAG) {
-        CHECK_STATUS(get_lag_bond_info(obj_id, bond_info));
-        if_name = std::string(PORTCHANNEL_PREFIX) + std::to_string(bond_info.id);
-        found = true;
-    } else {
-        found = getTapNameFromPortId(obj_id, if_name);
-    }
-
-    if (found == false)
-    {
-        SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(obj_id).c_str());
-        return SAI_STATUS_FAILURE;
-    }
-    const char *linux_ifname;
-
-    linux_ifname = if_name.c_str();
-
-    const char *hwif_name;
-    char hw_bondifname[32];
-    if (objectTypeQuery(obj_id) == SAI_OBJECT_TYPE_LAG) {
-        snprintf(hw_bondifname, sizeof(hw_bondifname), "%s%d", BONDETHERNET_PREFIX, bond_info.id);
-        hwif_name = hw_bondifname;
-    } else {
-        hwif_name = tap_to_hwif_name(if_name.c_str());
-    }
-
-    SWSS_LOG_NOTICE("Resetting to default vrf for interface %s, %s", linux_ifname, hwif_name);
-
-    /* Remove all IP addresses before changing VRF.
-     * VPP requires no addresses on the interface when rebinding to a new VRF table
-     * (returns VNET_API_ERROR_ADDRESS_FOUND_FOR_INTERFACE / -114 otherwise). */
-    interface_ip_address_del_all(hwif_name);
-
-    uint32_t vrf_id = 0;
-    /* For now support is only for ipv4 tables */
-    set_interface_vrf(hwif_name, 0, vrf_id, false);
-
-    return SAI_STATUS_SUCCESS;
-}
-
 sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
 {
     SWSS_LOG_ENTER();
@@ -2301,13 +2050,37 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
         return SAI_STATUS_FAILURE;
     }
 
-    if (rif_type != SAI_ROUTER_INTERFACE_TYPE_SUB_PORT)
-    {
-        vpp_router_interface_remove_vrf(obj_id);
+    std::string hwif_name;
 
+    if (!vpp_get_hwif_name(obj_id, 0, hwif_name))
+    {
+        /*
+         * Nothing further can be torn down without the hwif name, but a remove
+         * must stay idempotent: if the VPP side is already gone (or was never
+         * brought up) the RIF delete still has to succeed, otherwise the
+         * orchagent retries forever on an object that cannot come back.
+         */
+        SWSS_LOG_WARN("No VPP interface found for %s, skipping VPP cleanup on RIF remove",
+                sai_serialize_object_id(obj_id).c_str());
         return SAI_STATUS_SUCCESS;
     }
 
+    if (rif_type != SAI_ROUTER_INTERFACE_TYPE_SUB_PORT)
+    {
+        SWSS_LOG_NOTICE("Resetting to default vrf for interface %s, hwif %s",
+                sai_serialize_object_id(obj_id).c_str(), hwif_name.c_str());
+
+        /* Remove all IP addresses before changing VRF.
+         * VPP requires no addresses on the interface when rebinding to a new VRF table
+         * (returns VNET_API_ERROR_ADDRESS_FOUND_FOR_INTERFACE / -114 otherwise). */
+        interface_ip_address_del_all(hwif_name.c_str());
+
+        uint32_t vrf_id = 0;
+        /* For now support is only for ipv4 tables */
+        set_interface_vrf(hwif_name.c_str(), 0, vrf_id, false);
+
+        return SAI_STATUS_SUCCESS;
+    }
 
     attr.id = SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID;
     status = get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_id, 1, &attr);
@@ -2320,56 +2093,39 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
     }
     uint16_t vlan_id = attr.value.u16;
 
-    std::string if_name;
-    platform_bond_info_t bond_info;
-    bool found;
-    if (ot == SAI_OBJECT_TYPE_LAG) {
-        status = get_lag_bond_info(obj_id, bond_info);
-        if (status != SAI_STATUS_SUCCESS) {
-            return status;
-        }
-        if_name = std::string(BONDETHERNET_PREFIX) + std::to_string(bond_info.id);
-        found = true;
-    } else {
-        found = getTapNameFromPortId(obj_id, if_name);
-    }
-    if (found == false)
+    /*
+     * The LCP host tap of a sub-interface is named after the parent's host
+     * interface: "<tap>.<vlan>" for a port and "be<id>.<vlan>" for a bond.
+     * getTapNameFromPortOrLagId() yields both forms.
+     */
+    std::string tap_name;
+
+    if (!getTapNameFromPortOrLagId(obj_id, tap_name))
     {
-        SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(obj_id).c_str());
-        return SAI_STATUS_FAILURE;
-    }
-
-    const char *dev = if_name.c_str();
-
-    const char *parent_hwif;
-    char hw_del_parent[32];
-    if (ot == SAI_OBJECT_TYPE_LAG) {
-        snprintf(hw_del_parent, sizeof(hw_del_parent), "%s%u", BONDETHERNET_PREFIX, bond_info.id);
-        parent_hwif = hw_del_parent;
-    } else {
-        parent_hwif = tap_to_hwif_name(dev);
+        /*
+         * Only the host half of the LCP pair is lost here, and the LCP plugin
+         * ignores it on delete anyway (see below), so carry on and still tear
+         * down the VPP sub-interface rather than leaking it.
+         */
+        SWSS_LOG_WARN("host interface for port id %s not found, deleting sub-interface anyway",
+                sai_serialize_object_id(obj_id).c_str());
     }
 
     /*
      * Tear down the explicit LCP pair created in vpp_create_router_interface for
-     * SUB_PORT (lcp-auto-subint is disabled, HLD §3.6). hostif name is ignored by
-     * the LCP plugin on delete, but pass the symmetric value for log clarity.
+     * SUB_PORT (lcp-auto-subint is disabled, HLD §3.6). The host name is ignored
+     * by the LCP plugin on delete (the pair is keyed by the VPP sub-if), but keep
+     * it symmetric with create (SONiC PR #2440 §5.3) for log clarity.
      */
-    char vpp_subif_name[64];
-    char host_subifname[64];
-    snprintf(vpp_subif_name, sizeof(vpp_subif_name), "%s.%u", parent_hwif, vlan_id);
-    if (ot == SAI_OBJECT_TYPE_LAG) {
-        /* Symmetric with create (SONiC PR #2440 §5.3): the host tap is
-         * be<id>.<vlan>. The host name is ignored by the LCP plugin on
-         * delete (the pair is keyed by the VPP sub-if), but keep it
-         * symmetric for log clarity. */
-        snprintf(host_subifname, sizeof(host_subifname), "be%u.%u", bond_info.id, vlan_id);
-    } else {
-        snprintf(host_subifname, sizeof(host_subifname), "%s.%u", dev, vlan_id);
-    }
-    configure_lcp_interface(vpp_subif_name, host_subifname, false);
+    std::string sub_hwif = hwif_name + "." + std::to_string(vlan_id);
+    std::string sub_tap = tap_name.empty() ? "" : tap_name + "." + std::to_string(vlan_id);
 
-    delete_sub_interface(parent_hwif, vlan_id);
+    configure_lcp_interface(sub_hwif.c_str(), sub_tap.c_str(), false);
+
+    delete_sub_interface(hwif_name.c_str(), vlan_id);
+
+    m_ifaceRegistry.remove(sub_hwif);
+
     /* Get new list of physical interfaces from VS */
     refresh_interfaces_list();
 

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -434,17 +434,17 @@ bool SwitchVpp::getPortHwifNameFromLane(
         return false;
     }
 
-    const char *mapped_hwifname = osif_name_to_hwif_name(port_name.c_str());
-    if (mapped_hwifname == nullptr)
+    const std::string mapped_hwifname = m_ifaceRegistry.resolveHwIfByOsIf(port_name);
+    if (mapped_hwifname.empty())
     {
         SWSS_LOG_ERROR("port %s has no VPP mapping", port_name.c_str());
         return false;
     }
 
-    if (vpp_get_swif_idx_by_name(mapped_hwifname) == static_cast<uint32_t>(-1))
+    if (vpp_get_swif_idx_by_name(mapped_hwifname.c_str()) == static_cast<uint32_t>(-1))
     {
         SWSS_LOG_ERROR("VPP interface %s is not present for port %s",
-                mapped_hwifname, port_name.c_str());
+                mapped_hwifname.c_str(), port_name.c_str());
         return false;
     }
 
@@ -471,7 +471,7 @@ bool SwitchVpp::getPortHwifNameFromLane(
     return true;
 }
 
-bool SwitchVpp::vpp_get_hwif_name (
+bool SwitchVpp::vppGetHwIfNameForPort (
       _In_ sai_object_id_t object_id,
       _In_ uint32_t vlan_id,
     _Out_ std::string& ifname,
@@ -480,87 +480,37 @@ bool SwitchVpp::vpp_get_hwif_name (
 {
     SWSS_LOG_ENTER();
 
-    std::string osif_name;
-    std::string hwifname;
+    /*
+     * Registry first. A port records its oid the moment it acquires an
+     * identity, so once it is known this answers straight from the oid without
+     * going through a name at all.
+     */
+    std::string hwifname = m_ifaceRegistry.resolveHwIfName(object_id, vlan_id);
 
-    sai_object_type_t ot = objectTypeQuery(object_id);
-
-    if (ot == SAI_OBJECT_TYPE_VLAN)
+    if (!hwifname.empty())
     {
-        /*
-         * A VLAN is represented in VPP by its BVI, which is named after the
-         * VLAN id and has no host interface behind it, so it never goes
-         * through the osif name path below.
-         */
-        sai_attribute_t vlan_attr;
+        ifname = hwifname;
 
-        vlan_attr.id = SAI_VLAN_ATTR_VLAN_ID;
-
-        if (get(SAI_OBJECT_TYPE_VLAN, object_id, 1, &vlan_attr) != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("SAI_VLAN_ATTR_VLAN_ID not found for %s",
-                    sai_serialize_object_id(object_id).c_str());
-            return false;
-        }
-
-        hwifname = std::string(BVI_PREFIX) + std::to_string(vlan_attr.value.u16);
+        return true;
     }
-    else if (ot == SAI_OBJECT_TYPE_PORT &&
-                getPortHwifNameFromLane(object_id, attr_count, attr_list, hwifname))
+
+    /*
+     * Not registered yet, which on this path is the normal case rather than an
+     * error: it is the lane list that gives a port its name, and registering
+     * it is a side effect of resolving it.
+     */
+    if (objectTypeQuery(object_id) != SAI_OBJECT_TYPE_PORT ||
+            !getPortHwifNameFromLane(object_id, attr_count, attr_list, hwifname))
     {
-        SWSS_LOG_DEBUG("using lane-based VPP interface %s for port %s",
-                hwifname.c_str(), sai_serialize_object_id(object_id).c_str());
+        SWSS_LOG_ERROR("no interface record for port id %s",
+                sai_serialize_object_id(object_id).c_str());
+
+        return false;
     }
-    else
-    {
-        /*
-         * Registry first. Both kinds that reach here record their oid at the
-         * moment they acquire an identity -- addPhysicalPort() from the lane
-         * path above, addLag() from vpp_create_lag() -- so the registry answers
-         * straight from the oid without going through a name at all, and
-         * without needing get_lag_bond_info() to rebuild "PortChannel<id>"
-         * only for osif_name_to_hwif_name() to take it apart again.
-         */
-        auto rec = m_ifaceRegistry.findByOid(object_id);
 
-        if (rec)
-        {
-            hwifname = rec->getHwifName();
-        }
-        else
-        {
-            /*
-             * Legacy fallback, deliberately still here: the registry is
-             * in-memory and only populated by the create paths, so anything it
-             * has not seen must still resolve exactly as before. The WARN is
-             * the parity harness -- a VS run that never logs it is the signal
-             * that Phase 5 may delete this arm.
-             *
-             * osif_name_to_hwif_name() is keyed on the SONiC netdev name, so
-             * the LAG must be resolved to PortChannel<id> and not to its
-             * linux-cp tap be<id>.
-             */
-            if (getOsIfFromPortOrLagId(object_id, osif_name) == false)
-            {
-                SWSS_LOG_ERROR("host interface for port/lag id %s not found",
-                        sai_serialize_object_id(object_id).c_str());
-                return false;
-            }
+    SWSS_LOG_DEBUG("using lane-based VPP interface %s for port %s",
+            hwifname.c_str(), sai_serialize_object_id(object_id).c_str());
 
-            const char *mapped_hwifname = osif_name_to_hwif_name(osif_name.c_str());
-
-            if (mapped_hwifname == nullptr)
-            {
-                return false;
-            }
-
-            hwifname = mapped_hwifname;
-
-            SWSS_LOG_WARN("registry miss for %s, legacy path resolved %s to %s",
-                    sai_serialize_object_id(object_id).c_str(),
-                    osif_name.c_str(), hwifname.c_str());
-        }
-    }
     if (vlan_id) {
         ifname = hwifname + "." + std::to_string(vlan_id);
     } else {
@@ -585,12 +535,14 @@ void SwitchVpp::resyncPortOperStatus()
         }
 
         const char* dev = tapname.c_str();
-        const char* hwif_name = osif_name_to_hwif_name(dev);
+        const std::string hwif = m_ifaceRegistry.resolveHwIfByOsIf(tapname);
 
-        if (hwif_name == nullptr)
+        if (hwif.empty())
         {
             continue;
         }
+
+        const char* hwif_name = hwif.c_str();
 
         bool link_up = false;
 
@@ -763,16 +715,15 @@ sai_status_t SwitchVpp::asyncIntfStateUpdate(const char *hwif_name, bool link_up
 {
     SWSS_LOG_ENTER();
 
-    std::string tap_str;
-    const char *tap;
+    auto rec = m_ifaceRegistry.findByHwif(hwif_name);
 
-    tap = hwif_to_osif_name(hwif_name);
-    auto port_oid = getPortIdFromIfName(std::string(tap));
-
-    if (port_oid == SAI_NULL_OBJECT_ID) {
-        SWSS_LOG_NOTICE("Failed find port oid for tap interface %s. Ignore the update.", tap);
+    if (!rec)
+    {
+        SWSS_LOG_NOTICE("No interface record for hwif %s. Ignore the update.", hwif_name);
         return SAI_STATUS_SUCCESS;
     }
+
+    const sai_object_id_t port_oid = rec->getOid();
 
     auto state = link_up ? SAI_PORT_OPER_STATUS_UP : SAI_PORT_OPER_STATUS_DOWN;
 
@@ -796,7 +747,7 @@ sai_status_t SwitchVpp::vpp_set_interface_state (
 
     std::string ifname;
 
-    if (vpp_get_hwif_name(object_id, vlan_id, ifname, attr_count, attr_list))
+    if (vppGetHwIfNameForPort(object_id, vlan_id, ifname, attr_count, attr_list))
     {
         const char *hwif_name = ifname.c_str();
 
@@ -822,7 +773,7 @@ sai_status_t SwitchVpp::vpp_set_port_mtu (
 
     std::string ifname;
 
-    if (vpp_get_hwif_name(object_id, vlan_id, ifname, attr_count, attr_list))
+    if (vppGetHwIfNameForPort(object_id, vlan_id, ifname, attr_count, attr_list))
     {
         const char *hwif_name = ifname.c_str();
 
@@ -846,7 +797,7 @@ sai_status_t SwitchVpp::vpp_set_interface_mtu (
 
     std::string ifname;
 
-    if (vpp_get_hwif_name(object_id, vlan_id, ifname) == true) {
+    if (vppGetHwIfNameForPort(object_id, vlan_id, ifname) == true) {
         const char *hwif_name = ifname.c_str();
 
         sw_interface_set_mtu(hwif_name, mtu);
@@ -870,7 +821,7 @@ sai_status_t SwitchVpp::vpp_set_port_speed (
 
     std::string ifname;
 
-    if (vpp_get_hwif_name(object_id, vlan_id, ifname, attr_count, attr_list))
+    if (vppGetHwIfNameForPort(object_id, vlan_id, ifname, attr_count, attr_list))
     {
         const char *hwif_name = ifname.c_str();
 
@@ -1200,28 +1151,40 @@ sai_status_t SwitchVpp::vpp_add_del_intf_ip_addr_norif (
     /*
      * full_if_name is the kernel netdev that owns the prefix, i.e. a host OS
      * interface name: "Ethernet0[.<vlan>]", "PortChannel<N>[.<vlan>]" or
-     * "Vlan<N>". osif_name_to_hwif_name() resolves every one of those forms,
+     * "Vlan<N>". resolveHwIfByOsIf() resolves every one of those forms,
      * sub-interface suffix included, so no per-family string surgery is needed
      * here. It also replaces a std::stoi() on the PortChannel name that used to
      * silently parse "102.20" as 102 and program the address onto the bond main
      * interface instead of the sub-interface.
      */
-    const char *hw_ifname = osif_name_to_hwif_name(full_if_name.c_str());
+    const std::string hw_ifname_str = m_ifaceRegistry.resolveHwIfByOsIf(full_if_name);
 
-    if (hw_ifname == nullptr)
+    if (hw_ifname_str.empty())
     {
         SWSS_LOG_ERROR("no hwif found for interface %s", full_if_name.c_str());
 
         return SAI_STATUS_FAILURE;
     }
 
+    const char *hw_ifname = hw_ifname_str.c_str();
+
     SWSS_LOG_NOTICE("Setting ip on hw_ifname %s", hw_ifname);
 
     if (is_add)
     {
-        sai_object_id_t port_oid = getPortIdFromIfName(full_if_name);
+        auto rec = m_ifaceRegistry.findByOsIf(full_if_name);
 
-        if (port_oid != SAI_NULL_OBJECT_ID)
+        const sai_object_id_t port_oid = rec ? rec->getOid() : SAI_NULL_OBJECT_ID;
+
+        /*
+         * A PORT that already has a tap, and nothing else. A LAG, a BVI or a
+         * sub-interface has no tap MAC of its own to reconcile, and the hostif
+         * keyed map this replaces answered for none of them either -- so the
+         * tap test keeps a miss quiet here instead of letting
+         * restorePortTapMac() log it as a failure.
+         */
+        if (objectTypeQuery(port_oid) == SAI_OBJECT_TYPE_PORT &&
+                !m_ifaceRegistry.resolveTapName(port_oid).empty())
         {
             SWSS_LOG_NOTICE("reconciling tap MAC for %s before IP programming",
                     full_if_name.c_str());
@@ -1698,17 +1661,17 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
      * They differ for a LAG (PortChannel<id> / BondEthernet<id> / be<id>) and
      * coincide for a physical port.
      */
-    std::string osif_name;
+    std::string osif_name = m_ifaceRegistry.resolveOsIf(obj_id);
 
-    if (!getOsIfFromPortOrLagId(obj_id, osif_name))
+    if (osif_name.empty())
     {
         SWSS_LOG_ERROR("host interface for port id %s not found", sai_serialize_object_id(obj_id).c_str());
         return SAI_STATUS_FAILURE;
     }
 
-    std::string parent_hwif;
+    std::string parent_hwif = m_ifaceRegistry.resolveHwIfName(obj_id, 0);
 
-    if (!vpp_get_hwif_name(obj_id, 0, parent_hwif))
+    if (parent_hwif.empty())
     {
         SWSS_LOG_ERROR("No VPP interface found for %s", sai_serialize_object_id(obj_id).c_str());
         return SAI_STATUS_FAILURE;
@@ -1727,9 +1690,9 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
          * originating member tap (SONiC PR #2440 §5.3). For a plain port the
          * tap name is the SONiC name, so this is just Ethernet<n>.<vlan>.
          */
-        std::string tap_name;
+        std::string tap_name = m_ifaceRegistry.resolveTapName(obj_id);
 
-        if (!getTapNameFromPortOrLagId(obj_id, tap_name))
+        if (tap_name.empty())
         {
             SWSS_LOG_ERROR("host tap for port/lag id %s not found",
                     sai_serialize_object_id(obj_id).c_str());
@@ -1825,8 +1788,9 @@ sai_status_t SwitchVpp::vpp_create_router_interface(
 
     if (attr_type_mpls != NULL)
     {
-        std::string mpls_hwif_name;
-        if (vpp_get_hwif_name(obj_id, vlan_id, mpls_hwif_name))
+        std::string mpls_hwif_name = m_ifaceRegistry.resolveHwIfName(obj_id, vlan_id);
+
+        if (!mpls_hwif_name.empty())
         {
             CHECK_STATUS(ensureMplsTable());
             int mpls_ret = sw_interface_set_mpls_enable(mpls_hwif_name.c_str(), attr_type_mpls->value.booldata);
@@ -1949,8 +1913,9 @@ sai_status_t SwitchVpp::vpp_update_router_interface(
 
     if (attr_type_mpls != NULL)
     {
-        std::string mpls_hwif_name;
-        if (vpp_get_hwif_name(obj_id, vlan_id, mpls_hwif_name))
+        std::string mpls_hwif_name = m_ifaceRegistry.resolveHwIfName(obj_id, vlan_id);
+
+        if (!mpls_hwif_name.empty())
         {
             CHECK_STATUS(ensureMplsTable());
             int mpls_ret = sw_interface_set_mpls_enable(mpls_hwif_name.c_str(), attr_type_mpls->value.booldata);
@@ -2050,9 +2015,9 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
         return SAI_STATUS_FAILURE;
     }
 
-    std::string hwif_name;
+    std::string hwif_name = m_ifaceRegistry.resolveHwIfName(obj_id, 0);
 
-    if (!vpp_get_hwif_name(obj_id, 0, hwif_name))
+    if (hwif_name.empty())
     {
         /*
          * Nothing further can be torn down without the hwif name, but a remove
@@ -2096,11 +2061,11 @@ sai_status_t SwitchVpp::vpp_remove_router_interface(sai_object_id_t rif_id)
     /*
      * The LCP host tap of a sub-interface is named after the parent's host
      * interface: "<tap>.<vlan>" for a port and "be<id>.<vlan>" for a bond.
-     * getTapNameFromPortOrLagId() yields both forms.
+     * resolveTapName() yields both forms.
      */
-    std::string tap_name;
+    std::string tap_name = m_ifaceRegistry.resolveTapName(obj_id);
 
-    if (!getTapNameFromPortOrLagId(obj_id, tap_name))
+    if (tap_name.empty())
     {
         /*
          * Only the host half of the LCP pair is lost here, and the LCP plugin

--- a/vslib/vpp/SwitchVppRif.cpp
+++ b/vslib/vpp/SwitchVppRif.cpp
@@ -715,15 +715,25 @@ sai_status_t SwitchVpp::asyncIntfStateUpdate(const char *hwif_name, bool link_up
 {
     SWSS_LOG_ENTER();
 
-    auto rec = m_ifaceRegistry.findByHwif(hwif_name);
+    /*
+     * Runs on the VPP event thread, which holds neither m_apimutex nor any VPP
+     * lock at this point. The registry is internally synchronized, but a record
+     * handed back by findBy*() would be read after that lock is dropped, so ask
+     * for the oid as a value instead: the port type test and the oid read both
+     * happen inside the registry lock.
+     *
+     * A null oid means the hwif is not a front panel port (BondEthernet, bvi, a
+     * sub-interface) or has no oid yet. Only physical ports carry SAI port oper
+     * status.
+     */
+    const sai_object_id_t port_oid = m_ifaceRegistry.resolvePhysicalPortOid(hwif_name);
 
-    if (!rec)
+    if (port_oid == SAI_NULL_OBJECT_ID)
     {
-        SWSS_LOG_NOTICE("No interface record for hwif %s. Ignore the update.", hwif_name);
+        SWSS_LOG_INFO("no physical port record for hwif %s, ignoring link update", hwif_name);
+
         return SAI_STATUS_SUCCESS;
     }
-
-    const sai_object_id_t port_oid = rec->getOid();
 
     auto state = link_up ? SAI_PORT_OPER_STATUS_UP : SAI_PORT_OPER_STATUS_DOWN;
 

--- a/vslib/vpp/SwitchVppRoute.cpp
+++ b/vslib/vpp/SwitchVppRoute.cpp
@@ -140,10 +140,14 @@ const char* SwitchVpp::resolveNexthopMemberHwif(
     }
 
     rif_attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
-    if (get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, member->rif_oid, 1, &rif_attr) == SAI_STATUS_SUCCESS &&
-        vpp_get_hwif_name(rif_attr.value.oid, vlan_id, member_hwif))
+    if (get(SAI_OBJECT_TYPE_ROUTER_INTERFACE, member->rif_oid, 1, &rif_attr) == SAI_STATUS_SUCCESS)
     {
-        return member_hwif.c_str();
+        member_hwif = m_ifaceRegistry.resolveHwIfName(rif_attr.value.oid, vlan_id);
+
+        if (!member_hwif.empty())
+        {
+            return member_hwif.c_str();
+        }
     }
 
     return NULL;

--- a/vslib/vpp/SwitchVppRoute.cpp
+++ b/vslib/vpp/SwitchVppRoute.cpp
@@ -219,11 +219,7 @@ sai_status_t SwitchVpp::IpRouteAddRemove(
 
     nexthop_grp_config_t *nxthop_group = NULL;
 
-    if (SAI_OBJECT_TYPE_ROUTER_INTERFACE == RealObjectIdManager::objectTypeQuery(next_hop_oid))
-    {
-        // vpp_add_del_intf_ip_addr(route_entry.destination, next_hop_oid, is_add);
-    }
-    else if (SAI_OBJECT_TYPE_PORT == RealObjectIdManager::objectTypeQuery(next_hop_oid))
+    if (SAI_OBJECT_TYPE_PORT == RealObjectIdManager::objectTypeQuery(next_hop_oid))
     {
         attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
         status = route_obj->get_attr(attr);

--- a/vslib/vpp/SwitchVppSRv6.cpp
+++ b/vslib/vpp/SwitchVppSRv6.cpp
@@ -92,7 +92,8 @@ sai_status_t TunnelManagerSRv6::fill_next_hop(
         vlan_idx = 0;
     }
 
-    if(!m_switch_db->vpp_get_hwif_name(port_oid, vlan_idx, hwif_name)) {
+    hwif_name = m_switch_db->getInterfaceRegistry().resolveHwIfName(port_oid, vlan_idx);
+    if(hwif_name.empty()) {
         SWSS_LOG_WARN("VPP hwif name not found for port %s", sai_serialize_object_id(port_oid).c_str());
         return SAI_STATUS_FAILURE;
     }

--- a/vslib/vpp/SwitchVppSflow.cpp
+++ b/vslib/vpp/SwitchVppSflow.cpp
@@ -59,9 +59,9 @@ sai_status_t SwitchVpp::sflowEnableDisable(
 {
     SWSS_LOG_ENTER();
 
-    std::string if_name;
+    std::string if_name = m_ifaceRegistry.resolveHwIfName(port_id, 0);
 
-    if(!port_to_hwifname(port_id, if_name))
+    if (if_name.empty())
     {
         SWSS_LOG_ERROR("failed to get hwif name for port %s", sai_serialize_object_id(port_id).c_str());
         return SAI_STATUS_FAILURE;
@@ -237,9 +237,9 @@ sai_status_t SwitchVpp::sflowInterfaceSamplingRateSet(
 {
     SWSS_LOG_ENTER();
 
-    std::string if_name;
+    std::string if_name = m_ifaceRegistry.resolveHwIfName(port_id, 0);
 
-    if(!port_to_hwifname(port_id, if_name))
+    if (if_name.empty())
     {
         SWSS_LOG_ERROR("failed to get hwif name for port %s", sai_serialize_object_id(port_id).c_str());
         return SAI_STATUS_FAILURE;
@@ -263,9 +263,9 @@ sai_status_t SwitchVpp::sflowInterfaceDirectionSet(
 {
     SWSS_LOG_ENTER();
 
-    std::string if_name;
+    std::string if_name = m_ifaceRegistry.resolveHwIfName(port_id, 0);
 
-    if(!port_to_hwifname(port_id, if_name))
+    if (if_name.empty())
     {
         SWSS_LOG_ERROR("failed to get hwif name for port %s", sai_serialize_object_id(port_id).c_str());
         return SAI_STATUS_FAILURE;

--- a/vslib/vpp/SwitchVppUtils.h
+++ b/vslib/vpp/SwitchVppUtils.h
@@ -15,6 +15,17 @@ extern "C" {
 
 #define BONDETHERNET_PREFIX "BondEthernet"
 
+#define VLAN_PREFIX "Vlan"
+
+#define BVI_PREFIX "bvi"
+
+/*
+ * LCP host-interface (tap) name of a bond. Deliberately not PORTCHANNEL_PREFIX:
+ * "PortChannel<N>" is the kernel bond netdev owned by teamd, and naming the tap
+ * after it would collide with that device.
+ */
+#define BOND_TAP_PREFIX "be"
+
 /*
  * Kernel-only IP-in-IP mux tunnel interface created by swss tunnelmgrd on
  * dual-ToR devices (must match TUNIF in sonic-swss cfgmgr/tunnelmgr.cpp).

--- a/vslib/vpp/VppInterface.h
+++ b/vslib/vpp/VppInterface.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "swss/logger.h"
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -26,7 +26,6 @@ namespace saivs
     class VppBondInterface;
     class VppSubInterface;
     class VppVlanInterface;
-    class VppTunnelInterface;
 
     enum class VppInterfaceType
     {
@@ -36,7 +35,6 @@ namespace saivs
         LAG,                // BondEthernet<N>
         SUB_INTERFACE,      // <parent>.<vlan>, no PORT/LAG oid of its own
         VLAN_BVI,           // bvi<N>
-        TUNNEL,             // VXLAN/IPinIP, no tap and no port oid
     };
 
     class VppInterface
@@ -75,6 +73,7 @@ namespace saivs
 
             VppInterfaceType getType() const
             {
+                SWSS_LOG_ENTER();
                 return m_type;
             }
 
@@ -85,6 +84,7 @@ namespace saivs
              */
             const std::string& getHwifName() const
             {
+                SWSS_LOG_ENTER();
                 return m_hwifName;
             }
 
@@ -102,11 +102,13 @@ namespace saivs
              */
             const std::string& getOsIf() const
             {
+                SWSS_LOG_ENTER();
                 return m_osIf;
             }
 
             bool hasOsIf() const
             {
+                SWSS_LOG_ENTER();
                 return !m_osIf.empty();
             }
 
@@ -126,11 +128,13 @@ namespace saivs
              */
             const std::string& getTapName() const
             {
+                SWSS_LOG_ENTER();
                 return m_tapName;
             }
 
             bool hasTapName() const
             {
+                SWSS_LOG_ENTER();
                 return !m_tapName.empty();
             }
 
@@ -139,15 +143,17 @@ namespace saivs
              * SAI_OBJECT_TYPE_VLAN. The first two are what the FDB path
              * resolves to and what SAI_BRIDGE_PORT_ATTR_PORT_ID holds; the
              * third lets a BVI be found from the vlan oid a VLAN router
-             * interface carries. Sub-interfaces and tunnels never have one.
+             * interface carries. A sub-interface never has one.
              */
             sai_object_id_t getOid() const
             {
+                SWSS_LOG_ENTER();
                 return m_oid;
             }
 
             bool hasOid() const
             {
+                SWSS_LOG_ENTER();
                 return m_oid != SAI_NULL_OBJECT_ID;
             }
 
@@ -159,31 +165,37 @@ namespace saivs
              */
             sai_object_id_t getRifOid() const
             {
+                SWSS_LOG_ENTER();
                 return m_rifOid;
             }
 
             bool hasRifOid() const
             {
+                SWSS_LOG_ENTER();
                 return m_rifOid != SAI_NULL_OBJECT_ID;
             }
 
             uint32_t getSwIfIndex() const
             {
+                SWSS_LOG_ENTER();
                 return m_swIfIndex;
             }
 
             bool hasSwIfIndex() const
             {
+                SWSS_LOG_ENTER();
                 return m_swIfIndex != SWIF_INDEX_INVALID;
             }
 
             uint32_t getBdId() const
             {
+                SWSS_LOG_ENTER();
                 return m_bdId;
             }
 
             bool hasBdId() const
             {
+                SWSS_LOG_ENTER();
                 return m_bdId != BD_ID_INVALID;
             }
 
@@ -198,6 +210,7 @@ namespace saivs
 
             virtual std::string deriveTapName() const
             {
+                SWSS_LOG_ENTER();
                 return std::string();
             }
 
@@ -211,7 +224,6 @@ namespace saivs
             const VppBondInterface* asBond() const;
             const VppSubInterface* asSubIf() const;
             const VppVlanInterface* asVlan() const;
-            const VppTunnelInterface* asTunnel() const;
 
             /*
              * Non-const overload, for the one piece of bond state that is not
@@ -244,7 +256,7 @@ namespace saivs
                 m_swIfIndex(SWIF_INDEX_INVALID),
                 m_bdId(bdId)
             {
-                // empty
+                SWSS_LOG_ENTER();
             }
 
         private:
@@ -288,11 +300,12 @@ namespace saivs
                     _In_ const std::string& osIf):
                 VppInterface(VppInterfaceType::PHYSICAL_PORT, hwifName, osIf)
             {
-                // empty
+                SWSS_LOG_ENTER();
             }
 
             std::string deriveHwifName() const override
             {
+                SWSS_LOG_ENTER();
                 return getHwifName();
             }
 
@@ -302,6 +315,7 @@ namespace saivs
              */
             std::string deriveTapName() const override
             {
+                SWSS_LOG_ENTER();
                 return getOsIf();
             }
     };
@@ -322,27 +336,32 @@ namespace saivs
 
             uint32_t getBondId() const
             {
+                SWSS_LOG_ENTER();
                 return m_bondId;
             }
 
             bool isLcpCreated() const
             {
+                SWSS_LOG_ENTER();
                 return m_lcpCreated;
             }
 
             void setLcpCreated(
                     _In_ bool created)
             {
+                SWSS_LOG_ENTER();
                 m_lcpCreated = created;
             }
 
             std::string deriveHwifName() const override
             {
+                SWSS_LOG_ENTER();
                 return hwifNameFor(m_bondId);
             }
 
             std::string deriveTapName() const override
             {
+                SWSS_LOG_ENTER();
                 return tapNameFor(m_bondId);
             }
 
@@ -352,6 +371,7 @@ namespace saivs
             static std::string hwifNameFor(
                     _In_ uint32_t bondId)
             {
+                SWSS_LOG_ENTER();
                 return "BondEthernet" + std::to_string(bondId);
             }
 
@@ -359,6 +379,7 @@ namespace saivs
             static std::string osIfFor(
                     _In_ uint32_t bondId)
             {
+                SWSS_LOG_ENTER();
                 return "PortChannel" + std::to_string(bondId);
             }
 
@@ -370,6 +391,7 @@ namespace saivs
             static std::string tapNameFor(
                     _In_ uint32_t bondId)
             {
+                SWSS_LOG_ENTER();
                 return "be" + std::to_string(bondId);
             }
 
@@ -424,21 +446,25 @@ namespace saivs
              */
             std::shared_ptr<VppInterface> getParent() const
             {
+                SWSS_LOG_ENTER();
                 return m_parent.lock();
             }
 
             uint32_t getSubId() const
             {
+                SWSS_LOG_ENTER();
                 return m_subId;
             }
 
             uint16_t getVlanId() const
             {
+                SWSS_LOG_ENTER();
                 return m_vlanId;
             }
 
             std::string deriveHwifName() const override
             {
+                SWSS_LOG_ENTER();
                 auto parent = m_parent.lock();
 
                 return hwifNameFor(parent ? parent->getHwifName() : std::string(), m_subId);
@@ -452,6 +478,7 @@ namespace saivs
              */
             std::string deriveTapName() const override
             {
+                SWSS_LOG_ENTER();
                 auto parent = m_parent.lock();
 
                 if (!parent || !parent->hasTapName())
@@ -468,6 +495,7 @@ namespace saivs
                     _In_ const std::string& parentHwifName,
                     _In_ uint32_t subId)
             {
+                SWSS_LOG_ENTER();
                 return parentHwifName + "." + std::to_string(subId);
             }
 
@@ -475,6 +503,7 @@ namespace saivs
                     _In_ const std::string& parentOsIf,
                     _In_ uint32_t subId)
             {
+                SWSS_LOG_ENTER();
                 if (parentOsIf.empty())
                 {
                     return std::string();
@@ -512,16 +541,19 @@ namespace saivs
 
             uint16_t getVlanId() const
             {
+                SWSS_LOG_ENTER();
                 return m_vlanId;
             }
 
             std::string deriveHwifName() const override
             {
+                SWSS_LOG_ENTER();
                 return hwifNameFor(m_vlanId);
             }
 
             std::string deriveTapName() const override
             {
+                SWSS_LOG_ENTER();
                 return tapNameFor(m_vlanId);
             }
 
@@ -530,18 +562,21 @@ namespace saivs
             static std::string hwifNameFor(
                     _In_ uint16_t vlanId)
             {
+                SWSS_LOG_ENTER();
                 return "bvi" + std::to_string(vlanId);
             }
 
             static std::string osIfFor(
                     _In_ uint16_t vlanId)
             {
+                SWSS_LOG_ENTER();
                 return "Vlan" + std::to_string(vlanId);
             }
 
             static std::string tapNameFor(
                     _In_ uint16_t vlanId)
             {
+                SWSS_LOG_ENTER();
                 return "tap_Vlan" + std::to_string(vlanId);
             }
 
@@ -555,6 +590,7 @@ namespace saivs
             static uint32_t bdIdFor(
                     _In_ uint16_t vlanId)
             {
+                SWSS_LOG_ENTER();
                 return vlanId;
             }
 
@@ -563,42 +599,10 @@ namespace saivs
             uint16_t m_vlanId;
     };
 
-    /*
-     * No SONiC name, no tap, no port oid, and no derivable name: VPP names
-     * tunnels itself. L2 tunnels are keyed by vni, L3 encap by NEXT_HOP oid, so
-     * neither the by_oid nor the by_tap index applies here.
-     */
-    class VppTunnelInterface:
-        public VppInterface
-    {
-        public:
-
-            VppTunnelInterface(
-                    _In_ const std::string& hwifName,
-                    _In_ uint32_t vni):
-                VppInterface(VppInterfaceType::TUNNEL, hwifName, std::string()),
-                m_vni(vni)
-            {
-                // empty
-            }
-
-            uint32_t getVni() const
-            {
-                return m_vni;
-            }
-
-            std::string deriveHwifName() const override
-            {
-                return getHwifName();
-            }
-
-        private:
-
-            uint32_t m_vni;
-    };
-
     inline const VppBondInterface* VppInterface::asBond() const
     {
+        SWSS_LOG_ENTER();
+
         if (m_type != VppInterfaceType::LAG)
             return nullptr;
 
@@ -607,6 +611,8 @@ namespace saivs
 
     inline VppBondInterface* VppInterface::asBond()
     {
+        SWSS_LOG_ENTER();
+
         if (m_type != VppInterfaceType::LAG)
             return nullptr;
 
@@ -615,6 +621,8 @@ namespace saivs
 
     inline const VppSubInterface* VppInterface::asSubIf() const
     {
+        SWSS_LOG_ENTER();
+
         if (m_type != VppInterfaceType::SUB_INTERFACE)
             return nullptr;
 
@@ -623,17 +631,11 @@ namespace saivs
 
     inline const VppVlanInterface* VppInterface::asVlan() const
     {
+        SWSS_LOG_ENTER();
+
         if (m_type != VppInterfaceType::VLAN_BVI)
             return nullptr;
 
         return static_cast<const VppVlanInterface*>(this);
-    }
-
-    inline const VppTunnelInterface* VppInterface::asTunnel() const
-    {
-        if (m_type != VppInterfaceType::TUNNEL)
-            return nullptr;
-
-        return static_cast<const VppTunnelInterface*>(this);
     }
 }

--- a/vslib/vpp/VppInterface.h
+++ b/vslib/vpp/VppInterface.h
@@ -1,0 +1,637 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+extern "C" {
+#include "sai.h"
+}
+
+/*
+ * Passive identity records for every kind of interface the VPP SAI backend
+ * knows about.
+ *
+ * These objects hold data only. They deliberately do NOT call any VPP API
+ * (create_bond_interface, configure_lcp_interface, refresh_interfaces_list,
+ * ...) so that this header stays free of SaiVppXlate.h and the records remain
+ * unit-testable on their own. All behaviour stays in SwitchVpp; ownership and
+ * index consistency stay in VppInterfaceRegistry.
+ */
+
+namespace saivs
+{
+    class VppInterfaceRegistry;
+
+    class VppBondInterface;
+    class VppSubInterface;
+    class VppVlanInterface;
+    class VppTunnelInterface;
+
+    enum class VppInterfaceType
+    {
+        UNKNOWN = 0,
+
+        PHYSICAL_PORT,      // front panel port, named by sonic_vpp_ifmap.ini
+        LAG,                // BondEthernet<N>
+        SUB_INTERFACE,      // <parent>.<vlan>, no PORT/LAG oid of its own
+        VLAN_BVI,           // bvi<N>
+        TUNNEL,             // VXLAN/IPinIP, no tap and no port oid
+    };
+
+    class VppInterface
+    {
+        public:
+
+            /*
+             * Enumerators rather than static const members so that they need no
+             * out-of-line definition when odr-used (C++14).
+             */
+            enum : uint32_t
+            {
+                /*
+                 * sw_if_index is late bound: a physical port only learns its
+                 * index from a sw_interface_dump, well after the record is
+                 * created.
+                 */
+                SWIF_INDEX_INVALID = ~0u,
+
+                /*
+                 * "not a member of any bridge domain". This must stay distinct
+                 * from "no record exists": the FDB path uses the presence of a
+                 * bd_id as the gate that discards MAC events for L3 interfaces.
+                 */
+                BD_ID_INVALID = ~0u,
+            };
+
+        public:
+
+            virtual ~VppInterface() = default;
+
+            VppInterface(const VppInterface&) = delete;
+            VppInterface& operator=(const VppInterface&) = delete;
+
+        public:
+
+            VppInterfaceType getType() const
+            {
+                return m_type;
+            }
+
+            /*
+             * VPP side name, e.g. "TenGigabitEthernet0/0/0", "BondEthernet1",
+             * "BondEthernet1.100", "bvi200". This is the primary natural key:
+             * it is the only identity every interface kind always has.
+             */
+            const std::string& getHwifName() const
+            {
+                return m_hwifName;
+            }
+
+            /*
+             * SONiC side name, e.g. "Ethernet0", "PortChannel1", "Vlan200",
+             * "PortChannel1.100".
+             *
+             * A pure naming fact, known as soon as the interface is known. It
+             * is what the lane based port lookup resolves against
+             * (getPortHwifNameFromLane -> port_config.ini name ->
+             * sonic_vpp_ifmap.ini), which is why it must be available long
+             * before, and independently of, any host interface.
+             *
+             * This is NOT evidence that a host netdev exists. See getTapName().
+             */
+            const std::string& getSonicName() const
+            {
+                return m_sonicName;
+            }
+
+            bool hasSonicName() const
+            {
+                return !m_sonicName.empty();
+            }
+
+            /*
+             * Linux side name of an EXISTING host netdev, e.g. "Ethernet0",
+             * "be1", "tap_Vlan200", "be1.100".
+             *
+             * Late bound and optional. A physical port is fully usable before
+             * SAI ever creates a hostif for it, and some never get one, so this
+             * must not be seeded at registration time: doing so would make the
+             * punt paths believe in a tap that does not exist.
+             *
+             * Usually equal to getSonicName() but not always - a sub-port RIF on
+             * a bond deliberately uses "be<id>.<vlan>" rather than
+             * "PortChannel<id>.<vlan>", which would collide with the kernel
+             * 8021q netdev owned by the Linux bond stack.
+             */
+            const std::string& getTapName() const
+            {
+                return m_tapName;
+            }
+
+            bool hasTapName() const
+            {
+                return !m_tapName.empty();
+            }
+
+            /*
+             * SAI_OBJECT_TYPE_PORT or SAI_OBJECT_TYPE_LAG only. This is what the
+             * FDB path resolves to and what SAI_BRIDGE_PORT_ATTR_PORT_ID holds.
+             * Sub-interfaces, BVIs and tunnels never have one.
+             */
+            sai_object_id_t getOid() const
+            {
+                return m_oid;
+            }
+
+            bool hasOid() const
+            {
+                return m_oid != SAI_NULL_OBJECT_ID;
+            }
+
+            /*
+             * SAI_OBJECT_TYPE_ROUTER_INTERFACE, kept separate from getOid() on
+             * purpose: a RIF's SAI_ROUTER_INTERFACE_ATTR_PORT_ID is validated as
+             * PORT *or LAG*, so a bond carries one too. Denormalised cache of an
+             * attribute that also lives in the SAI object store.
+             */
+            sai_object_id_t getRifOid() const
+            {
+                return m_rifOid;
+            }
+
+            bool hasRifOid() const
+            {
+                return m_rifOid != SAI_NULL_OBJECT_ID;
+            }
+
+            uint32_t getSwIfIndex() const
+            {
+                return m_swIfIndex;
+            }
+
+            bool hasSwIfIndex() const
+            {
+                return m_swIfIndex != SWIF_INDEX_INVALID;
+            }
+
+            uint32_t getBdId() const
+            {
+                return m_bdId;
+            }
+
+            bool hasBdId() const
+            {
+                return m_bdId != BD_ID_INVALID;
+            }
+
+        public:
+
+            /*
+             * Per-type name construction. Currently duplicated across the code
+             * base ("bvi%u" is built in two places, "be"+id in two more, the
+             * BondEthernet prefix in seven); these are the single source.
+             */
+            virtual std::string deriveHwifName() const = 0;
+
+            virtual std::string deriveTapName() const
+            {
+                return std::string();
+            }
+
+        public:
+
+            /*
+             * Cheap downcasts: an enum test plus static_cast, returning nullptr
+             * on a type mismatch. Deliberately NOT dynamic_cast, because these
+             * run on the FDB learn/move/age path for every MAC event.
+             */
+            const VppBondInterface* asBond() const;
+            const VppSubInterface* asSubIf() const;
+            const VppVlanInterface* asVlan() const;
+            const VppTunnelInterface* asTunnel() const;
+
+            /*
+             * Non-const overload, for the one piece of bond state that is not
+             * identity and so is not owned by the registry: lcp_created.
+             */
+            VppBondInterface* asBond();
+
+        protected:
+
+            /*
+             * Note that no tap name is accepted here: it is late bound through
+             * VppInterfaceRegistry::setTapName() when the hostif is actually
+             * created.
+             *
+             * bdId is accepted because for a BVI it is not late bound at all:
+             * it is a pure function of the vlan id, known before the interface
+             * exists. Every other kind joins a bridge domain as a later,
+             * separate act and so leaves it invalid here.
+             */
+            VppInterface(
+                    _In_ VppInterfaceType type,
+                    _In_ const std::string& hwifName,
+                    _In_ const std::string& sonicName,
+                    _In_ uint32_t bdId = BD_ID_INVALID):
+                m_type(type),
+                m_hwifName(hwifName),
+                m_sonicName(sonicName),
+                m_oid(SAI_NULL_OBJECT_ID),
+                m_rifOid(SAI_NULL_OBJECT_ID),
+                m_swIfIndex(SWIF_INDEX_INVALID),
+                m_bdId(bdId)
+            {
+                // empty
+            }
+
+        private:
+
+            /*
+             * Only the registry may mutate identity, because every one of these
+             * fields is also an index key and the indexes must be updated in the
+             * same step. That invariant is the entire reason the registry exists.
+             */
+            friend class VppInterfaceRegistry;
+
+            VppInterfaceType m_type;
+
+            std::string m_hwifName;
+
+            std::string m_sonicName;
+
+            std::string m_tapName;
+
+            sai_object_id_t m_oid;
+
+            sai_object_id_t m_rifOid;
+
+            uint32_t m_swIfIndex;
+
+            uint32_t m_bdId;
+    };
+
+    /*
+     * Front panel port. Both names come from sonic_vpp_ifmap.ini and are known
+     * at seed time, so there is nothing to derive. The sw_if_index, the PORT
+     * oid and the host tap all arrive later and independently of each other.
+     */
+    class VppPhysicalPort:
+        public VppInterface
+    {
+        public:
+
+            VppPhysicalPort(
+                    _In_ const std::string& hwifName,
+                    _In_ const std::string& sonicName):
+                VppInterface(VppInterfaceType::PHYSICAL_PORT, hwifName, sonicName)
+            {
+                // empty
+            }
+
+            std::string deriveHwifName() const override
+            {
+                return getHwifName();
+            }
+
+            /*
+             * The tap SAI would create for this port, which is the port name
+             * itself. Says nothing about whether it exists yet.
+             */
+            std::string deriveTapName() const override
+            {
+                return getSonicName();
+            }
+    };
+
+    class VppBondInterface:
+        public VppInterface
+    {
+        public:
+
+            VppBondInterface(
+                    _In_ uint32_t bondId):
+                VppInterface(VppInterfaceType::LAG, hwifNameFor(bondId), sonicNameFor(bondId)),
+                m_bondId(bondId),
+                m_lcpCreated(false)
+            {
+                // empty
+            }
+
+            uint32_t getBondId() const
+            {
+                return m_bondId;
+            }
+
+            bool isLcpCreated() const
+            {
+                return m_lcpCreated;
+            }
+
+            void setLcpCreated(
+                    _In_ bool created)
+            {
+                m_lcpCreated = created;
+            }
+
+            std::string deriveHwifName() const override
+            {
+                return hwifNameFor(m_bondId);
+            }
+
+            std::string deriveTapName() const override
+            {
+                return tapNameFor(m_bondId);
+            }
+
+        public:
+
+            // must match BONDETHERNET_PREFIX in SwitchVppUtils.h
+            static std::string hwifNameFor(
+                    _In_ uint32_t bondId)
+            {
+                return "BondEthernet" + std::to_string(bondId);
+            }
+
+            // must match PORTCHANNEL_PREFIX in SwitchVppUtils.h
+            static std::string sonicNameFor(
+                    _In_ uint32_t bondId)
+            {
+                return "PortChannel" + std::to_string(bondId);
+            }
+
+            /*
+             * The LCP tap for the bond. Deliberately "be<N>" and not
+             * "PortChannel<N>": the latter is the kernel bond netdev owned by
+             * teamd, not something linux-cp may bind to.
+             */
+            static std::string tapNameFor(
+                    _In_ uint32_t bondId)
+            {
+                return "be" + std::to_string(bondId);
+            }
+
+        private:
+
+            uint32_t m_bondId;
+
+            bool m_lcpCreated;
+    };
+
+    /*
+     * "<parent hwif>.<sub id>".
+     *
+     * Two call sites create sub-interfaces, and they produce differently shaped
+     * objects under the same VPP name:
+     *
+     *   tagged VLAN member  - L2 bridged, no tap, no rif oid, has bd_id
+     *   sub-port RIF        - L3, has an LCP tap and a rif oid, no bd_id
+     *
+     * The two are mutually exclusive and SONiC never overlaps them: it deletes
+     * one before creating the other. So the record carries no ownership token --
+     * which of the two a live sub-interface is, is already visible from
+     * hasBdId() versus hasRifOid().
+     *
+     * The parent is held by composition rather than inheritance: a sub-interface
+     * on a bond and one on a physical port are the same kind of thing, so
+     * deriving from VppPhysicalPort would force a VppBondSubInterface as well.
+     */
+    class VppSubInterface:
+        public VppInterface
+    {
+        public:
+
+            VppSubInterface(
+                    _In_ const std::shared_ptr<VppInterface>& parent,
+                    _In_ uint32_t subId,
+                    _In_ uint16_t vlanId):
+                VppInterface(VppInterfaceType::SUB_INTERFACE,
+                        hwifNameFor(parent ? parent->getHwifName() : std::string(), subId),
+                        sonicNameFor(parent ? parent->getSonicName() : std::string(), subId)),
+                m_parent(parent),
+                m_subId(subId),
+                m_vlanId(vlanId)
+            {
+                // empty
+            }
+
+            /*
+             * Weak, so that a sub-interface never keeps its parent alive. The
+             * registry cascades removal from parent to children, mirroring VPP,
+             * which deletes sub-interfaces when the parent goes away.
+             */
+            std::shared_ptr<VppInterface> getParent() const
+            {
+                return m_parent.lock();
+            }
+
+            uint32_t getSubId() const
+            {
+                return m_subId;
+            }
+
+            uint16_t getVlanId() const
+            {
+                return m_vlanId;
+            }
+
+            std::string deriveHwifName() const override
+            {
+                auto parent = m_parent.lock();
+
+                return hwifNameFor(parent ? parent->getHwifName() : std::string(), m_subId);
+            }
+
+            /*
+             * The LCP tap a sub-port RIF would create. It hangs off the
+             * PARENT'S TAP, not off the parent's SONiC name, so for a bond this
+             * is "be<id>.<vlan>" while getSonicName() is
+             * "PortChannel<id>.<vlan>". Empty while the parent has no tap.
+             */
+            std::string deriveTapName() const override
+            {
+                auto parent = m_parent.lock();
+
+                if (!parent || !parent->hasTapName())
+                {
+                    return std::string();
+                }
+
+                return hwifNameFor(parent->getTapName(), m_subId);
+            }
+
+        public:
+
+            static std::string hwifNameFor(
+                    _In_ const std::string& parentHwifName,
+                    _In_ uint32_t subId)
+            {
+                return parentHwifName + "." + std::to_string(subId);
+            }
+
+            static std::string sonicNameFor(
+                    _In_ const std::string& parentSonicName,
+                    _In_ uint32_t subId)
+            {
+                if (parentSonicName.empty())
+                {
+                    return std::string();
+                }
+
+                return parentSonicName + "." + std::to_string(subId);
+            }
+
+        private:
+
+            std::weak_ptr<VppInterface> m_parent;
+
+            uint32_t m_subId;
+
+            uint16_t m_vlanId;
+    };
+
+    /*
+     * BVI for a .1q VLAN. Carries no PORT oid; its rif oid is the
+     * SAI_ROUTER_INTERFACE_TYPE_VLAN object.
+     */
+    class VppVlanInterface:
+        public VppInterface
+    {
+        public:
+
+            VppVlanInterface(
+                    _In_ uint16_t vlanId):
+                VppInterface(VppInterfaceType::VLAN_BVI, hwifNameFor(vlanId), sonicNameFor(vlanId),
+                             bdIdFor(vlanId)),
+                m_vlanId(vlanId)
+            {
+                // empty
+            }
+
+            uint16_t getVlanId() const
+            {
+                return m_vlanId;
+            }
+
+            std::string deriveHwifName() const override
+            {
+                return hwifNameFor(m_vlanId);
+            }
+
+            std::string deriveTapName() const override
+            {
+                return tapNameFor(m_vlanId);
+            }
+
+        public:
+
+            static std::string hwifNameFor(
+                    _In_ uint16_t vlanId)
+            {
+                return "bvi" + std::to_string(vlanId);
+            }
+
+            static std::string sonicNameFor(
+                    _In_ uint16_t vlanId)
+            {
+                return "Vlan" + std::to_string(vlanId);
+            }
+
+            static std::string tapNameFor(
+                    _In_ uint16_t vlanId)
+            {
+                return "tap_Vlan" + std::to_string(vlanId);
+            }
+
+            /*
+             * Bridge domains 1-4095 are statically reserved for .1q VLANs by
+             * vlan id, so a BVI's bd_id needs no allocation and no lookup. The
+             * identity is asserted in several places already (see
+             * SwitchVppFdb.cpp "bd_id is same as VLAN ID for .1Q bridge"); this
+             * is the single source for it.
+             */
+            static uint32_t bdIdFor(
+                    _In_ uint16_t vlanId)
+            {
+                return vlanId;
+            }
+
+        private:
+
+            uint16_t m_vlanId;
+    };
+
+    /*
+     * No SONiC name, no tap, no port oid, and no derivable name: VPP names
+     * tunnels itself. L2 tunnels are keyed by vni, L3 encap by NEXT_HOP oid, so
+     * neither the by_oid nor the by_tap index applies here.
+     */
+    class VppTunnelInterface:
+        public VppInterface
+    {
+        public:
+
+            VppTunnelInterface(
+                    _In_ const std::string& hwifName,
+                    _In_ uint32_t vni):
+                VppInterface(VppInterfaceType::TUNNEL, hwifName, std::string()),
+                m_vni(vni)
+            {
+                // empty
+            }
+
+            uint32_t getVni() const
+            {
+                return m_vni;
+            }
+
+            std::string deriveHwifName() const override
+            {
+                return getHwifName();
+            }
+
+        private:
+
+            uint32_t m_vni;
+    };
+
+    inline const VppBondInterface* VppInterface::asBond() const
+    {
+        if (m_type != VppInterfaceType::LAG)
+            return nullptr;
+
+        return static_cast<const VppBondInterface*>(this);
+    }
+
+    inline VppBondInterface* VppInterface::asBond()
+    {
+        if (m_type != VppInterfaceType::LAG)
+            return nullptr;
+
+        return static_cast<VppBondInterface*>(this);
+    }
+
+    inline const VppSubInterface* VppInterface::asSubIf() const
+    {
+        if (m_type != VppInterfaceType::SUB_INTERFACE)
+            return nullptr;
+
+        return static_cast<const VppSubInterface*>(this);
+    }
+
+    inline const VppVlanInterface* VppInterface::asVlan() const
+    {
+        if (m_type != VppInterfaceType::VLAN_BVI)
+            return nullptr;
+
+        return static_cast<const VppVlanInterface*>(this);
+    }
+
+    inline const VppTunnelInterface* VppInterface::asTunnel() const
+    {
+        if (m_type != VppInterfaceType::TUNNEL)
+            return nullptr;
+
+        return static_cast<const VppTunnelInterface*>(this);
+    }
+}

--- a/vslib/vpp/VppInterface.h
+++ b/vslib/vpp/VppInterface.h
@@ -100,14 +100,14 @@ namespace saivs
              *
              * This is NOT evidence that a host netdev exists. See getTapName().
              */
-            const std::string& getSonicName() const
+            const std::string& getOsIf() const
             {
-                return m_sonicName;
+                return m_osIf;
             }
 
-            bool hasSonicName() const
+            bool hasOsIf() const
             {
-                return !m_sonicName.empty();
+                return !m_osIf.empty();
             }
 
             /*
@@ -119,7 +119,7 @@ namespace saivs
              * must not be seeded at registration time: doing so would make the
              * punt paths believe in a tap that does not exist.
              *
-             * Usually equal to getSonicName() but not always - a sub-port RIF on
+             * Usually equal to getOsIf() but not always - a sub-port RIF on
              * a bond deliberately uses "be<id>.<vlan>" rather than
              * "PortChannel<id>.<vlan>", which would collide with the kernel
              * 8021q netdev owned by the Linux bond stack.
@@ -135,9 +135,11 @@ namespace saivs
             }
 
             /*
-             * SAI_OBJECT_TYPE_PORT or SAI_OBJECT_TYPE_LAG only. This is what the
-             * FDB path resolves to and what SAI_BRIDGE_PORT_ATTR_PORT_ID holds.
-             * Sub-interfaces, BVIs and tunnels never have one.
+             * SAI_OBJECT_TYPE_PORT, SAI_OBJECT_TYPE_LAG or, for a BVI,
+             * SAI_OBJECT_TYPE_VLAN. The first two are what the FDB path
+             * resolves to and what SAI_BRIDGE_PORT_ATTR_PORT_ID holds; the
+             * third lets a BVI be found from the vlan oid a VLAN router
+             * interface carries. Sub-interfaces and tunnels never have one.
              */
             sai_object_id_t getOid() const
             {
@@ -232,11 +234,11 @@ namespace saivs
             VppInterface(
                     _In_ VppInterfaceType type,
                     _In_ const std::string& hwifName,
-                    _In_ const std::string& sonicName,
+                    _In_ const std::string& osIf,
                     _In_ uint32_t bdId = BD_ID_INVALID):
                 m_type(type),
                 m_hwifName(hwifName),
-                m_sonicName(sonicName),
+                m_osIf(osIf),
                 m_oid(SAI_NULL_OBJECT_ID),
                 m_rifOid(SAI_NULL_OBJECT_ID),
                 m_swIfIndex(SWIF_INDEX_INVALID),
@@ -258,7 +260,7 @@ namespace saivs
 
             std::string m_hwifName;
 
-            std::string m_sonicName;
+            std::string m_osIf;
 
             std::string m_tapName;
 
@@ -283,8 +285,8 @@ namespace saivs
 
             VppPhysicalPort(
                     _In_ const std::string& hwifName,
-                    _In_ const std::string& sonicName):
-                VppInterface(VppInterfaceType::PHYSICAL_PORT, hwifName, sonicName)
+                    _In_ const std::string& osIf):
+                VppInterface(VppInterfaceType::PHYSICAL_PORT, hwifName, osIf)
             {
                 // empty
             }
@@ -300,7 +302,7 @@ namespace saivs
              */
             std::string deriveTapName() const override
             {
-                return getSonicName();
+                return getOsIf();
             }
     };
 
@@ -311,7 +313,7 @@ namespace saivs
 
             VppBondInterface(
                     _In_ uint32_t bondId):
-                VppInterface(VppInterfaceType::LAG, hwifNameFor(bondId), sonicNameFor(bondId)),
+                VppInterface(VppInterfaceType::LAG, hwifNameFor(bondId), osIfFor(bondId)),
                 m_bondId(bondId),
                 m_lcpCreated(false)
             {
@@ -354,7 +356,7 @@ namespace saivs
             }
 
             // must match PORTCHANNEL_PREFIX in SwitchVppUtils.h
-            static std::string sonicNameFor(
+            static std::string osIfFor(
                     _In_ uint32_t bondId)
             {
                 return "PortChannel" + std::to_string(bondId);
@@ -407,7 +409,7 @@ namespace saivs
                     _In_ uint16_t vlanId):
                 VppInterface(VppInterfaceType::SUB_INTERFACE,
                         hwifNameFor(parent ? parent->getHwifName() : std::string(), subId),
-                        sonicNameFor(parent ? parent->getSonicName() : std::string(), subId)),
+                        osIfFor(parent ? parent->getOsIf() : std::string(), subId)),
                 m_parent(parent),
                 m_subId(subId),
                 m_vlanId(vlanId)
@@ -445,7 +447,7 @@ namespace saivs
             /*
              * The LCP tap a sub-port RIF would create. It hangs off the
              * PARENT'S TAP, not off the parent's SONiC name, so for a bond this
-             * is "be<id>.<vlan>" while getSonicName() is
+             * is "be<id>.<vlan>" while getOsIf() is
              * "PortChannel<id>.<vlan>". Empty while the parent has no tap.
              */
             std::string deriveTapName() const override
@@ -469,16 +471,16 @@ namespace saivs
                 return parentHwifName + "." + std::to_string(subId);
             }
 
-            static std::string sonicNameFor(
-                    _In_ const std::string& parentSonicName,
+            static std::string osIfFor(
+                    _In_ const std::string& parentOsIf,
                     _In_ uint32_t subId)
             {
-                if (parentSonicName.empty())
+                if (parentOsIf.empty())
                 {
                     return std::string();
                 }
 
-                return parentSonicName + "." + std::to_string(subId);
+                return parentOsIf + "." + std::to_string(subId);
             }
 
         private:
@@ -491,8 +493,8 @@ namespace saivs
     };
 
     /*
-     * BVI for a .1q VLAN. Carries no PORT oid; its rif oid is the
-     * SAI_ROUTER_INTERFACE_TYPE_VLAN object.
+     * BVI for a .1q VLAN. Its oid is the SAI_OBJECT_TYPE_VLAN object rather
+     * than a port, and its rif oid is the SAI_ROUTER_INTERFACE_TYPE_VLAN one.
      */
     class VppVlanInterface:
         public VppInterface
@@ -501,7 +503,7 @@ namespace saivs
 
             VppVlanInterface(
                     _In_ uint16_t vlanId):
-                VppInterface(VppInterfaceType::VLAN_BVI, hwifNameFor(vlanId), sonicNameFor(vlanId),
+                VppInterface(VppInterfaceType::VLAN_BVI, hwifNameFor(vlanId), osIfFor(vlanId),
                              bdIdFor(vlanId)),
                 m_vlanId(vlanId)
             {
@@ -531,7 +533,7 @@ namespace saivs
                 return "bvi" + std::to_string(vlanId);
             }
 
-            static std::string sonicNameFor(
+            static std::string osIfFor(
                     _In_ uint16_t vlanId)
             {
                 return "Vlan" + std::to_string(vlanId);

--- a/vslib/vpp/VppInterface.h
+++ b/vslib/vpp/VppInterface.h
@@ -37,6 +37,31 @@ namespace saivs
         VLAN_BVI,           // bvi<N>
     };
 
+    /*
+     * Interface identity model used by VppInterfaceRegistry.
+     *
+     * Base attributes on every record:
+     *   - hwif name   (always present, primary key)
+     *   - osif name   (SONiC side name)
+     *   - tap name    (optional, present only while host netdev exists)
+     *   - oid         (optional; PORT/LAG/VLAN identity)
+     *   - rif oid     (optional router interface oid)
+     *   - sw_if_index (optional VPP runtime index)
+     *   - bd_id       (optional bridge domain id)
+     *
+     * Subclasses:
+     *   - VppPhysicalPort: front panel port identity seeded from ifmap.
+     *   - VppBondInterface: LAG identity with bond id and lcp-created state.
+     *   - VppSubInterface: parent-linked <parent>.<subId> interface identity.
+     *   - VppVlanInterface: VLAN BVI identity (bvi<VLAN>, Vlan<VLAN>).
+     *
+     * Lookup coverage by subclass (through registry indexes):
+     *   - Physical/LAG/BVI: hwif + osif + optional tap + optional oid +
+     *                       optional sw_if_index.
+     *   - Sub-interface:    hwif + osif + optional tap + optional sw_if_index,
+     *                       and findSubIf(parentHwif, subId).
+     */
+
     class VppInterface
     {
         public:

--- a/vslib/vpp/VppInterfaceRegistry.cpp
+++ b/vslib/vpp/VppInterfaceRegistry.cpp
@@ -2,18 +2,131 @@
 
 #include "swss/logger.h"
 
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+
 using namespace saivs;
+
+// TODO to config
+static const char *sonic_vpp_ifmap = "/usr/share/sonic/hwsku/sonic_vpp_ifmap.ini";
+
+/*
+ * Split a trailing ".<vlan>" sub-interface suffix off an interface name.
+ * Returns false if there is a '.' that is not followed by digits only, which
+ * means the name is not something this switch ever creates.
+ */
+static bool split_subif_suffix(
+        _In_ const std::string& name,
+        _Out_ std::string& base,
+        _Out_ std::string& suffix)
+{
+    auto dot = name.find('.');
+
+    if (dot == std::string::npos)
+    {
+        base = name;
+        suffix.clear();
+
+        return true;
+    }
+
+    base = name.substr(0, dot);
+    suffix = name.substr(dot);
+
+    if (suffix.size() < 2)
+    {
+        return false;
+    }
+
+    for (size_t i = 1; i < suffix.size(); i++)
+    {
+        if (!isdigit(static_cast<unsigned char>(suffix[i])))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/*
+ * Derive the VPP hardware interface name of a logical interface. These are
+ * hard invariants of the way this switch creates VPP interfaces:
+ *
+ *   PortChannel<N> -> BondEthernet<N>   vpp_create_lag(); find_new_bond_id()
+ *                                       takes the bond id straight from the
+ *                                       PortChannel kernel netdev name
+ *   Vlan<N>        -> bvi<N>            vpp_create_bvi_interface()
+ *
+ * Only SONiC-side names are accepted. The bond's linux-cp tap name be<N> is
+ * deliberately not resolved here: it is a VPP-side artefact, and accepting it
+ * would let a caller that wants the SONiC netdev (`ip link show`, VRF
+ * enslavement) silently get away with the wrong name.
+ *
+ * Physical ports are not handled here: their hwif name is platform specific
+ * and only sonic_vpp_ifmap.ini knows it.
+ *
+ * The id is carried across as a string rather than parsed, so this cannot
+ * disagree with the VppInterface name rules over what a large or leading-zero
+ * id turns into.
+ */
+static bool derive_logical_hwif(
+        _In_ const std::string& base,
+        _Out_ std::string& hwif)
+{
+    SWSS_LOG_ENTER();
+
+    // prefixes must match PORTCHANNEL_PREFIX / VLAN_PREFIX in SwitchVppUtils.h,
+    // results must match VppBondInterface / VppVlanInterface hwifNameFor()
+    const char *prefix;
+    const char *hwif_prefix;
+
+    if (base.compare(0, 11, "PortChannel") == 0)
+    {
+        prefix = "PortChannel";
+        hwif_prefix = "BondEthernet";
+    }
+    else if (base.compare(0, 4, "Vlan") == 0)
+    {
+        prefix = "Vlan";
+        hwif_prefix = "bvi";
+    }
+    else
+    {
+        return false;
+    }
+
+    std::string id = base.substr(strlen(prefix));
+
+    if (id.empty())
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < id.size(); i++)
+    {
+        if (!isdigit(static_cast<unsigned char>(id[i])))
+        {
+            return false;
+        }
+    }
+
+    hwif = std::string(hwif_prefix) + id;
+
+    return true;
+}
 
 std::shared_ptr<VppPhysicalPort> VppInterfaceRegistry::addPhysicalPort(
         _In_ const std::string& hwifName,
-        _In_ const std::string& sonicName,
+        _In_ const std::string& osIf,
         _In_ sai_object_id_t oid)
 {
     SWSS_LOG_ENTER();
 
     if (oid == SAI_NULL_OBJECT_ID)
     {
-        SWSS_LOG_ERROR("refusing to register port %s with a null oid", sonicName.c_str());
+        SWSS_LOG_ERROR("refusing to register port %s with a null oid", osIf.c_str());
 
         return nullptr;
     }
@@ -28,14 +141,14 @@ std::shared_ptr<VppPhysicalPort> VppInterfaceRegistry::addPhysicalPort(
         return nullptr;
     }
 
-    auto rec = std::make_shared<VppPhysicalPort>(hwifName, sonicName);
+    auto rec = std::make_shared<VppPhysicalPort>(hwifName, osIf);
 
     indexRecord(rec);
 
     setOid(hwifName, oid);
 
     SWSS_LOG_INFO("registered physical port %s as hwif %s oid 0x%llx",
-            sonicName.c_str(), hwifName.c_str(), static_cast<unsigned long long>(oid));
+            osIf.c_str(), hwifName.c_str(), static_cast<unsigned long long>(oid));
 
     return rec;
 }
@@ -135,7 +248,8 @@ std::shared_ptr<VppSubInterface> VppInterfaceRegistry::addSubInterface(
 }
 
 std::shared_ptr<VppVlanInterface> VppInterfaceRegistry::addBvi(
-        _In_ uint16_t vlanId)
+        _In_ uint16_t vlanId,
+        _In_ sai_object_id_t vlanOid)
 {
     SWSS_LOG_ENTER();
 
@@ -148,11 +262,21 @@ std::shared_ptr<VppVlanInterface> VppInterfaceRegistry::addBvi(
         return nullptr;
     }
 
+    if (vlanOid == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("refusing to register BVI %s with a null vlan oid", hwifName.c_str());
+
+        return nullptr;
+    }
+
     auto rec = std::make_shared<VppVlanInterface>(vlanId);
 
     indexRecord(rec);
 
-    SWSS_LOG_INFO("registered BVI %s", hwifName.c_str());
+    setOid(hwifName, vlanOid);
+
+    SWSS_LOG_INFO("registered BVI %s oid 0x%llx",
+            hwifName.c_str(), static_cast<unsigned long long>(vlanOid));
 
     return rec;
 }
@@ -341,13 +465,16 @@ bool VppInterfaceRegistry::setOid(
     }
 
     /*
-     * by_oid is deliberately partial. Only a PORT or a LAG has the kind of oid
-     * the FDB path resolves to; admitting ROUTER_INTERFACE or NEXT_HOP oids
-     * here would destroy that contract.
+     * by_oid is deliberately partial. It admits the three object kinds that
+     * name a forwarding interface -- PORT, LAG and the VLAN behind a BVI --
+     * and nothing else; admitting ROUTER_INTERFACE or NEXT_HOP oids here would
+     * destroy that contract.
      */
-    if (rec->getType() != VppInterfaceType::PHYSICAL_PORT && rec->getType() != VppInterfaceType::LAG)
+    if (rec->getType() != VppInterfaceType::PHYSICAL_PORT &&
+            rec->getType() != VppInterfaceType::LAG &&
+            rec->getType() != VppInterfaceType::VLAN_BVI)
     {
-        SWSS_LOG_ERROR("refusing to set port oid on %s of type %d; use setRifOid()",
+        SWSS_LOG_ERROR("refusing to set oid on %s of type %d; use setRifOid()",
                 hwifName.c_str(), static_cast<int>(rec->getType()));
 
         return false;
@@ -482,12 +609,12 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByHwif(
     return it == m_byHwif.end() ? nullptr : it->second;
 }
 
-std::shared_ptr<VppInterface> VppInterfaceRegistry::findBySonicName(
-        _In_ const std::string& sonicName) const
+std::shared_ptr<VppInterface> VppInterfaceRegistry::findByOsIf(
+        _In_ const std::string& osIf) const
 {
-    auto it = m_bySonicName.find(sonicName);
+    auto it = m_byOsIf.find(osIf);
 
-    return it == m_bySonicName.end() ? nullptr : it->second;
+    return it == m_byOsIf.end() ? nullptr : it->second;
 }
 
 std::shared_ptr<VppInterface> VppInterfaceRegistry::findByTap(
@@ -532,7 +659,7 @@ std::shared_ptr<VppSubInterface> VppInterfaceRegistry::findSubIf(
     return std::dynamic_pointer_cast<VppSubInterface>(rec);
 }
 
-sai_object_id_t VppInterfaceRegistry::resolvePortOid(
+sai_object_id_t VppInterfaceRegistry::resolveIfOid(
         _In_ uint32_t swIfIndex) const
 {
     SWSS_LOG_ENTER();
@@ -562,10 +689,194 @@ sai_object_id_t VppInterfaceRegistry::resolvePortOid(
             return SAI_NULL_OBJECT_ID;
         }
 
-        return parent->getOid();
+        rec = parent;
     }
 
     return rec->getOid();
+}
+
+std::string VppInterfaceRegistry::resolveTapName(
+        _In_ sai_object_id_t oid) const
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByOid(oid);
+
+    if (rec && rec->hasTapName())
+    {
+        return rec->getTapName();
+    }
+
+    return std::string();
+}
+
+std::string VppInterfaceRegistry::resolveOsIf(
+        _In_ sai_object_id_t oid) const
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByOid(oid);
+
+    if (rec && rec->hasOsIf())
+    {
+        return rec->getOsIf();
+    }
+
+    return std::string();
+}
+
+std::string VppInterfaceRegistry::resolveOsIfByHwif(
+        _In_ const std::string& hwifName) const
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (rec && rec->hasOsIf())
+    {
+        return rec->getOsIf();
+    }
+
+    return std::string();
+}
+
+std::string VppInterfaceRegistry::resolveHwIfName(
+        _In_ sai_object_id_t oid,
+        _In_ uint32_t vlanId) const
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByOid(oid);
+
+    if (!rec)
+    {
+        return std::string();
+    }
+
+    if (vlanId)
+    {
+        return rec->getHwifName() + "." + std::to_string(vlanId);
+    }
+
+    return rec->getHwifName();
+}
+
+/*
+ * sonic_vpp_ifmap.ini maps the host OS interface name ("osif") to the VPP
+ * hardware interface name, e.g. "Ethernet0" -> "TenGigabitEthernet0/0/0". The
+ * osif name is whatever the NOS above SAI calls the port -- under SONiC it is
+ * the port_config.ini name, but nothing here depends on that.
+ * Only physical ports appear in the file -- every logical interface is derived
+ * by rule in derive_logical_hwif() above.
+ *
+ * Note that for a physical port the osif name, the LCP tap name and the SAI
+ * hostif name are all the same string, which is why this map has historically
+ * been described as a "tap" map. It is not: for a bond the osif name is
+ * "PortChannel<N>" while the tap is "be<N>", and the two must not be confused.
+ */
+void VppInterfaceRegistry::loadIfMapping() const
+{
+    SWSS_LOG_ENTER();
+
+    if (m_ifMapLoaded)
+    {
+        return;
+    }
+
+    FILE *fp = fopen(sonic_vpp_ifmap, "r");
+
+    if (!fp)
+    {
+        return;
+    }
+
+    char osif_name[64], vpp_name[64];
+
+    while (fscanf(fp, "%63s %63s", osif_name, vpp_name) != EOF)
+    {
+        m_osIfToHwIf[std::string(osif_name)] = std::string(vpp_name);
+    }
+
+    m_ifMapLoaded = true;
+
+    fclose(fp);
+}
+
+std::string VppInterfaceRegistry::resolveHwIfByOsIf(
+        _In_ const std::string& osIfName) const
+{
+    SWSS_LOG_ENTER();
+
+    loadIfMapping();
+
+    auto it = m_osIfToHwIf.find(osIfName);
+
+    if (it != m_osIfToHwIf.end())
+    {
+        return it->second;
+    }
+
+    std::string base, suffix;
+
+    if (split_subif_suffix(osIfName, base, suffix))
+    {
+        /*
+         * A sub-interface carries the ".<vlan>" suffix over unchanged, so
+         * "Ethernet0.100" -> "TenGigabitEthernet0/0/0.100" and
+         * "PortChannel1.100" -> "BondEthernet1.100".
+         */
+        auto baseIt = m_osIfToHwIf.find(base);
+
+        if (baseIt != m_osIfToHwIf.end())
+        {
+            return baseIt->second + suffix;
+        }
+
+        std::string derived;
+
+        if (derive_logical_hwif(base, derived))
+        {
+            return derived + suffix;
+        }
+    }
+
+    SWSS_LOG_ERROR("failed to find hwif info entry for interface: %s", osIfName.c_str());
+
+    return std::string();
+}
+
+std::shared_ptr<VppInterface> VppInterfaceRegistry::findLag(
+        _In_ sai_object_id_t oid) const
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByOid(oid);
+
+    if (rec && rec->getType() == VppInterfaceType::LAG && rec->hasSwIfIndex())
+    {
+        return rec;
+    }
+
+    return nullptr;
+}
+
+std::unordered_set<uint32_t> VppInterfaceRegistry::collectBondIds() const
+{
+    SWSS_LOG_ENTER();
+
+    std::unordered_set<uint32_t> ids;
+
+    for (const auto& kvp: m_byHwif)
+    {
+        const VppBondInterface *bond = kvp.second->asBond();
+
+        if (bond)
+        {
+            ids.insert(bond->getBondId());
+        }
+    }
+
+    return ids;
 }
 
 void VppInterfaceRegistry::clear()
@@ -575,7 +886,7 @@ void VppInterfaceRegistry::clear()
     m_bySwIfIndex.clear();
     m_byOid.clear();
     m_byTap.clear();
-    m_bySonicName.clear();
+    m_byOsIf.clear();
     m_byHwif.clear();
 }
 
@@ -584,9 +895,9 @@ void VppInterfaceRegistry::indexRecord(
 {
     m_byHwif[rec->getHwifName()] = rec;
 
-    if (rec->hasSonicName())
+    if (rec->hasOsIf())
     {
-        m_bySonicName[rec->getSonicName()] = rec;
+        m_byOsIf[rec->getOsIf()] = rec;
     }
 
     if (rec->hasTapName())
@@ -623,9 +934,9 @@ void VppInterfaceRegistry::unindexRecord(
         m_byTap.erase(rec->getTapName());
     }
 
-    if (rec->hasSonicName())
+    if (rec->hasOsIf())
     {
-        m_bySonicName.erase(rec->getSonicName());
+        m_byOsIf.erase(rec->getOsIf());
     }
 
     m_byHwif.erase(rec->getHwifName());

--- a/vslib/vpp/VppInterfaceRegistry.cpp
+++ b/vslib/vpp/VppInterfaceRegistry.cpp
@@ -125,6 +125,7 @@ std::shared_ptr<VppPhysicalPort> VppInterfaceRegistry::addPhysicalPort(
         _In_ sai_object_id_t oid)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     if (oid == SAI_NULL_OBJECT_ID)
     {
@@ -161,6 +162,7 @@ std::shared_ptr<VppBondInterface> VppInterfaceRegistry::addLag(
         _In_ sai_object_id_t oid)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto hwifName = VppBondInterface::hwifNameFor(bondId);
 
@@ -202,6 +204,7 @@ std::shared_ptr<VppSubInterface> VppInterfaceRegistry::addSubInterface(
         _In_ uint16_t vlanId)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     if (!parent)
     {
@@ -254,6 +257,7 @@ std::shared_ptr<VppVlanInterface> VppInterfaceRegistry::addBvi(
         _In_ sai_object_id_t vlanOid)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto hwifName = VppVlanInterface::hwifNameFor(vlanId);
 
@@ -288,6 +292,7 @@ bool VppInterfaceRegistry::bindSwIfIndex(
         _In_ uint32_t swIfIndex)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -340,6 +345,7 @@ bool VppInterfaceRegistry::unbindSwIfIndex(
         _In_ const std::string& hwifName)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -360,6 +366,7 @@ bool VppInterfaceRegistry::setTapName(
         _In_ const std::string& tapName)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -412,6 +419,7 @@ bool VppInterfaceRegistry::clearTapName(
         _In_ const std::string& hwifName)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -434,6 +442,7 @@ bool VppInterfaceRegistry::setOid(
         _In_ sai_object_id_t oid)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -480,6 +489,7 @@ bool VppInterfaceRegistry::setRifOid(
         _In_ sai_object_id_t rifOid)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -501,6 +511,7 @@ bool VppInterfaceRegistry::setBdId(
         _In_ uint32_t bdId)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -520,6 +531,7 @@ bool VppInterfaceRegistry::clearBdId(
         _In_ const std::string& hwifName)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -537,6 +549,7 @@ size_t VppInterfaceRegistry::remove(
         _In_ const std::string& hwifName)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -570,6 +583,7 @@ size_t VppInterfaceRegistry::removeByOid(
         _In_ sai_object_id_t oid)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto it = m_byOid.find(oid);
 
@@ -585,6 +599,7 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByHwif(
         _In_ const std::string& hwifName) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto it = m_byHwif.find(hwifName);
 
@@ -595,6 +610,7 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByOsIf(
         _In_ const std::string& osIf) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto it = m_byOsIf.find(osIf);
 
@@ -605,6 +621,7 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByTap(
         _In_ const std::string& tapName) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto it = m_byTap.find(tapName);
 
@@ -615,6 +632,7 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByOid(
         _In_ sai_object_id_t oid) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto it = m_byOid.find(oid);
 
@@ -625,6 +643,7 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findBySwIfIndex(
         _In_ uint32_t swIfIndex) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto it = m_bySwIfIndex.find(swIfIndex);
 
@@ -636,6 +655,7 @@ std::shared_ptr<VppSubInterface> VppInterfaceRegistry::findSubIf(
         _In_ uint32_t subId) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     /*
      * A sub-interface is named after its parent, so the primary index already
@@ -655,6 +675,7 @@ sai_object_id_t VppInterfaceRegistry::resolveIfOid(
         _In_ uint32_t swIfIndex) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findBySwIfIndex(swIfIndex);
 
@@ -691,6 +712,7 @@ std::string VppInterfaceRegistry::resolveTapName(
         _In_ sai_object_id_t oid) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByOid(oid);
 
@@ -706,6 +728,7 @@ std::string VppInterfaceRegistry::resolveOsIf(
         _In_ sai_object_id_t oid) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByOid(oid);
 
@@ -721,6 +744,7 @@ std::string VppInterfaceRegistry::resolveOsIfByHwif(
         _In_ const std::string& hwifName) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByHwif(hwifName);
 
@@ -737,6 +761,7 @@ std::string VppInterfaceRegistry::resolveHwIfName(
         _In_ uint32_t vlanId) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByOid(oid);
 
@@ -769,6 +794,7 @@ std::string VppInterfaceRegistry::resolveHwIfName(
 void VppInterfaceRegistry::loadIfMapping() const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     if (m_ifMapLoaded)
     {
@@ -798,6 +824,7 @@ std::string VppInterfaceRegistry::resolveHwIfByOsIf(
         _In_ const std::string& osIfName) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     loadIfMapping();
 
@@ -837,10 +864,32 @@ std::string VppInterfaceRegistry::resolveHwIfByOsIf(
     return std::string();
 }
 
+sai_object_id_t VppInterfaceRegistry::resolvePhysicalPortOid(
+        _In_ const std::string& hwifName) const
+{
+    SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+    /*
+     * The type test and the oid read are deliberately done here rather than by
+     * the caller: this is reached from the VPP event thread, which must not
+     * dereference a record once the lock is gone.
+     */
+    auto rec = findByHwif(hwifName);
+
+    if (!rec || rec->getType() != VppInterfaceType::PHYSICAL_PORT)
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    return rec->getOid();
+}
+
 std::shared_ptr<VppInterface> VppInterfaceRegistry::findLag(
         _In_ sai_object_id_t oid) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     auto rec = findByOid(oid);
 
@@ -855,6 +904,7 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findLag(
 std::unordered_set<uint32_t> VppInterfaceRegistry::collectBondIds() const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     std::unordered_set<uint32_t> ids;
 
@@ -874,6 +924,7 @@ std::unordered_set<uint32_t> VppInterfaceRegistry::collectBondIds() const
 void VppInterfaceRegistry::clear()
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     m_bySwIfIndex.clear();
     m_byOid.clear();
@@ -886,6 +937,7 @@ void VppInterfaceRegistry::indexRecord(
         _In_ const std::shared_ptr<VppInterface>& rec)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     m_byHwif[rec->getHwifName()] = rec;
 
@@ -914,6 +966,7 @@ void VppInterfaceRegistry::unindexRecord(
         _In_ const std::shared_ptr<VppInterface>& rec)
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     if (rec->hasSwIfIndex())
     {
@@ -942,6 +995,7 @@ std::vector<std::string> VppInterfaceRegistry::collectChildren(
         _In_ const std::shared_ptr<VppInterface>& parent) const
 {
     SWSS_LOG_ENTER();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     std::vector<std::string> children;
 

--- a/vslib/vpp/VppInterfaceRegistry.cpp
+++ b/vslib/vpp/VppInterfaceRegistry.cpp
@@ -21,6 +21,8 @@ static bool split_subif_suffix(
         _Out_ std::string& base,
         _Out_ std::string& suffix)
 {
+    SWSS_LOG_ENTER();
+
     auto dot = name.find('.');
 
     if (dot == std::string::npos)
@@ -277,28 +279,6 @@ std::shared_ptr<VppVlanInterface> VppInterfaceRegistry::addBvi(
 
     SWSS_LOG_INFO("registered BVI %s oid 0x%llx",
             hwifName.c_str(), static_cast<unsigned long long>(vlanOid));
-
-    return rec;
-}
-
-std::shared_ptr<VppTunnelInterface> VppInterfaceRegistry::addTunnel(
-        _In_ const std::string& hwifName,
-        _In_ uint32_t vni)
-{
-    SWSS_LOG_ENTER();
-
-    if (findByHwif(hwifName))
-    {
-        SWSS_LOG_WARN("interface %s already registered, not adding tunnel", hwifName.c_str());
-
-        return nullptr;
-    }
-
-    auto rec = std::make_shared<VppTunnelInterface>(hwifName, vni);
-
-    indexRecord(rec);
-
-    SWSS_LOG_INFO("registered tunnel %s vni %u", hwifName.c_str(), vni);
 
     return rec;
 }
@@ -604,6 +584,8 @@ size_t VppInterfaceRegistry::removeByOid(
 std::shared_ptr<VppInterface> VppInterfaceRegistry::findByHwif(
         _In_ const std::string& hwifName) const
 {
+    SWSS_LOG_ENTER();
+
     auto it = m_byHwif.find(hwifName);
 
     return it == m_byHwif.end() ? nullptr : it->second;
@@ -612,6 +594,8 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByHwif(
 std::shared_ptr<VppInterface> VppInterfaceRegistry::findByOsIf(
         _In_ const std::string& osIf) const
 {
+    SWSS_LOG_ENTER();
+
     auto it = m_byOsIf.find(osIf);
 
     return it == m_byOsIf.end() ? nullptr : it->second;
@@ -620,6 +604,8 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByOsIf(
 std::shared_ptr<VppInterface> VppInterfaceRegistry::findByTap(
         _In_ const std::string& tapName) const
 {
+    SWSS_LOG_ENTER();
+
     auto it = m_byTap.find(tapName);
 
     return it == m_byTap.end() ? nullptr : it->second;
@@ -628,6 +614,8 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByTap(
 std::shared_ptr<VppInterface> VppInterfaceRegistry::findByOid(
         _In_ sai_object_id_t oid) const
 {
+    SWSS_LOG_ENTER();
+
     auto it = m_byOid.find(oid);
 
     return it == m_byOid.end() ? nullptr : it->second;
@@ -636,6 +624,8 @@ std::shared_ptr<VppInterface> VppInterfaceRegistry::findByOid(
 std::shared_ptr<VppInterface> VppInterfaceRegistry::findBySwIfIndex(
         _In_ uint32_t swIfIndex) const
 {
+    SWSS_LOG_ENTER();
+
     auto it = m_bySwIfIndex.find(swIfIndex);
 
     return it == m_bySwIfIndex.end() ? nullptr : it->second;
@@ -645,6 +635,8 @@ std::shared_ptr<VppSubInterface> VppInterfaceRegistry::findSubIf(
         _In_ const std::string& parentHwifName,
         _In_ uint32_t subId) const
 {
+    SWSS_LOG_ENTER();
+
     /*
      * A sub-interface is named after its parent, so the primary index already
      * answers this; no separate (parent, vlan) index has to be kept in sync.
@@ -893,6 +885,8 @@ void VppInterfaceRegistry::clear()
 void VppInterfaceRegistry::indexRecord(
         _In_ const std::shared_ptr<VppInterface>& rec)
 {
+    SWSS_LOG_ENTER();
+
     m_byHwif[rec->getHwifName()] = rec;
 
     if (rec->hasOsIf())
@@ -919,6 +913,8 @@ void VppInterfaceRegistry::indexRecord(
 void VppInterfaceRegistry::unindexRecord(
         _In_ const std::shared_ptr<VppInterface>& rec)
 {
+    SWSS_LOG_ENTER();
+
     if (rec->hasSwIfIndex())
     {
         m_bySwIfIndex.erase(rec->getSwIfIndex());
@@ -945,6 +941,8 @@ void VppInterfaceRegistry::unindexRecord(
 std::vector<std::string> VppInterfaceRegistry::collectChildren(
         _In_ const std::shared_ptr<VppInterface>& parent) const
 {
+    SWSS_LOG_ENTER();
+
     std::vector<std::string> children;
 
     /*

--- a/vslib/vpp/VppInterfaceRegistry.cpp
+++ b/vslib/vpp/VppInterfaceRegistry.cpp
@@ -1,0 +1,655 @@
+#include "VppInterfaceRegistry.h"
+
+#include "swss/logger.h"
+
+using namespace saivs;
+
+std::shared_ptr<VppPhysicalPort> VppInterfaceRegistry::addPhysicalPort(
+        _In_ const std::string& hwifName,
+        _In_ const std::string& sonicName,
+        _In_ sai_object_id_t oid)
+{
+    SWSS_LOG_ENTER();
+
+    if (oid == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("refusing to register port %s with a null oid", sonicName.c_str());
+
+        return nullptr;
+    }
+
+    auto existing = findByHwif(hwifName);
+
+    if (existing)
+    {
+        SWSS_LOG_WARN("interface %s already registered as type %d, not adding physical port",
+                hwifName.c_str(), static_cast<int>(existing->getType()));
+
+        return nullptr;
+    }
+
+    auto rec = std::make_shared<VppPhysicalPort>(hwifName, sonicName);
+
+    indexRecord(rec);
+
+    setOid(hwifName, oid);
+
+    SWSS_LOG_INFO("registered physical port %s as hwif %s oid 0x%llx",
+            sonicName.c_str(), hwifName.c_str(), static_cast<unsigned long long>(oid));
+
+    return rec;
+}
+
+std::shared_ptr<VppBondInterface> VppInterfaceRegistry::addLag(
+        _In_ uint32_t bondId,
+        _In_ uint32_t swIfIndex,
+        _In_ sai_object_id_t oid)
+{
+    SWSS_LOG_ENTER();
+
+    auto hwifName = VppBondInterface::hwifNameFor(bondId);
+
+    auto existing = findByHwif(hwifName);
+
+    if (existing)
+    {
+        SWSS_LOG_WARN("interface %s already registered, not adding LAG", hwifName.c_str());
+
+        return nullptr;
+    }
+
+    if (oid == SAI_NULL_OBJECT_ID || swIfIndex == VppInterface::SWIF_INDEX_INVALID)
+    {
+        SWSS_LOG_ERROR("refusing to register LAG %s with oid 0x%llx / sw_if_index %u: both are known"
+                " at bond creation and must be supplied",
+                hwifName.c_str(), static_cast<unsigned long long>(oid), swIfIndex);
+
+        return nullptr;
+    }
+
+    auto rec = std::make_shared<VppBondInterface>(bondId);
+
+    indexRecord(rec);
+
+    bindSwIfIndex(hwifName, swIfIndex);
+
+    setOid(hwifName, oid);
+
+    SWSS_LOG_INFO("registered LAG %s sw_if_index %u oid 0x%llx",
+            hwifName.c_str(), swIfIndex, static_cast<unsigned long long>(oid));
+
+    return rec;
+}
+
+std::shared_ptr<VppSubInterface> VppInterfaceRegistry::addSubInterface(
+        _In_ const std::shared_ptr<VppInterface>& parent,
+        _In_ uint32_t subId,
+        _In_ uint16_t vlanId)
+{
+    SWSS_LOG_ENTER();
+
+    if (!parent)
+    {
+        SWSS_LOG_ERROR("cannot add sub-interface .%u with no parent", subId);
+
+        return nullptr;
+    }
+
+    if (!findByHwif(parent->getHwifName()))
+    {
+        SWSS_LOG_ERROR("parent %s of sub-interface .%u is not registered",
+                parent->getHwifName().c_str(), subId);
+
+        return nullptr;
+    }
+
+    auto hwifName = VppSubInterface::hwifNameFor(parent->getHwifName(), subId);
+
+    auto existing = findByHwif(hwifName);
+
+    if (existing)
+    {
+        auto sub = std::dynamic_pointer_cast<VppSubInterface>(existing);
+
+        if (!sub)
+        {
+            SWSS_LOG_ERROR("interface %s already registered as type %d, not a sub-interface",
+                    hwifName.c_str(), static_cast<int>(existing->getType()));
+
+            return nullptr;
+        }
+
+        SWSS_LOG_INFO("sub-interface %s already registered", hwifName.c_str());
+
+        return sub;
+    }
+
+    auto rec = std::make_shared<VppSubInterface>(parent, subId, vlanId);
+
+    indexRecord(rec);
+
+    SWSS_LOG_INFO("registered sub-interface %s vlan %u",
+            hwifName.c_str(), static_cast<unsigned int>(vlanId));
+
+    return rec;
+}
+
+std::shared_ptr<VppVlanInterface> VppInterfaceRegistry::addBvi(
+        _In_ uint16_t vlanId)
+{
+    SWSS_LOG_ENTER();
+
+    auto hwifName = VppVlanInterface::hwifNameFor(vlanId);
+
+    if (findByHwif(hwifName))
+    {
+        SWSS_LOG_WARN("interface %s already registered, not adding BVI", hwifName.c_str());
+
+        return nullptr;
+    }
+
+    auto rec = std::make_shared<VppVlanInterface>(vlanId);
+
+    indexRecord(rec);
+
+    SWSS_LOG_INFO("registered BVI %s", hwifName.c_str());
+
+    return rec;
+}
+
+std::shared_ptr<VppTunnelInterface> VppInterfaceRegistry::addTunnel(
+        _In_ const std::string& hwifName,
+        _In_ uint32_t vni)
+{
+    SWSS_LOG_ENTER();
+
+    if (findByHwif(hwifName))
+    {
+        SWSS_LOG_WARN("interface %s already registered, not adding tunnel", hwifName.c_str());
+
+        return nullptr;
+    }
+
+    auto rec = std::make_shared<VppTunnelInterface>(hwifName, vni);
+
+    indexRecord(rec);
+
+    SWSS_LOG_INFO("registered tunnel %s vni %u", hwifName.c_str(), vni);
+
+    return rec;
+}
+
+bool VppInterfaceRegistry::bindSwIfIndex(
+        _In_ const std::string& hwifName,
+        _In_ uint32_t swIfIndex)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec)
+    {
+        SWSS_LOG_ERROR("cannot bind sw_if_index %u: %s is not registered", swIfIndex, hwifName.c_str());
+
+        return false;
+    }
+
+    if (swIfIndex == VppInterface::SWIF_INDEX_INVALID)
+    {
+        SWSS_LOG_ERROR("refusing to bind invalid sw_if_index to %s", hwifName.c_str());
+
+        return false;
+    }
+
+    /*
+     * VPP reuses sw_if_index values once an interface is deleted. If a stale
+     * record still claims this index, drop its binding now; leaving it would
+     * mis-attribute every subsequent FDB event to the dead interface.
+     */
+    auto it = m_bySwIfIndex.find(swIfIndex);
+
+    if (it != m_bySwIfIndex.end() && it->second != rec)
+    {
+        SWSS_LOG_WARN("sw_if_index %u was still bound to %s, rebinding to %s",
+                swIfIndex, it->second->getHwifName().c_str(), hwifName.c_str());
+
+        it->second->m_swIfIndex = VppInterface::SWIF_INDEX_INVALID;
+
+        m_bySwIfIndex.erase(it);
+    }
+
+    if (rec->hasSwIfIndex() && rec->getSwIfIndex() != swIfIndex)
+    {
+        m_bySwIfIndex.erase(rec->getSwIfIndex());
+    }
+
+    rec->m_swIfIndex = swIfIndex;
+
+    m_bySwIfIndex[swIfIndex] = rec;
+
+    SWSS_LOG_INFO("bound %s to sw_if_index %u", hwifName.c_str(), swIfIndex);
+
+    return true;
+}
+
+bool VppInterfaceRegistry::unbindSwIfIndex(
+        _In_ const std::string& hwifName)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec || !rec->hasSwIfIndex())
+    {
+        return false;
+    }
+
+    m_bySwIfIndex.erase(rec->getSwIfIndex());
+
+    rec->m_swIfIndex = VppInterface::SWIF_INDEX_INVALID;
+
+    return true;
+}
+
+bool VppInterfaceRegistry::setTapName(
+        _In_ const std::string& hwifName,
+        _In_ const std::string& tapName)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec)
+    {
+        SWSS_LOG_ERROR("cannot set tap %s: %s is not registered", tapName.c_str(), hwifName.c_str());
+
+        return false;
+    }
+
+    if (tapName.empty())
+    {
+        SWSS_LOG_ERROR("refusing to set an empty tap name on %s; use clearTapName()", hwifName.c_str());
+
+        return false;
+    }
+
+    auto it = m_byTap.find(tapName);
+
+    if (it != m_byTap.end() && it->second != rec)
+    {
+        /*
+         * Host netdev names are recycled too: a port removed and re-added gets
+         * the same name back. Detach the stale holder rather than letting two
+         * records claim one netdev.
+         */
+        SWSS_LOG_WARN("tap %s was still held by %s, reassigning to %s",
+                tapName.c_str(), it->second->getHwifName().c_str(), hwifName.c_str());
+
+        it->second->m_tapName.clear();
+
+        m_byTap.erase(it);
+    }
+
+    if (rec->hasTapName() && rec->getTapName() != tapName)
+    {
+        m_byTap.erase(rec->getTapName());
+    }
+
+    rec->m_tapName = tapName;
+
+    m_byTap[tapName] = rec;
+
+    SWSS_LOG_INFO("interface %s now has host tap %s", hwifName.c_str(), tapName.c_str());
+
+    return true;
+}
+
+bool VppInterfaceRegistry::clearTapName(
+        _In_ const std::string& hwifName)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec || !rec->hasTapName())
+    {
+        return false;
+    }
+
+    SWSS_LOG_INFO("interface %s lost host tap %s", hwifName.c_str(), rec->getTapName().c_str());
+
+    m_byTap.erase(rec->getTapName());
+
+    rec->m_tapName.clear();
+
+    return true;
+}
+
+bool VppInterfaceRegistry::setOid(
+        _In_ const std::string& hwifName,
+        _In_ sai_object_id_t oid)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec)
+    {
+        SWSS_LOG_ERROR("cannot set oid on %s: not registered", hwifName.c_str());
+
+        return false;
+    }
+
+    /*
+     * by_oid is deliberately partial. Only a PORT or a LAG has the kind of oid
+     * the FDB path resolves to; admitting ROUTER_INTERFACE or NEXT_HOP oids
+     * here would destroy that contract.
+     */
+    if (rec->getType() != VppInterfaceType::PHYSICAL_PORT && rec->getType() != VppInterfaceType::LAG)
+    {
+        SWSS_LOG_ERROR("refusing to set port oid on %s of type %d; use setRifOid()",
+                hwifName.c_str(), static_cast<int>(rec->getType()));
+
+        return false;
+    }
+
+    if (rec->hasOid())
+    {
+        m_byOid.erase(rec->getOid());
+    }
+
+    rec->m_oid = oid;
+
+    if (oid != SAI_NULL_OBJECT_ID)
+    {
+        m_byOid[oid] = rec;
+    }
+
+    return true;
+}
+
+bool VppInterfaceRegistry::setRifOid(
+        _In_ const std::string& hwifName,
+        _In_ sai_object_id_t rifOid)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec)
+    {
+        SWSS_LOG_ERROR("cannot set rif oid on %s: not registered", hwifName.c_str());
+
+        return false;
+    }
+
+    /* not indexed: nothing looks an interface up by its router interface oid yet */
+    rec->m_rifOid = rifOid;
+
+    return true;
+}
+
+bool VppInterfaceRegistry::setBdId(
+        _In_ const std::string& hwifName,
+        _In_ uint32_t bdId)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec)
+    {
+        SWSS_LOG_ERROR("cannot set bd_id on %s: not registered", hwifName.c_str());
+
+        return false;
+    }
+
+    rec->m_bdId = bdId;
+
+    return true;
+}
+
+bool VppInterfaceRegistry::clearBdId(
+        _In_ const std::string& hwifName)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec)
+    {
+        return false;
+    }
+
+    rec->m_bdId = VppInterface::BD_ID_INVALID;
+
+    return true;
+}
+
+size_t VppInterfaceRegistry::remove(
+        _In_ const std::string& hwifName)
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findByHwif(hwifName);
+
+    if (!rec)
+    {
+        return 0;
+    }
+
+    size_t removed = 0;
+
+    /*
+     * Children must be collected before the parent is unindexed: dropping the
+     * last owning reference would expire their weak parent pointer and lose the
+     * link needed to find them.
+     */
+    for (auto& childName: collectChildren(rec))
+    {
+        removed += remove(childName);
+    }
+
+    unindexRecord(rec);
+
+    removed++;
+
+    SWSS_LOG_INFO("removed interface %s (%zu records)", hwifName.c_str(), removed);
+
+    return removed;
+}
+
+size_t VppInterfaceRegistry::removeByOid(
+        _In_ sai_object_id_t oid)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_byOid.find(oid);
+
+    if (it == m_byOid.end())
+    {
+        return 0;
+    }
+
+    return remove(it->second->getHwifName());
+}
+
+std::shared_ptr<VppInterface> VppInterfaceRegistry::findByHwif(
+        _In_ const std::string& hwifName) const
+{
+    auto it = m_byHwif.find(hwifName);
+
+    return it == m_byHwif.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<VppInterface> VppInterfaceRegistry::findBySonicName(
+        _In_ const std::string& sonicName) const
+{
+    auto it = m_bySonicName.find(sonicName);
+
+    return it == m_bySonicName.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<VppInterface> VppInterfaceRegistry::findByTap(
+        _In_ const std::string& tapName) const
+{
+    auto it = m_byTap.find(tapName);
+
+    return it == m_byTap.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<VppInterface> VppInterfaceRegistry::findByOid(
+        _In_ sai_object_id_t oid) const
+{
+    auto it = m_byOid.find(oid);
+
+    return it == m_byOid.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<VppInterface> VppInterfaceRegistry::findBySwIfIndex(
+        _In_ uint32_t swIfIndex) const
+{
+    auto it = m_bySwIfIndex.find(swIfIndex);
+
+    return it == m_bySwIfIndex.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<VppSubInterface> VppInterfaceRegistry::findSubIf(
+        _In_ const std::string& parentHwifName,
+        _In_ uint32_t subId) const
+{
+    /*
+     * A sub-interface is named after its parent, so the primary index already
+     * answers this; no separate (parent, vlan) index has to be kept in sync.
+     */
+    auto rec = findByHwif(VppSubInterface::hwifNameFor(parentHwifName, subId));
+
+    if (!rec)
+    {
+        return nullptr;
+    }
+
+    return std::dynamic_pointer_cast<VppSubInterface>(rec);
+}
+
+sai_object_id_t VppInterfaceRegistry::resolvePortOid(
+        _In_ uint32_t swIfIndex) const
+{
+    SWSS_LOG_ENTER();
+
+    auto rec = findBySwIfIndex(swIfIndex);
+
+    if (!rec)
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    if (rec->getType() == VppInterfaceType::SUB_INTERFACE)
+    {
+        /*
+         * VPP reports the sub-interface index in an FDB learn event, but SAI
+         * knows the MAC on the parent PORT or LAG, which is what
+         * SAI_BRIDGE_PORT_ATTR_PORT_ID holds.
+         */
+        auto sub = rec->asSubIf();
+
+        auto parent = sub->getParent();
+
+        if (!parent)
+        {
+            SWSS_LOG_ERROR("sub-interface %s has an expired parent", rec->getHwifName().c_str());
+
+            return SAI_NULL_OBJECT_ID;
+        }
+
+        return parent->getOid();
+    }
+
+    return rec->getOid();
+}
+
+void VppInterfaceRegistry::clear()
+{
+    SWSS_LOG_ENTER();
+
+    m_bySwIfIndex.clear();
+    m_byOid.clear();
+    m_byTap.clear();
+    m_bySonicName.clear();
+    m_byHwif.clear();
+}
+
+void VppInterfaceRegistry::indexRecord(
+        _In_ const std::shared_ptr<VppInterface>& rec)
+{
+    m_byHwif[rec->getHwifName()] = rec;
+
+    if (rec->hasSonicName())
+    {
+        m_bySonicName[rec->getSonicName()] = rec;
+    }
+
+    if (rec->hasTapName())
+    {
+        m_byTap[rec->getTapName()] = rec;
+    }
+
+    if (rec->hasOid())
+    {
+        m_byOid[rec->getOid()] = rec;
+    }
+
+    if (rec->hasSwIfIndex())
+    {
+        m_bySwIfIndex[rec->getSwIfIndex()] = rec;
+    }
+}
+
+void VppInterfaceRegistry::unindexRecord(
+        _In_ const std::shared_ptr<VppInterface>& rec)
+{
+    if (rec->hasSwIfIndex())
+    {
+        m_bySwIfIndex.erase(rec->getSwIfIndex());
+    }
+
+    if (rec->hasOid())
+    {
+        m_byOid.erase(rec->getOid());
+    }
+
+    if (rec->hasTapName())
+    {
+        m_byTap.erase(rec->getTapName());
+    }
+
+    if (rec->hasSonicName())
+    {
+        m_bySonicName.erase(rec->getSonicName());
+    }
+
+    m_byHwif.erase(rec->getHwifName());
+}
+
+std::vector<std::string> VppInterfaceRegistry::collectChildren(
+        _In_ const std::shared_ptr<VppInterface>& parent) const
+{
+    std::vector<std::string> children;
+
+    /*
+     * Linear scan rather than a parent->children index. Removal is rare and the
+     * table is small, and the alternative is a fifth index that would have to be
+     * kept consistent on every mutation.
+     */
+    for (auto& kv: m_byHwif)
+    {
+        auto sub = kv.second->asSubIf();
+
+        if (sub && sub->getParent() == parent)
+        {
+            children.push_back(kv.first);
+        }
+    }
+
+    return children;
+}

--- a/vslib/vpp/VppInterfaceRegistry.h
+++ b/vslib/vpp/VppInterfaceRegistry.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "swss/logger.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -115,10 +115,6 @@ namespace saivs
                     _In_ uint16_t vlanId,
                     _In_ sai_object_id_t vlanOid);
 
-            std::shared_ptr<VppTunnelInterface> addTunnel(
-                    _In_ const std::string& hwifName,
-                    _In_ uint32_t vni);
-
         public:
 
             // ---- mutation, keyed by the primary key -----------------------
@@ -229,8 +225,7 @@ namespace saivs
              *
              * The oid is whatever the record carries: a PORT, a LAG or, for a
              * BVI, a VLAN. SAI_NULL_OBJECT_ID when the index is unknown or the
-             * interface has no oid, as a tunnel or a bare sub-interface does
-             * not.
+             * interface has no oid, as a bare sub-interface does not.
              */
             sai_object_id_t resolveIfOid(
                     _In_ uint32_t swIfIndex) const;
@@ -323,6 +318,7 @@ namespace saivs
 
             size_t size() const
             {
+                SWSS_LOG_ENTER();
                 return m_byHwif.size();
             }
 

--- a/vslib/vpp/VppInterfaceRegistry.h
+++ b/vslib/vpp/VppInterfaceRegistry.h
@@ -2,6 +2,7 @@
 #include "swss/logger.h"
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -29,10 +30,31 @@ namespace saivs
      * this netdev" and splitting name resolution across two owners is what
      * this class exists to stop.
      *
-     * Threading: this class takes NO lock of its own. It lives under the
-     * existing recursive m_apimutex held by the main/command thread and by the
-     * FDB aging thread. The VPP API RX thread (staticMacEventCb) must NEVER
-     * touch it -- that thread only enqueues onto m_mac_event_queue.
+     * Threading: this class is internally synchronized by a recursive mutex and
+     * is safe to call from the command thread, the FDB aging thread and the VPP
+     * event thread. It is a LEAF lock -- no other lock is ever acquired while it
+     * is held -- so it cannot take part in a deadlock cycle. This mirrors the
+     * vpp_intf_table_mutex leaf lock in SaiVppXlate.c, which guards the shared
+     * interface tables read from both the command and the event paths.
+     *
+     * The lock is recursive because the public API self-nests: remove() recurses
+     * through collectChildren(), every setter re-enters findByHwif(), and
+     * resolveHwIfByOsIf() calls loadIfMapping().
+     *
+     * IMPORTANT: only the registry's own state is synchronized. A VppInterface
+     * returned by findBy*() is NOT individually locked, and the shared_ptr is a
+     * lifetime guarantee, NOT a lock -- the mutex is already released by the
+     * time the pointer reaches the caller. The record therefore cannot be freed
+     * underneath you, but its mutable fields (oid, tap name, sw_if_index) may be
+     * rewritten by the command thread while you read them. A caller that does
+     * not already hold m_apimutex must therefore read records through the
+     * value-returning resolve*() accessors, which do the whole read inside the
+     * lock, never by dereferencing a findBy*() result.
+     *
+     * The VPP API RX thread (staticMacEventCb) must still NEVER touch it: that
+     * thread runs holding VPP_LOCK, and taking any further lock there would
+     * break the "never acquire another lock while holding vpp_mutex" ordering
+     * rule. It only enqueues onto m_mac_event_queue.
      *
      * This class makes no VPP API calls. Resolving a sw_if_index from VPP stays
      * in SwitchVpp, which then calls bindSwIfIndex(); that keeps the registry
@@ -316,9 +338,24 @@ namespace saivs
             std::string resolveHwIfByOsIf(
                     _In_ const std::string& osIfName) const;
 
+            /*
+             * Oid of the front panel port named by hwifName, or
+             * SAI_NULL_OBJECT_ID if there is no such record, it is not a
+             * physical port, or it has no oid yet.
+             *
+             * Exists so the VPP event thread can answer "which PORT does this
+             * link event belong to" without dereferencing a record outside the
+             * lock: the type test and the oid read both happen while the lock
+             * is held and only a value comes back. See the threading note on
+             * the class.
+             */
+            sai_object_id_t resolvePhysicalPortOid(
+                    _In_ const std::string& hwifName) const;
+
             size_t size() const
             {
                 SWSS_LOG_ENTER();
+                std::lock_guard<std::recursive_mutex> lock(m_mutex);
                 return m_byHwif.size();
             }
 
@@ -343,6 +380,14 @@ namespace saivs
             void loadIfMapping() const;
 
         private:
+
+            /*
+             * Leaf lock guarding every index below. Recursive because the
+             * public API self-nests, mutable so the const resolve*() accessors
+             * and loadIfMapping() can take it. See the threading note on the
+             * class.
+             */
+            mutable std::recursive_mutex m_mutex;
 
             /*
              * All five indexes hold a shared_ptr rather than a raw pointer.

--- a/vslib/vpp/VppInterfaceRegistry.h
+++ b/vslib/vpp/VppInterfaceRegistry.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "VppInterface.h"
@@ -14,10 +15,19 @@ namespace saivs
      *
      * Every field that is also a lookup key lives in one place, and every
      * mutation updates all affected indexes in the same step. That invariant is
-     * the entire reason this class exists: today the same facts are spread over
-     * seven maps (m_osif_to_hwif_map, m_hwif_to_osif_map, m_ifname_to_port_id_map,
-     * m_port_id_to_tapname, m_lag_bond_map, m_swif_to_bdid, m_swif_to_port_id)
-     * whose lifetimes are only loosely related to each other.
+     * the entire reason this class exists: the same facts used to be spread over
+     * several side maps (m_lag_bond_map, m_swif_to_bdid, m_swif_to_port_id, and
+     * the tap/name maps) whose lifetimes were only loosely related to each other,
+     * so a teardown that missed one left the others answering with stale data.
+     *
+     * What deliberately stays outside: the SAI object hashes. The registry
+     * knows names and oids, not attributes.
+     *
+     * The osif->hwif mapping parsed from sonic_vpp_ifmap.ini lives here too,
+     * even though it is a seed read from a file rather than derived state,
+     * because it is the only remaining way to answer "what is the VPP name of
+     * this netdev" and splitting name resolution across two owners is what
+     * this class exists to stop.
      *
      * Threading: this class takes NO lock of its own. It lives under the
      * existing recursive m_apimutex held by the main/command thread and by the
@@ -60,12 +70,13 @@ namespace saivs
              *
              * NO tap name is taken. A physical port exists and is routable
              * whether or not SAI ever creates a hostif for it -- the lane based
-             * lookup in vpp_get_hwif_name() never touches a tap -- so seeding
-             * one would make findByTap() answer for taps that do not exist.
+             * lookup in vppGetHwIfNameForPort() never touches a tap -- so
+             * seeding one would make findByTap() answer for taps that do not
+             * exist.
              */
             std::shared_ptr<VppPhysicalPort> addPhysicalPort(
                     _In_ const std::string& hwifName,
-                    _In_ const std::string& sonicName,
+                    _In_ const std::string& osIf,
                     _In_ sai_object_id_t oid);
 
             /*
@@ -95,8 +106,14 @@ namespace saivs
                     _In_ uint32_t subId,
                     _In_ uint16_t vlanId);
 
+            /*
+             * The VLAN oid is recorded so that a BVI can be resolved straight
+             * from SAI_ROUTER_INTERFACE_ATTR_VLAN_ID without a SAI attribute
+             * read to turn the oid back into a vlan id.
+             */
             std::shared_ptr<VppVlanInterface> addBvi(
-                    _In_ uint16_t vlanId);
+                    _In_ uint16_t vlanId,
+                    _In_ sai_object_id_t vlanOid);
 
             std::shared_ptr<VppTunnelInterface> addTunnel(
                     _In_ const std::string& hwifName,
@@ -137,9 +154,9 @@ namespace saivs
                     _In_ const std::string& hwifName);
 
             /*
-             * PORT or LAG object id only; anything else is rejected.
+             * PORT, LAG or VLAN object id only; anything else is rejected.
              *
-             * Both kinds now supply their oid at registration, so this exists
+             * All three kinds supply their oid at registration, so this exists
              * for the rare re-bind rather than as a required second step.
              */
             bool setOid(
@@ -183,8 +200,8 @@ namespace saivs
              * available for a registered interface, so this is what the lane
              * based port lookup and any config driven path should use.
              */
-            std::shared_ptr<VppInterface> findBySonicName(
-                    _In_ const std::string& sonicName) const;
+            std::shared_ptr<VppInterface> findByOsIf(
+                    _In_ const std::string& osIf) const;
 
             /*
              * Resolve a host netdev name. Answers only for interfaces that
@@ -205,14 +222,104 @@ namespace saivs
                     _In_ uint32_t subId) const;
 
             /*
-             * Resolve a sw_if_index reported by VPP to the PORT/LAG oid that
-             * SAI_BRIDGE_PORT_ATTR_PORT_ID would carry, walking from a
-             * sub-interface up to its parent. This is what the FDB learn/move
-             * path needs, and the reason a sub-interface is a stored record
-             * rather than a derived name.
+             * Resolve a sw_if_index reported by VPP to the oid of the interface
+             * it belongs to, walking from a sub-interface up to its parent.
+             * That walk is the reason a sub-interface is a stored record rather
+             * than a derived name.
+             *
+             * The oid is whatever the record carries: a PORT, a LAG or, for a
+             * BVI, a VLAN. SAI_NULL_OBJECT_ID when the index is unknown or the
+             * interface has no oid, as a tunnel or a bare sub-interface does
+             * not.
              */
-            sai_object_id_t resolvePortOid(
+            sai_object_id_t resolveIfOid(
                     _In_ uint32_t swIfIndex) const;
+
+            /*
+             * Host netdev (linux-cp tap) of a PORT or LAG: "Ethernet0" for a
+             * port, "be<N>" for a bond. Empty when the interface has no host
+             * representation yet -- a port before its hostif is created, a bond
+             * before vpp_ensure_lag_lcp() makes the be<N> pair. A miss means
+             * "no host netdev", not "unknown interface".
+             */
+            std::string resolveTapName(
+                    _In_ sai_object_id_t oid) const;
+
+            /*
+             * SONiC netdev of a PORT or LAG: "Ethernet0", "PortChannel<N>".
+             *
+             * Deliberately NOT resolveTapName(): a LAG has two host netdevs,
+             * the teamd-owned PortChannel<N> returned here and the linux-cp tap
+             * be<N> returned there. They coincide for a physical port. Use this
+             * one for anything keyed on the SONiC name -- `ip link show`, VRF
+             * enslavement, resolveHwIfByOsIf().
+             */
+            std::string resolveOsIf(
+                    _In_ sai_object_id_t oid) const;
+
+            /* Same, keyed on the VPP interface name. */
+            std::string resolveOsIfByHwif(
+                    _In_ const std::string& hwifName) const;
+
+            /*
+             * VPP interface name of a PORT, LAG or VLAN, with an optional
+             * .<vlanId> sub-interface suffix: "TenGigabitEthernet0/0/0",
+             * "BondEthernet1.100", "bvi1000". Empty on miss.
+             *
+             * A pure index lookup: it makes no SAI and no VPP call, so it
+             * cannot register anything it does not already know about. The one
+             * caller that has to cope with a port that has not been registered
+             * yet is SwitchVpp::vppGetHwIfNameForPort().
+             */
+            std::string resolveHwIfName(
+                    _In_ sai_object_id_t oid,
+                    _In_ uint32_t vlanId) const;
+
+            /*
+             * A LAG that is fully realised: registered, of LAG type and bound
+             * to a VPP sw_if_index. addLag() takes the bond id, the sw_if_index
+             * and the oid in one call, so those three are either all present or
+             * all absent. nullptr on miss.
+             *
+             * Callers reach the bond id and the LCP flag through asBond().
+             */
+            std::shared_ptr<VppInterface> findLag(
+                    _In_ sai_object_id_t oid) const;
+
+            /*
+             * Bond ids currently in use.
+             *
+             * find_new_bond_id() picks the one kernel PortChannel that no LAG
+             * has claimed yet, so it needs the set of already-allocated ids and
+             * nothing else. Returning ids rather than exposing an iterator over
+             * records keeps the indexes private.
+             *
+             * Note this cannot tell you the id OF a given PortChannel: a bond
+             * record's SONiC name is built FROM its id, so the mapping only runs
+             * that way. The kernel netdev name remains the sole source of a new
+             * id.
+             */
+            std::unordered_set<uint32_t> collectBondIds() const;
+
+            /*
+             * VPP interface name of a host OS interface name ("Ethernet0",
+             * "PortChannel1", "PortChannel1.100", "Vlan200"). The input is the
+             * SONiC-side netdev name as produced by resolveOsIf(); a bond LCP
+             * tap name ("be1") is deliberately not accepted. Empty on miss.
+             *
+             * Unlike every other resolver here this does NOT consult the
+             * records: it answers from sonic_vpp_ifmap.ini plus the naming
+             * rules, so it works before anything is registered. That is what
+             * makes it usable as the registry's own seed --
+             * getPortHwifNameFromLane() has to turn a port_config.ini name into
+             * a hwif name before addPhysicalPort() can make a record.
+             *
+             * The flip side is that it answers by RULE, not by existence: ask
+             * it about a PortChannel that was never created and it will still
+             * say "BondEthernet<N>".
+             */
+            std::string resolveHwIfByOsIf(
+                    _In_ const std::string& osIfName) const;
 
             size_t size() const
             {
@@ -232,6 +339,13 @@ namespace saivs
             std::vector<std::string> collectChildren(
                     _In_ const std::shared_ptr<VppInterface>& parent) const;
 
+            /*
+             * Parse sonic_vpp_ifmap.ini on first use. Retries on every call
+             * until the file can actually be opened: at switch create time the
+             * hwsku directory is not guaranteed to be there yet.
+             */
+            void loadIfMapping() const;
+
         private:
 
             /*
@@ -245,7 +359,7 @@ namespace saivs
             std::map<std::string, std::shared_ptr<VppInterface>> m_byHwif;
 
             /* SONiC facing name; populated at registration, never late bound */
-            std::map<std::string, std::shared_ptr<VppInterface>> m_bySonicName;
+            std::map<std::string, std::shared_ptr<VppInterface>> m_byOsIf;
 
             /* only records that CURRENTLY have a host tap */
             std::map<std::string, std::shared_ptr<VppInterface>> m_byTap;
@@ -255,5 +369,15 @@ namespace saivs
 
             /* only records whose sw_if_index has been resolved */
             std::map<uint32_t, std::shared_ptr<VppInterface>> m_bySwIfIndex;
+
+            /*
+             * Physical ports only, straight out of sonic_vpp_ifmap.ini; every
+             * logical interface is derived by rule instead. Mutable because it
+             * is a read-through cache of an immutable file, which does not make
+             * a lookup any less of an observer.
+             */
+            mutable std::map<std::string, std::string> m_osIfToHwIf;
+
+            mutable bool m_ifMapLoaded = false;
     };
 }

--- a/vslib/vpp/VppInterfaceRegistry.h
+++ b/vslib/vpp/VppInterfaceRegistry.h
@@ -1,0 +1,259 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "VppInterface.h"
+
+namespace saivs
+{
+    /*
+     * Single owner of interface identity for the VPP SAI backend.
+     *
+     * Every field that is also a lookup key lives in one place, and every
+     * mutation updates all affected indexes in the same step. That invariant is
+     * the entire reason this class exists: today the same facts are spread over
+     * seven maps (m_osif_to_hwif_map, m_hwif_to_osif_map, m_ifname_to_port_id_map,
+     * m_port_id_to_tapname, m_lag_bond_map, m_swif_to_bdid, m_swif_to_port_id)
+     * whose lifetimes are only loosely related to each other.
+     *
+     * Threading: this class takes NO lock of its own. It lives under the
+     * existing recursive m_apimutex held by the main/command thread and by the
+     * FDB aging thread. The VPP API RX thread (staticMacEventCb) must NEVER
+     * touch it -- that thread only enqueues onto m_mac_event_queue.
+     *
+     * This class makes no VPP API calls. Resolving a sw_if_index from VPP stays
+     * in SwitchVpp, which then calls bindSwIfIndex(); that keeps the registry
+     * free of SaiVppXlate.h and unit-testable on its own.
+     */
+    class VppInterfaceRegistry
+    {
+        public:
+
+            VppInterfaceRegistry() = default;
+
+            ~VppInterfaceRegistry() = default;
+
+            VppInterfaceRegistry(const VppInterfaceRegistry&) = delete;
+            VppInterfaceRegistry& operator=(const VppInterfaceRegistry&) = delete;
+
+        public:
+
+            // ---- creation -------------------------------------------------
+
+            /*
+             * Registered once the port's lane list is known, which is the point
+             * at which it first HAS an identity: create_ports() creates ports
+             * with no attributes at all and only then sets
+             * SAI_PORT_ATTR_HW_LANE_LIST, so a port is anonymous until that set
+             * lands. The lane set yields the SONiC name, sonic_vpp_ifmap.ini
+             * turns that into the hwif name, and the oid is already in hand --
+             * so unlike the old two step tap dance, a physical port is fully
+             * identified in one call.
+             *
+             * The ifmap lookup is the CALLER'S job. It is platform config read
+             * from a file, and keeping that out of here leaves the registry a
+             * pure in-memory index: no I/O, no lazy state, no mutable members,
+             * and unit-testable without fixture files.
+             *
+             * NO tap name is taken. A physical port exists and is routable
+             * whether or not SAI ever creates a hostif for it -- the lane based
+             * lookup in vpp_get_hwif_name() never touches a tap -- so seeding
+             * one would make findByTap() answer for taps that do not exist.
+             */
+            std::shared_ptr<VppPhysicalPort> addPhysicalPort(
+                    _In_ const std::string& hwifName,
+                    _In_ const std::string& sonicName,
+                    _In_ sai_object_id_t oid);
+
+            /*
+             * A bond is the one kind of interface whose whole identity is known
+             * at once: vpp_create_lag() is handed the LAG oid, allocates the
+             * bond id, and gets the sw_if_index back from
+             * create_bond_interface() before it returns. Taking all three here
+             * makes "a registered LAG always has an oid and an index" true by
+             * construction, instead of leaving a window where it does not.
+             *
+             * The tap ("be<N>") is NOT taken: it only exists once the LCP pair
+             * is created, which is a later and separate step.
+             */
+            std::shared_ptr<VppBondInterface> addLag(
+                    _In_ uint32_t bondId,
+                    _In_ uint32_t swIfIndex,
+                    _In_ sai_object_id_t oid);
+
+            /*
+             * Idempotent: an existing sub-interface under the same name is
+             * returned as is. The tagged VLAN member and sub-port RIF paths both
+             * land here, but SONiC never overlaps them -- one is deleted before
+             * the other is created -- so there is no ownership to arbitrate.
+             */
+            std::shared_ptr<VppSubInterface> addSubInterface(
+                    _In_ const std::shared_ptr<VppInterface>& parent,
+                    _In_ uint32_t subId,
+                    _In_ uint16_t vlanId);
+
+            std::shared_ptr<VppVlanInterface> addBvi(
+                    _In_ uint16_t vlanId);
+
+            std::shared_ptr<VppTunnelInterface> addTunnel(
+                    _In_ const std::string& hwifName,
+                    _In_ uint32_t vni);
+
+        public:
+
+            // ---- mutation, keyed by the primary key -----------------------
+
+            /*
+             * Late binding for records whose index only becomes known after a
+             * sw_interface_dump. If another record already holds this index --
+             * VPP recycles indexes after a delete -- the stale holder is
+             * unbound first so the by_swif index can never alias.
+             */
+            bool bindSwIfIndex(
+                    _In_ const std::string& hwifName,
+                    _In_ uint32_t swIfIndex);
+
+            bool unbindSwIfIndex(
+                    _In_ const std::string& hwifName);
+
+            /*
+             * Record that a host netdev now exists for this interface, and its
+             * name. Driven by hostif create for a physical port, by LCP pair
+             * creation for a bond or a sub-port RIF.
+             *
+             * Kept apart from registration on purpose: tap lifetime is strictly
+             * shorter than interface lifetime, and conflating the two is what
+             * made the old m_port_id_to_tapname / m_hwif_to_osif_map pair
+             * disagree with reality.
+             */
+            bool setTapName(
+                    _In_ const std::string& hwifName,
+                    _In_ const std::string& tapName);
+
+            bool clearTapName(
+                    _In_ const std::string& hwifName);
+
+            /*
+             * PORT or LAG object id only; anything else is rejected.
+             *
+             * Both kinds now supply their oid at registration, so this exists
+             * for the rare re-bind rather than as a required second step.
+             */
+            bool setOid(
+                    _In_ const std::string& hwifName,
+                    _In_ sai_object_id_t oid);
+
+            bool setRifOid(
+                    _In_ const std::string& hwifName,
+                    _In_ sai_object_id_t rifOid);
+
+            bool setBdId(
+                    _In_ const std::string& hwifName,
+                    _In_ uint32_t bdId);
+
+            bool clearBdId(
+                    _In_ const std::string& hwifName);
+
+        public:
+
+            // ---- removal --------------------------------------------------
+
+            /*
+             * Cascades to sub-interfaces, mirroring VPP, which deletes them
+             * along with their parent. Returns the number of records removed.
+             */
+            size_t remove(
+                    _In_ const std::string& hwifName);
+
+            size_t removeByOid(
+                    _In_ sai_object_id_t oid);
+
+        public:
+
+            // ---- lookup, nullptr on miss ----------------------------------
+
+            std::shared_ptr<VppInterface> findByHwif(
+                    _In_ const std::string& hwifName) const;
+
+            /*
+             * Resolve a SONiC facing name ("Ethernet0", "PortChannel1"). Always
+             * available for a registered interface, so this is what the lane
+             * based port lookup and any config driven path should use.
+             */
+            std::shared_ptr<VppInterface> findBySonicName(
+                    _In_ const std::string& sonicName) const;
+
+            /*
+             * Resolve a host netdev name. Answers only for interfaces that
+             * currently HAVE a tap, so a miss is meaningful: it means there is
+             * no host representation, not that the interface is unknown.
+             */
+            std::shared_ptr<VppInterface> findByTap(
+                    _In_ const std::string& tapName) const;
+
+            std::shared_ptr<VppInterface> findByOid(
+                    _In_ sai_object_id_t oid) const;
+
+            std::shared_ptr<VppInterface> findBySwIfIndex(
+                    _In_ uint32_t swIfIndex) const;
+
+            std::shared_ptr<VppSubInterface> findSubIf(
+                    _In_ const std::string& parentHwifName,
+                    _In_ uint32_t subId) const;
+
+            /*
+             * Resolve a sw_if_index reported by VPP to the PORT/LAG oid that
+             * SAI_BRIDGE_PORT_ATTR_PORT_ID would carry, walking from a
+             * sub-interface up to its parent. This is what the FDB learn/move
+             * path needs, and the reason a sub-interface is a stored record
+             * rather than a derived name.
+             */
+            sai_object_id_t resolvePortOid(
+                    _In_ uint32_t swIfIndex) const;
+
+            size_t size() const
+            {
+                return m_byHwif.size();
+            }
+
+            void clear();
+
+        private:
+
+            void indexRecord(
+                    _In_ const std::shared_ptr<VppInterface>& rec);
+
+            void unindexRecord(
+                    _In_ const std::shared_ptr<VppInterface>& rec);
+
+            std::vector<std::string> collectChildren(
+                    _In_ const std::shared_ptr<VppInterface>& parent) const;
+
+        private:
+
+            /*
+             * All five indexes hold a shared_ptr rather than a raw pointer.
+             * Consistency is then structural: a missed erase leaves a stale
+             * entry, which is diagnosable, instead of a dangling pointer, which
+             * is undefined behaviour on the FDB hot path.
+             */
+
+            /* owning, primary key */
+            std::map<std::string, std::shared_ptr<VppInterface>> m_byHwif;
+
+            /* SONiC facing name; populated at registration, never late bound */
+            std::map<std::string, std::shared_ptr<VppInterface>> m_bySonicName;
+
+            /* only records that CURRENTLY have a host tap */
+            std::map<std::string, std::shared_ptr<VppInterface>> m_byTap;
+
+            /* PARTIAL: PORT and LAG oids only, never ROUTER_INTERFACE */
+            std::map<sai_object_id_t, std::shared_ptr<VppInterface>> m_byOid;
+
+            /* only records whose sw_if_index has been resolved */
+            std::map<uint32_t, std::shared_ptr<VppInterface>> m_bySwIfIndex;
+    };
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Consolidate VPP interface identity into VppInterfaceRegistry

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
The VPP backend kept interface identity in multiple side maps and helper paths (tap map, ifname map, bond/bd/swif maps, name derivation helpers), which made lifecycle handling fragile and hard to reason about.
The goal is to make one registry the source of truth for interface identity and lookups, while keeping compatibility writes for inherited base paths that still consult legacy maps.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?
1. Introducing interface identity model used by VppInterfaceRegistry.
###
Base attributes on every record:
- hwif name   (always present, primary key)
- osif name   (SONiC side name like Ethernet0, PortChannel0, Vlan100, Ethernet0.10)
- tap name    (optional, present only when vpp lcp creates the host tap)
- oid         (optional; PORT/LAG/VLAN identity)
- rif oid     (optional router interface oid)
- sw_if_index (optional VPP runtime interface index)
- bd_id       (optional bridge domain id)
###
Subclasses:
- VppPhysicalPort: front panel port identity seeded from ifmap.
- VppBondInterface: LAG identity with bond id and lcp-created state.
- VppSubInterface: parent-linked <parent>.<subId> interface identity.
- VppVlanInterface: VLAN BVI identity (bvi<VLAN>, Vlan<VLAN>).
###
Lookup coverage by subclass (through registry indexes):
- Physical/LAG/BVI: hwif + osif + optional tap + optional oid + optional sw_if_index.
- Sub-interface:    hwif + osif + optional tap + optional sw_if_index, and findSubIf(parentHwif, subId).

2. Introduced a dedicated interface identity model and registry for VPP.
3. Migrated VPP call sites to registry-based lookups for interface resolution.
4. Renamed resolvePortOid to resolveIfOid and made it generic so callers can apply explicit type checks where needed.
5. Moved OS interface name to VPP hardware interface resolution into the registry (including logical interface derivation and sub-interface suffix handling).
6. Removed legacy/dead helper wrappers that were replaced by registry lookups.
7. Kept legacy map writes on hostif create/remove only for compatibility with inherited base logic:

- setIfNameToPortId and setPortIdToTapName are still written.
- removeIfNameToPortId and removePortIdToTapName are still removed on teardown.
- VPP read paths now use the interface registry instead of those maps.
- Hardened ifmap parsing with bounded scanf widths.

8. Fixed a BFD string lifetime issue by keeping the hardware interface name in owning string scope.
#### How did you verify/test it?
Run full regression through PR https://github.com/sonic-net/sonic-buildimage/pull/27039
#### Any platform specific information?
vpp
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
