### PR TITLE
[syncd]: Drop host_tx_ready ntf when port RID is not mapped yet

### DIFF
--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -474,15 +474,28 @@ void NotificationProcessor::process_on_port_host_tx_ready_change(
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_DEBUG("Port ID before translating from RID to VID is %s", sai_serialize_object_id(port_id).c_str());
-    sai_object_id_t port_vid = m_translator->translateRidToVid(port_id, SAI_NULL_OBJECT_ID);
-    SWSS_LOG_DEBUG("Port ID after translating from RID to VID is %s", sai_serialize_object_id(port_id).c_str());
+    sai_object_id_t port_vid = SAI_NULL_OBJECT_ID;
+    sai_object_id_t switch_vid = SAI_NULL_OBJECT_ID;
 
-    sai_object_id_t switch_vid = m_translator->translateRidToVid(switch_id, SAI_NULL_OBJECT_ID);
+    /*
+     * Port should already be in local/redis db after creation. If this
+     * notification races ahead of create port (warmboot before
+     * onPostPortsCreate), do not allocate a new VID. orchagent gets
+     * SAI_PORT_ATTR_HOST_TX_READY_STATUS after ports exist.
+     */
+    if (!m_translator->tryTranslateRidToVid(port_id, port_vid))
+    {
+        SWSS_LOG_WARN("Port RID %s translated to null VID!!!", sai_serialize_object_id(port_id).c_str());
+        return;
+    }
+
+    if (!m_translator->tryTranslateRidToVid(switch_id, switch_vid))
+    {
+        SWSS_LOG_WARN("Switch RID %s translated to null VID!!!", sai_serialize_object_id(switch_id).c_str());
+        return;
+    }
 
     std::string s = sai_serialize_port_host_tx_ready_ntf(switch_vid, port_vid, *host_tx_ready_status);
-
-    SWSS_LOG_DEBUG("Host_tx_ready status after sai_serialize is %s", s.c_str());
 
     sendNotification(SAI_SWITCH_NOTIFICATION_NAME_PORT_HOST_TX_READY, s);
 }

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -477,6 +477,7 @@ vxlan
 VXLAN
 Werror
 wikipedia
+warmboot
 workaroung
 WRED
 www

--- a/unittest/syncd/TestNotificationProcessor.cpp
+++ b/unittest/syncd/TestNotificationProcessor.cpp
@@ -143,4 +143,26 @@ TEST(NotificationProcessor, NotificationProcessorTest)
     translator->insertRidAndVid(0x123456789abcdef, 0x123456789abcdef);
     notificationProcessor->syncProcessNotification(flowBulkGetSessionEventItem);
     translator->eraseRidAndVid(0x123456789abcdef, 0x123456789abcdef);
+
+    // host_tx_ready notification with an unknown RID must be dropped, not abort syncd.
+    // Port RIDs are only mapped in SaiSwitch::onPostPortsCreate, so a port flap right
+    // after switch create (warmboot) is translated before the port VID exists.
+    std::string hostTxReadyData =
+        "[{\"host_tx_ready_status\":\"SAI_PORT_HOST_TX_READY_STATUS_NOT_READY\","
+        "\"port_id\":\"oid:0x10000000000fd\",\"switch_id\":\"oid:0x21000000000000\"}]";
+    std::vector<swss::FieldValueTuple> hostTxReadyEntry;
+    swss::KeyOpFieldsValuesTuple hostTxReadyItem(
+            SAI_SWITCH_NOTIFICATION_NAME_PORT_HOST_TX_READY,
+            hostTxReadyData,
+            hostTxReadyEntry);
+
+    // switch RID mapped, port RID unknown
+    translator->insertRidAndVid(0x21000000000000, 0x210000000000);
+    EXPECT_NO_THROW(notificationProcessor->syncProcessNotification(hostTxReadyItem));
+    translator->eraseRidAndVid(0x21000000000000, 0x210000000000);
+
+    // port RID mapped, switch RID unknown
+    translator->insertRidAndVid(0x10000000000fd, 0x1000000000019);
+    EXPECT_NO_THROW(notificationProcessor->syncProcessNotification(hostTxReadyItem));
+    translator->eraseRidAndVid(0x10000000000fd, 0x1000000000019);
 }


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Description of PR

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

## The bug

`syncd` can `SIGABRT` during warm-reboot when a `PORT_HOST_TX_READY`
notification arrives after switch create and before PORT objects exist.

`NotificationProcessor::process_on_port_host_tx_ready_change()` translated
SAI RIDs with `translateRidToVid(rid, SAI_NULL_OBJECT_ID)`. That API is a
mutating discovery helper: on a miss it calls
`allocateNewObjectId(object_type, switchVid)`. The second argument is switch
**context** for allocating a VID, not an in-place destination.
`SAI_NULL_OBJECT_ID` is an invalid context, so a missing port RID throws:

```text
allocateNewObjectId: object type of switch oid:0x0 is SAI_OBJECT_TYPE_NULL,
should be SWITCH
```

uncaught in the notification thread → `std::terminate` → `SIGABRT`.

Port RID→VID is only inserted in `SaiSwitch::onPostPortsCreate`. Hardware
links stay up across warm-reboot, so a flap in that window is a real SAI
RID that sairedis has not mapped yet. The sibling
`process_on_port_state_change()` already uses read-only
`tryTranslateRidToVid()` and only WARNs on a miss.

## Why dropping the notification is safe

orchagent does not depend on that one-shot edge for the starting picture.
After PORT create it GETs `SAI_PORT_ATTR_HOST_TX_READY_STATUS`
(`initializePortHostTxReadyBulk`). At warm restore end it GETs
`SAI_PORT_ATTR_OPER_STATUS` (`refreshPortStatus`). A later flap still
delivers a mapped-RID notification.

## The fix

Use `tryTranslateRidToVid()` for both port and switch. On a miss, WARN and
return without allocating a VID or calling `sendNotification`.

```cpp
if (!m_translator->tryTranslateRidToVid(port_id, port_vid))
{
    SWSS_LOG_WARN("Port RID %s translated to null VID!!!",
            sai_serialize_object_id(port_id).c_str());
    return;
}

if (!m_translator->tryTranslateRidToVid(switch_id, switch_vid))
{
    SWSS_LOG_WARN("Switch RID %s translated to null VID!!!",
            sai_serialize_object_id(switch_id).c_str());
    return;
}
```

Unit test: unknown port RID and unknown switch RID must not throw
(`allocateNewObjectId` → `SIGABRT`). Miss handling
is `return` before `sendNotification`; the test does not spy on the
producer.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [x] Test improvement

### Approach
#### What is the motivation for this PR?

A `host_tx_ready` SAI notification during warm-reboot, before PORT create, must not
kill `syncd`. The same race is already handled for port oper-state
notifications.

#### Work item tracking

* N/A

#### How did you do it?

* `syncd/NotificationProcessor.cpp` —
  `process_on_port_host_tx_ready_change()` uses `tryTranslateRidToVid()`
  for port and switch; miss → WARN and drop
* `unittest/syncd/TestNotificationProcessor.cpp` —
  unknown port RID and unknown switch RID must not throw (`EXPECT_NO_THROW`).
  That is the `allocateNewObjectId` / `SIGABRT` regression. Dropping the ntf is the handler
  `return` before `sendNotification`, not a separate UT assertion.

#### How did you verify/test it?

1. syncd unit test (existing `NotificationProcessorTest` plus the two
   `host_tx_ready` miss cases):
```
make -C unittest/syncd check
```
2. On a DUT that registers `SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY`,
   warm-reboot with a port that can flap in the switch-create → PORT-create
   window. Confirm `syncd` stays up (no
   `allocateNewObjectId: object type of switch oid:0x0`) and orchagent
   reaches reconciled. `host_tx_ready` in STATE_DB matches HW after
   `initializePortHostTxReadyBulk`.

#### Any platform specific information?

No. Generic sairedis notification path. More likely to show up where
PortsOrch SETs `SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY` (CMIS-ASIC sync),
because that arms the callback before PORT create.
Any platform that delivers `host_tx_ready` in that window is affected.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A — bug fix; behavior documented in the handler comment and unit test.

#### A picture of a cute animal (not mandatory but encouraged)

```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```
