### PR TITLE
[syncd]: Reject empty warm boot state and fall back to cold start

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -38,6 +38,10 @@
 
 #include <unistd.h>
 #include <inttypes.h>
+#include <dirent.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/stat.h>
 
 #include <iterator>
 #include <algorithm>
@@ -322,6 +326,64 @@ Syncd::~Syncd()
     stopDampingTimerThread();
 }
 
+bool Syncd::hasWarmBootState(
+        _In_ const char* warmBootReadFile)
+{
+    SWSS_LOG_ENTER();
+
+    struct stat st;
+
+    if (stat(warmBootReadFile, &st) == -1)
+    {
+        SWSS_LOG_WARN("failed to stat warmBootReadFile '%s': %s", warmBootReadFile, strerror(errno));
+
+        return false;
+    }
+
+    if (S_ISDIR(st.st_mode))
+    {
+        DIR* dir = opendir(warmBootReadFile);
+
+        if (dir == NULL)
+        {
+            SWSS_LOG_WARN("failed to open warmBootReadFile directory '%s': %s", warmBootReadFile, strerror(errno));
+
+            return false;
+        }
+
+        bool hasEntry = false;
+
+        while (const struct dirent* entry = readdir(dir))
+        {
+            if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            {
+                continue;
+            }
+
+            hasEntry = true;
+            break;
+        }
+
+        closedir(dir);
+
+        if (!hasEntry)
+        {
+            SWSS_LOG_WARN("warmBootReadFile directory '%s' is empty", warmBootReadFile);
+        }
+
+        return hasEntry;
+    }
+
+    if (st.st_size == 0)
+    {
+        SWSS_LOG_WARN("warmBootReadFile '%s' is empty", warmBootReadFile);
+
+        return false;
+    }
+
+    return true;
+}
+
 void Syncd::performStartupLogic()
 {
     SWSS_LOG_ENTER();
@@ -343,9 +405,9 @@ void Syncd::performStartupLogic()
 
         SWSS_LOG_NOTICE("using warmBootReadFile: '%s'", warmBootReadFile);
 
-        if (warmBootReadFile == NULL || access(warmBootReadFile, F_OK) == -1)
+        if (warmBootReadFile == NULL || !hasWarmBootState(warmBootReadFile))
         {
-            SWSS_LOG_WARN("user requested warmStart but warmBootReadFile is not specified or not accessible, forcing cold start");
+            SWSS_LOG_WARN("user requested warmStart but warmBootReadFile is not specified or holds no warm boot state, forcing cold start");
 
             m_commandLineOptions->m_startType = SAI_START_TYPE_COLD_BOOT;
         }

--- a/syncd/Syncd.h
+++ b/syncd/Syncd.h
@@ -34,6 +34,7 @@
 
 class SyncdTest;
 class SyncdLinkEventDampingTest;
+class SyncdWarmBootStateTest;
 
 namespace syncd
 {
@@ -41,6 +42,7 @@ namespace syncd
     {
         friend class ::SyncdTest;
         friend class ::SyncdLinkEventDampingTest;
+        friend class ::SyncdWarmBootStateTest;
 
         private:
 
@@ -103,6 +105,9 @@ namespace syncd
                     _Out_ const char** value);
 
             void performStartupLogic();
+
+            static bool hasWarmBootState(
+                    _In_ const char* warmBootReadFile);
 
             void sendShutdownRequest(
                     _In_ sai_object_id_t switchVid);

--- a/unittest/syncd/TestSyncd.cpp
+++ b/unittest/syncd/TestSyncd.cpp
@@ -24,6 +24,8 @@
 
 #include <chrono>
 #include <thread>
+#include <fstream>
+#include <cstdlib>
 
 #include "swss/table.h"
 
@@ -371,6 +373,67 @@ TEST(Syncd, asyncRecIgnoredWhenContextConfigDisablesZmq)
 }
 
 using namespace syncd;
+
+class SyncdWarmBootStateTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        char tmpl[] = "/tmp/syncd_warmboot_XXXXXX";
+
+        ASSERT_NE(mkdtemp(tmpl), nullptr);
+
+        m_dir = tmpl;
+    }
+
+    void TearDown() override
+    {
+        std::string cmd = "rm -rf " + m_dir;
+
+        ASSERT_EQ(system(cmd.c_str()), 0);
+    }
+
+    std::string m_dir;
+};
+
+TEST_F(SyncdWarmBootStateTest, missingPathHasNoState)
+{
+    EXPECT_FALSE(Syncd::hasWarmBootState((m_dir + "/does-not-exist").c_str()));
+}
+
+TEST_F(SyncdWarmBootStateTest, emptyDirectoryHasNoState)
+{
+    EXPECT_FALSE(Syncd::hasWarmBootState(m_dir.c_str()));
+}
+
+TEST_F(SyncdWarmBootStateTest, emptyFileHasNoState)
+{
+    std::string file = m_dir + "/sai-warmboot.bin";
+
+    std::ofstream(file).close();
+
+    EXPECT_FALSE(Syncd::hasWarmBootState(file.c_str()));
+}
+
+TEST_F(SyncdWarmBootStateTest, populatedFileHasState)
+{
+    std::string file = m_dir + "/sai-warmboot.bin";
+
+    std::ofstream ofs(file);
+    ofs << "warm boot state";
+    ofs.close();
+
+    EXPECT_TRUE(Syncd::hasWarmBootState(file.c_str()));
+}
+
+TEST_F(SyncdWarmBootStateTest, directoryWithFileHasState)
+{
+    std::ofstream ofs(m_dir + "/sai-warmboot.bin");
+    ofs << "warm boot state";
+    ofs.close();
+
+    EXPECT_TRUE(Syncd::hasWarmBootState(m_dir.c_str()));
+}
 
 #ifdef MOCK_METHOD
 class MockSelectableChannel : public sairedis::SelectableChannel {


### PR DESCRIPTION
### Description of PR

Summary:
Fixes sonic-net/sonic-buildimage#29310

`performStartupLogic` guards the warm start path with `access(warmBootReadFile, F_OK)`, which only tests that the path exists. Several platforms point `SAI_WARM_BOOT_READ_FILE` at a directory such as `/var/warmboot/`, and a directory that exists but holds no warm state passes that check, so the start type stays `SAI_START_TYPE_WARM_BOOT`. An empty regular file passes it too.

That is what the linked issue hits. If syncd is restarted while `warm-reboot` is still waiting for pre-shutdown to complete, `WARM_RESTART_ENABLE_TABLE|system` is already set but SAI never finished writing the warm state, so the warmboot directory is empty or holds leftovers from an earlier warm boot. The restarted syncd still picks warm boot, the restore fails, and syncd parks in shutdown-wait mode rather than coming back cold.

This is a partial fix for the issue. It addresses the start type selection only. It does not change what happens when a warm restore fails for some other reason, where syncd still enters `inShutdownWaitMode` without a cold retry, and it does not touch the `warm-reboot` side, which lives in sonic-utilities and still kexecs warm after a failed pre-shutdown.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

A syncd that selects warm boot without any saved warm state cannot recover on its own, and the box ends up with a dead dataplane that only an operator cold reboot clears. Refusing the warm start when the state is not actually there keeps that failure inside a cold start, which is recoverable.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

Replaced the `access(..., F_OK)` call with a `hasWarmBootState()` helper. It stats the path, requires a directory to contain at least one entry other than `.` and `..`, and requires a regular file to be non-zero length. Anything else logs a warning and returns false, which takes the existing cold start branch. The surrounding control flow is unchanged.

#### How did you verify/test it?

Added five cases to `unittest/syncd/TestSyncd.cpp` covering a missing path, an empty directory, an empty file, a populated file and a directory holding a file.

I could not build the full sairedis suite locally, `libswsscommon` and the SAI headers are not available on this machine, so CI is the first real run of the gtest suite here. What I did run was the extracted helper and the new test block compiled standalone under `-Wall -Wextra -Werror`, all five assertions passing, and I confirmed separately that `access()` returns 0 on an empty directory, which is the behaviour this change relies on being wrong. `tests/swsslogentercheck.pl` is clean on the three edited files and the diff adds no trailing whitespace or tabs.

I do not have a DUT, so the end to end warm-reboot reproduction from the issue is not verified by me.

#### Any platform specific information?

Only affects platforms where the configured warm boot read path is a directory, or where the warm state file is present but empty. Platforms that write a normal non-empty file behave exactly as before.

### Documentation

No, this is a bug fix with no user facing interface change.
