### PR TITLE
[vpp][acl] raise the ACL entry attribute cap and report a missing priority

### DIFF
--- a/vslib/vpp/SwitchVppAcl.cpp
+++ b/vslib/vpp/SwitchVppAcl.cpp
@@ -758,7 +758,12 @@ sai_status_t SwitchVpp::get_sorted_aces(
         }
 
         p_ace->priority = 0;
-        acl_priority_attr_get(p_ace->attrs_count, p_ace->attrs, &p_ace->priority);
+        if (acl_priority_attr_get(p_ace->attrs_count, p_ace->attrs,
+                                  &p_ace->priority) != SAI_STATUS_SUCCESS) {
+            SWSS_LOG_ERROR("No priority attribute on ACL entry %s, ordering it at 0; "
+                           "its %u attributes may have been truncated at MAX_ACL_ATTRS (%u)",
+                           sid.c_str(), p_ace->attrs_count, MAX_ACL_ATTRS);
+        }
 
         ordered_aces.push_back({index, p_ace->priority, entry_id, false, 0, 0});
         p_ace++;

--- a/vslib/vpp/SwitchVppAcl.h
+++ b/vslib/vpp/SwitchVppAcl.h
@@ -4,7 +4,12 @@
 extern "C" {
 #endif
 
-#define MAX_ACL_ATTRS 12
+/*
+ * Cap on the attributes read back per ACL entry. The attribute store is keyed
+ * by attribute name, so an entry above the cap loses attributes in name order,
+ * PRIORITY and TABLE_ID first. Keep it above the widest entry orchagent builds.
+ */
+#define MAX_ACL_ATTRS 20
 
 typedef struct _acl_tbl_entries_ {
     uint32_t priority;


### PR DESCRIPTION
### Description of PR

Summary: raises `MAX_ACL_ATTRS` from 12 to 20 and stops the ACL entry attribute read from discarding a truncated `PRIORITY` silently.

Split out of #2064 at the request of @yue-fred-gao and @aaronber0614. Neither problem is caused by that change — both predate it — so they are fixed here on their own. No dependency between the two PRs; they touch adjacent lines and merge in either order.

Fixes # (issue) — n/a, review follow-up.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?


`get_sorted_aces()` reads each ACL entry back with `get_max()`, capped at `MAX_ACL_ATTRS`. The store behind it is a `std::map` keyed by attribute *name* (`AttrHash` in `SwitchState.h`, keyed by `attridname` in `SwitchStateBase.cpp`), and `get_max()` walks it in iteration order and breaks at the cap. An entry with more attributes than the cap therefore does not lose the ones it was given last — it loses the ones that sort last alphabetically.

For names of the form `SAI_ACL_ENTRY_ATTR_*` that order is: every `ACTION_*`, then `ADMIN_STATE`, then every `FIELD_*`, then `PRIORITY`, then `TABLE_ID`. So the first two casualties of any truncation are `PRIORITY` and `TABLE_ID`, and it then eats match fields from the tail of the `FIELD_*` range — `SRC_IP`, `TCP_FLAGS`, `L4_*` among them, all of which this code goes on to read. Nothing about the cut follows what the entry means.

At 12 that was close enough to real configurations to matter:

| entry shape | attributes |
| --- | --- |
| mux standby drop (`IN_PORTS` + drop + counter) | 6 |
| L3 five-tuple | 11 |
| L3V4V6 + ICMP + port range + `ACL_IP_TYPE` + `ACL_USER_META` | past the cap |

A truncated entry loses its priority first, and the priority read then swallowed the failure: `acl_priority_attr_get()` returns `SAI_STATUS_FAILURE` when `PRIORITY` is absent, the return value was discarded, and the entry kept the `0` initialised on the line above. The rule sorts to the bottom of the table with nothing in the log to say why.

#### How did you do it?

Two changes, both in `vslib/vpp/`:

- `MAX_ACL_ATTRS` 12 → 20, with a comment in the header recording that the cut is by name and that `PRIORITY`/`TABLE_ID` go first, so the number is not free to trim back later. 20 clears every entry shape orchagent builds in the configurations shipped today.
- `acl_priority_attr_get()`'s return value is checked, and a missing `PRIORITY` is logged with the entry id and its attribute count. Priority still falls back to `0` — failing a whole table over one entry costs more than misordering it, and that lesson is from the review of #2064 — but it is no longer invisible.

The second change doubles as the general truncation detector: since `PRIORITY` is the *first* attribute the cut discards, this log fires on any future overflow of the raised cap, whatever else was lost alongside it.

##### Work item tracking
- Microsoft ADO **(number only)**: 39625316

#### How did you verify/test it?

Reasoned from the code rather than from a run, since neither path is reachable with the configurations currently shipped — that is the point of the cap raise:

- The ordering claim is mechanical: `AttrHash` is a `std::map<std::string, ...>` keyed by `attridname`, `get_max()` (`SwitchVpp.cpp`) iterates it and `break`s at `idx == max_attr_count`, so the surviving set is the alphabetical prefix. `PRIORITY` and `TABLE_ID` sort after every `ACTION_*`, `ADMIN_STATE` and `FIELD_*` name in `sai_acl_entry_attr_t`.
- The attribute counts above were taken from `aclMatchLookup` / `aclL3ActionLookup` in `sonic-swss/orchagent/aclorch.cpp` against the rule shapes SONiC actually writes.

The change is confined to a `#define` and one added `if`, with no behavioural change on the path where `PRIORITY` is present.

#### Any platform specific information?

VPP only — `vslib/vpp/`. The extra 8 `sai_attribute_t` slots are per ACL entry in the `calloc` in `get_sorted_aces()`, freed at the end of the same call.

### Documentation

No. Behaviour of an internal read-back limit; nothing user-facing changes.
